### PR TITLE
Tesseract link

### DIFF
--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -253,6 +253,7 @@ file(GLOB MAIN_SOURCES
     Source/CommonFramework/OCR/OCR_TextMatcher.h
     Source/CommonFramework/OCR/OCR_TrainingTools.cpp
     Source/CommonFramework/OCR/OCR_TrainingTools.h
+    Source/CommonFramework/OCR/TesseractPA.cpp
     Source/CommonFramework/OCR/TesseractPA.h
     Source/CommonFramework/Options/BatchOption/BatchOption.cpp
     Source/CommonFramework/Options/BatchOption/BatchOption.h

--- a/SerialPrograms/Source/CommonFramework/OCR/TesseractPA.cpp
+++ b/SerialPrograms/Source/CommonFramework/OCR/TesseractPA.cpp
@@ -1,0 +1,70 @@
+/*  Tesseract Wrapper
+ * 
+ *  From: https://github.com/PokemonAutomation/
+ * 
+ */
+
+#ifdef UNIX_LINK_TESSERACT
+
+#include "TesseractPA.h"
+
+#include <tesseract/baseapi.h>
+#include <cstddef>
+#include <iostream>
+using std::cout;
+using std::endl;
+
+
+// We hope to use our own Tesseract build in future for Unix systems too.
+// But right now to run on Linux and Mac we need to use external Tesseract library API directly.
+// So the Tesseract API wrapper is defined here to match Windows.
+
+
+struct TesseractAPI_internal{
+    tesseract::TessBaseAPI m_api;
+
+    TesseractAPI_internal(const char* path, const char* language){
+        if (m_api.Init(path, language)){
+            throw "Could not initialize TesseractAPI.";
+        }
+    }
+
+};
+
+
+
+TesseractAPI_internal* TesseractAPI_construct(const char* path, const char* language){
+    try{
+        return new TesseractAPI_internal(path, language);
+    }catch (const char* err){
+        cout << err << endl;
+    }
+    return nullptr;
+}
+void TesseractAPI_destroy(TesseractAPI_internal* api){
+    delete api;
+}
+
+
+
+char* TesseractAPI_read_bitmap(
+    TesseractAPI_internal* api,
+    const unsigned char* data,
+    size_t width, size_t height,
+    size_t bytes_per_pixel, size_t bytes_per_line,
+    size_t ppi
+){
+    api->m_api.SetImage(data, (int)width, (int)height, (int)bytes_per_pixel, (int)bytes_per_line);
+    api->m_api.SetSourceResolution((int)ppi);
+    return api->m_api.GetUTF8Text();
+}
+void Tesseract_delete(char* text){
+    delete[] text;
+}
+
+
+#endif // UNIX_LINK_TESSERACT
+
+
+
+

--- a/SerialPrograms/Source/CommonFramework/OCR/TesseractPA.h
+++ b/SerialPrograms/Source/CommonFramework/OCR/TesseractPA.h
@@ -8,6 +8,7 @@
 #define PokemonAutomation_TesseractPA_H
 
 #include <stdint.h>
+#include <cstddef>
 
 //#define TESSERACT_STATIC
 
@@ -23,12 +24,12 @@
 #define TESSERACT_EXPORT __declspec(dllimport)
 #endif
 
-#else
+#else // not on _WIN32
 
 #define TESSERACT_EXPORT __attribute__((visibility("default")))
 
-#endif
-#endif
+#endif // _WIN32
+#endif // TESSERACT_STATIC
 
 
 
@@ -36,7 +37,11 @@
 extern "C" {
 #endif
 
-
+// We build a custom Tesseract library,
+// https://github.com/PokemonAutomation/Tesseract-OCR_for_Windows
+// to ship with SerialProgram on Windows, in the form of tesseractPA.dll.
+// The following C API is a wrapper for the raw Tesseract API. The wrapper
+// along with Tesseract itself is implemented in tesseractPA.dll.
 struct TesseractAPI_internal;
 TESSERACT_EXPORT TesseractAPI_internal* TesseractAPI_construct(
     const char* path, const char* language
@@ -57,8 +62,6 @@ TESSERACT_EXPORT void Tesseract_delete(char* text);
 #ifdef __cplusplus
 }
 #endif
-
-
 
 
 class TesseractString{

--- a/SerialPrograms/Source/CommonFramework/Tools/ProgramEnvironment.h
+++ b/SerialPrograms/Source/CommonFramework/Tools/ProgramEnvironment.h
@@ -14,9 +14,23 @@
 #include "CommonFramework/Notifications/ProgramInfo.h"
 
 
+// Forward declare std mutex and condition_variable
+// to reduce the amount of header includes.
 namespace std{
+
+// for libc++ used by clang, mutex and condition_variable are
+// defined in inline std::__1 namespace instead of std.
+#ifdef _LIBCPP_VERSION
+    inline namespace __1 {
+#endif
+
     class mutex;
     class condition_variable;
+
+#ifdef _LIBCPP_VERSION
+    }
+#endif
+
 }
 
 namespace PokemonAutomation{

--- a/SerialPrograms/Source/CommonFramework/Widgets/Qt6CameraWidget.h
+++ b/SerialPrograms/Source/CommonFramework/Widgets/Qt6CameraWidget.h
@@ -7,6 +7,7 @@
 #ifndef PokemonAutomation_Qt6VideoWidget_H
 #define PokemonAutomation_Qt6VideoWidget_H
 
+#include <mutex>
 #include "CommonFramework/Logging/Logger.h"
 #include "VideoWidget.h"
 


### PR DESCRIPTION
- Add a conditional branch in cmake to link with external Tesseract for unix systems. Now configure the project on macOS using `cmake <folder with CMakeLists.txt> -DQT_MAJOR:STRING=6 -DUNIX_LINK_TESSERACT:BOOL=true`
- Fix some compiler warnings reported on macOS.