### PR TITLE
Qt 5.15: move away from deprecated APIs

### DIFF
--- a/Common/Qt/AutoWidthLineEdit.cpp
+++ b/Common/Qt/AutoWidthLineEdit.cpp
@@ -25,7 +25,7 @@ AutoWidthLineEdit::AutoWidthLineEdit(QWidget* parent)
 void AutoWidthLineEdit::resize_to_content(){
     QString text = this->text();
     QFontMetrics fm(this->font());
-    int pixelsWide = fm.width(text);
+    int pixelsWide = fm.boundingRect(text).width();
     this->setFixedWidth(pixelsWide);
     adjustSize();
 }

--- a/Common/Qt/Options/EditableTableOptionBase.cpp
+++ b/Common/Qt/Options/EditableTableOptionBase.cpp
@@ -90,7 +90,7 @@ EditableTableBaseUI::EditableTableBaseUI(QWidget& parent, EditableTableBase& val
 {
     QVBoxLayout* layout = new QVBoxLayout(this);
     if (!value.m_margin){
-        layout->setMargin(0);
+        layout->setContentsMargins(0, 0, 0, 0);
     }
 
     layout->addWidget(new QLabel(value.m_label, this));

--- a/Common/Qt/Options/MultiHostTableOptionBase.cpp
+++ b/Common/Qt/Options/MultiHostTableOptionBase.cpp
@@ -146,7 +146,7 @@ QWidget* MultiHostSlot::make_backup_save_box(QWidget& parent){
     QWidget* widget = new QWidget(&parent);
     QHBoxLayout* layout = new QHBoxLayout(widget);
     layout->setAlignment(Qt::AlignHCenter);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
     QCheckBox* box = new QCheckBox(&parent);
     layout->addWidget(box);
     box->setChecked(backup_save);
@@ -162,7 +162,7 @@ QWidget* MultiHostSlot::make_catchable_box(QWidget& parent){
     QWidget* widget = new QWidget(&parent);
     QHBoxLayout* layout = new QHBoxLayout(widget);
     layout->setAlignment(Qt::AlignHCenter);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
     QCheckBox* box = new QCheckBox(&parent);
     layout->addWidget(box);
     box->setChecked(always_catchable);
@@ -178,7 +178,7 @@ QWidget* MultiHostSlot::make_raid_code_box(QWidget& parent){
     QWidget* widget = new QWidget(&parent);
     QHBoxLayout* layout = new QHBoxLayout(widget);
     layout->setAlignment(Qt::AlignHCenter);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
     QCheckBox* box = new QCheckBox(&parent);
     layout->addWidget(box);
     box->setChecked(use_raid_code);
@@ -194,7 +194,7 @@ QWidget* MultiHostSlot::make_accept_FRs_box(QWidget& parent){
     QWidget* widget = new QWidget(&parent);
     QHBoxLayout* layout = new QHBoxLayout(widget);
     layout->setAlignment(Qt::AlignHCenter);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
     QCheckBox* box = new QCheckBox(&parent);
     layout->addWidget(box);
     box->setChecked(accept_FRs);
@@ -226,7 +226,7 @@ QWidget* MultiHostSlot::make_dynamax_box(QWidget& parent){
     QWidget* widget = new QWidget(&parent);
     QHBoxLayout* layout = new QHBoxLayout(widget);
     layout->setAlignment(Qt::AlignHCenter);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
     QCheckBox* box = new QCheckBox(&parent);
     layout->addWidget(box);
     box->setChecked(dynamax);

--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -21,6 +21,8 @@ set(CMAKE_AUTOUIC ON)
 
 #find Qt
 find_package(Qt5 COMPONENTS Widgets SerialPort Multimedia MultimediaWidgets REQUIRED)
+#disable deprecated Qt APIs
+add_compile_definitions(QT_DISABLE_DEPRECATED_BEFORE=0x050F00)
 
 #add current directory to find tesseractPA.lib
 link_directories(${CMAKE_CURRENT_LIST_DIR})

--- a/SerialPrograms/Source/CommonFramework/Notifications/EventNotificationsTable.cpp
+++ b/SerialPrograms/Source/CommonFramework/Notifications/EventNotificationsTable.cpp
@@ -127,7 +127,7 @@ QWidget* EventNotificationsTableUI::make_enabled_box(EventNotificationOption& en
     QWidget* widget = new QWidget(this);
     QHBoxLayout* layout = new QHBoxLayout(widget);
     layout->setAlignment(Qt::AlignHCenter);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
     QCheckBox* box = new QCheckBox(this);
     layout->addWidget(box);
     box->setChecked(entry.m_current.enabled);
@@ -143,7 +143,7 @@ QWidget* EventNotificationsTableUI::make_ping_box(EventNotificationOption& entry
     QWidget* widget = new QWidget(this);
     QHBoxLayout* layout = new QHBoxLayout(widget);
     layout->setAlignment(Qt::AlignHCenter);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
     QCheckBox* box = new QCheckBox(this);
     layout->addWidget(box);
     box->setChecked(entry.m_current.ping);

--- a/SerialPrograms/Source/CommonFramework/Options/BatchOption.cpp
+++ b/SerialPrograms/Source/CommonFramework/Options/BatchOption.cpp
@@ -69,7 +69,7 @@ BatchOptionUI::BatchOptionUI(QWidget& parent, BatchOption& value)
 {
     QVBoxLayout* options_layout = new QVBoxLayout(this);
     options_layout->setAlignment(Qt::AlignTop);
-    options_layout->setMargin(0);
+    options_layout->setContentsMargins(0, 0, 0, 0);
 
     for (auto& item : m_value.m_options){
         m_options.emplace_back(item.first->make_ui(parent));
@@ -157,7 +157,7 @@ GroupOptionUI::GroupOptionUI(QWidget& parent, GroupOption& value)
 
     QVBoxLayout* group_layout = new QVBoxLayout(m_group_box);
     group_layout->setAlignment(Qt::AlignTop);
-    group_layout->setMargin(0);
+    group_layout->setContentsMargins(0, 0, 0, 0);
 
     m_expand_text = new QWidget(m_group_box);
     m_expand_text->setLayout(new QVBoxLayout());
@@ -169,7 +169,7 @@ GroupOptionUI::GroupOptionUI(QWidget& parent, GroupOption& value)
     m_options_holder = new QWidget(m_group_box);
     group_layout->addWidget(m_options_holder);
     m_options_layout = new QVBoxLayout(m_options_holder);
-    m_options_layout->setMargin(0);
+    m_options_layout->setContentsMargins(0, 0, 0, 0);
 
     for (auto& item : m_value.m_options){
         m_options.emplace_back(item.first->make_ui(parent));

--- a/SerialPrograms/Source/CommonFramework/Panels/RunnablePanel.cpp
+++ b/SerialPrograms/Source/CommonFramework/Panels/RunnablePanel.cpp
@@ -156,7 +156,7 @@ RunnablePanelWidget::RunnablePanelWidget(
     , m_state(ProgramState::NOT_READY)
 {
     QVBoxLayout* layout = new QVBoxLayout(this);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
 
     m_header_holder = new QVBoxLayout();
     layout->addLayout(m_header_holder);
@@ -233,7 +233,7 @@ QWidget* RunnablePanelWidget::make_actions(QWidget& parent){
     QGroupBox* actions_widget = new QGroupBox("Actions", &parent);
 
     QHBoxLayout* action_layout = new QHBoxLayout(actions_widget);
-    action_layout->setMargin(0);
+    action_layout->setContentsMargins(0, 0, 0, 0);
 
     {
         m_start_button = new QPushButton("Start Program!", &parent);

--- a/SerialPrograms/Source/CommonFramework/Panels/SettingsPanel.cpp
+++ b/SerialPrograms/Source/CommonFramework/Panels/SettingsPanel.cpp
@@ -49,7 +49,7 @@ SettingsPanelWidget::SettingsPanelWidget(
 {}
 void SettingsPanelWidget::construct(){
     QVBoxLayout* layout = new QVBoxLayout(this);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
     layout->addWidget(make_header(*this));
 
     QScrollArea* scroll = new QScrollArea(this);
@@ -78,7 +78,7 @@ QWidget* SettingsPanelWidget::make_actions(QWidget& parent){
     QGroupBox* actions_widget = new QGroupBox("Actions", &parent);
 
     QHBoxLayout* action_layout = new QHBoxLayout(actions_widget);
-    action_layout->setMargin(0);
+    action_layout->setContentsMargins(0, 0, 0, 0);
     {
         m_default_button = new QPushButton("Restore Defaults", actions_widget);
         action_layout->addWidget(m_default_button, 1);

--- a/SerialPrograms/Source/CommonFramework/Widgets/CameraSelector.cpp
+++ b/SerialPrograms/Source/CommonFramework/Widgets/CameraSelector.cpp
@@ -87,7 +87,7 @@ CameraSelectorUI::CameraSelectorUI(
     , m_snapshots_allowed(true)
 {
     QHBoxLayout* camera_row = new QHBoxLayout(this);
-    camera_row->setMargin(0);
+    camera_row->setContentsMargins(0, 0, 0, 0);
 
     camera_row->addWidget(new QLabel("<b>Camera:</b>", this), 1);
     camera_row->addSpacing(5);

--- a/SerialPrograms/Source/CommonFramework/Widgets/QtVideoWidget.cpp
+++ b/SerialPrograms/Source/CommonFramework/Widgets/QtVideoWidget.cpp
@@ -26,7 +26,7 @@ QtVideoWidget::QtVideoWidget(
 
     QVBoxLayout* layout = new QVBoxLayout(this);
     layout->setAlignment(Qt::AlignTop);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
 
     m_camera = new QCamera(info, this);
 

--- a/SerialPrograms/Source/CommonFramework/Widgets/SerialSelector.cpp
+++ b/SerialPrograms/Source/CommonFramework/Widgets/SerialSelector.cpp
@@ -69,7 +69,7 @@ SerialSelectorUI::SerialSelectorUI(
     , m_connection(value.m_port, value.m_minimum_pabotbase, m_logger)
 {
     QHBoxLayout* serial_row = new QHBoxLayout(this);
-    serial_row->setMargin(0);
+    serial_row->setContentsMargins(0, 0, 0, 0);
 
     serial_row->addWidget(new QLabel("<b>Serial Port:</b>", this), 1);
     serial_row->addSpacing(5);
@@ -82,7 +82,7 @@ SerialSelectorUI::SerialSelectorUI(
     QWidget* status = new QWidget(this);
     serial_row->addWidget(status, 3);
     QVBoxLayout* sbox = new QVBoxLayout(status);
-    sbox->setMargin(0);
+    sbox->setContentsMargins(0, 0, 0, 0);
     sbox->setSpacing(0);
     m_serial_program = new QLabel(this);
     sbox->addWidget(m_serial_program);

--- a/SerialPrograms/Source/Integrations/DiscordIntegrationTable.cpp
+++ b/SerialPrograms/Source/Integrations/DiscordIntegrationTable.cpp
@@ -69,7 +69,7 @@ QWidget* DiscordIntegrationChannel::make_enabled_box(QWidget& parent){
     QWidget* wrapper = new QWidget(&parent);
     QHBoxLayout* layout = new QHBoxLayout(wrapper);
     layout->setAlignment(Qt::AlignCenter);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
     QCheckBox* box = new QCheckBox(&parent);
     box->setChecked(enabled);
     layout->addWidget(box);
@@ -97,7 +97,7 @@ QWidget* DiscordIntegrationChannel::make_ping_box(QWidget& parent){
     QWidget* wrapper = new QWidget(&parent);
     QHBoxLayout* layout = new QHBoxLayout(wrapper);
     layout->setAlignment(Qt::AlignCenter);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
     QCheckBox* box = new QCheckBox(&parent);
     box->setChecked(ping);
     layout->addWidget(box);
@@ -125,7 +125,7 @@ QWidget* DiscordIntegrationChannel::make_commands_box(QWidget& parent){
     QWidget* wrapper = new QWidget(&parent);
     QHBoxLayout* layout = new QHBoxLayout(wrapper);
     layout->setAlignment(Qt::AlignCenter);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
     QCheckBox* box = new QCheckBox(&parent);
     box->setChecked(allow_commands);
     layout->addWidget(box);

--- a/SerialPrograms/Source/Integrations/DiscordWebhookSettings.cpp
+++ b/SerialPrograms/Source/Integrations/DiscordWebhookSettings.cpp
@@ -71,7 +71,7 @@ QWidget* DiscordWebhookUrl::make_enabled_box(QWidget& parent){
     QWidget* wrapper = new QWidget(&parent);
     QHBoxLayout* layout = new QHBoxLayout(wrapper);
     layout->setAlignment(Qt::AlignCenter);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
     QCheckBox* box = new QCheckBox(&parent);
     box->setChecked(enabled);
     layout->addWidget(box);
@@ -99,7 +99,7 @@ QWidget* DiscordWebhookUrl::make_ping_box(QWidget& parent){
     QWidget* wrapper = new QWidget(&parent);
     QHBoxLayout* layout = new QHBoxLayout(wrapper);
     layout->setAlignment(Qt::AlignCenter);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
     QCheckBox* box = new QCheckBox(&parent);
     box->setChecked(ping);
     layout->addWidget(box);

--- a/SerialPrograms/Source/NintendoSwitch/Framework/MultiSwitchSystem.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/Framework/MultiSwitchSystem.cpp
@@ -117,11 +117,11 @@ MultiSwitchSystem::MultiSwitchSystem(
     , m_videos(nullptr)
 {
     QVBoxLayout* vbox = new QVBoxLayout(this);
-    vbox->setMargin(0);
+    vbox->setContentsMargins(0, 0, 0, 0);
 
     QHBoxLayout* row = new QHBoxLayout();
     vbox->addLayout(row, 0);
-    row->setMargin(0);
+    row->setContentsMargins(0, 0, 0, 0);
     row->addStretch(2);
     row->addWidget(new QLabel("<b>Switch Count:</b>", this), 0);
     m_console_count_box = new NoWheelComboBox(this);
@@ -166,11 +166,11 @@ void MultiSwitchSystem::redraw_videos(size_t count){
     m_videos = new QWidget(this);
     this->layout()->addWidget(m_videos);
     QVBoxLayout* vbox = new QVBoxLayout(m_videos);
-    vbox->setMargin(0);
+    vbox->setContentsMargins(0, 0, 0, 0);
 
     QHBoxLayout* vrow0 = new QHBoxLayout();
     vbox->addLayout(vrow0, 1);
-    vrow0->setMargin(0);
+    vrow0->setContentsMargins(0, 0, 0, 0);
 
     vrow0->addWidget(m_switches[0], 1);
     if (m_switches.size() >= 2){
@@ -179,7 +179,7 @@ void MultiSwitchSystem::redraw_videos(size_t count){
     if (m_switches.size() >= 3){
         QHBoxLayout* vrow1 = new QHBoxLayout();
         vbox->addLayout(vrow1, 1);
-        vrow1->setMargin(0);
+        vrow1->setContentsMargins(0, 0, 0, 0);
         vrow1->addWidget(m_switches[2], 1);
         if (m_switches.size() >= MultiSwitchSystemFactory::MAX_SWITCHES){
             vrow1->addWidget(m_switches[3], 1);

--- a/SerialPrograms/Source/NintendoSwitch/Framework/SwitchCommandRow.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/Framework/SwitchCommandRow.cpp
@@ -23,7 +23,7 @@ CommandRow::CommandRow(
     , m_last_known_focus(false)
 {
     QHBoxLayout* command_row = new QHBoxLayout(this);
-    command_row->setMargin(0);
+    command_row->setContentsMargins(0, 0, 0, 0);
 
     command_row->addWidget(new QLabel("<b>Keyboard Input:</b>", this), 1);
     command_row->addSpacing(5);

--- a/SerialPrograms/Source/NintendoSwitch/Programs/NintendoSwitch_SwitchViewer.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/Programs/NintendoSwitch_SwitchViewer.cpp
@@ -60,7 +60,7 @@ SwitchViewer_Widget::SwitchViewer_Widget(
 {}
 void SwitchViewer_Widget::construct(){
     QVBoxLayout* layout = new QVBoxLayout(this);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
     layout->addWidget(make_header(*this));
 
     SwitchViewer& instance = static_cast<SwitchViewer&>(m_instance);

--- a/SerialPrograms/Source/NintendoSwitch/Programs/NintendoSwitch_VirtualConsole.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/Programs/NintendoSwitch_VirtualConsole.cpp
@@ -58,7 +58,7 @@ VirtualConsole_Widget::VirtualConsole_Widget(
 {}
 void VirtualConsole_Widget::construct(){
     QVBoxLayout* layout = new QVBoxLayout(this);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
     layout->addWidget(make_header(*this));
 
     VirtualConsole& instance = static_cast<VirtualConsole&>(m_instance);


### PR DESCRIPTION
This cleans up the code by removing calls to deprecated APIs as of Qt 5.15. I made sure this compiles with Qt 5.12, too.