### PR TITLE
Add sweet scent for overworld encounter

### DIFF
--- a/SerialPrograms/Source/PokemonBDSP/Programs/Farming/PokemonBDSP_DoublesLeveling.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/Farming/PokemonBDSP_DoublesLeveling.cpp
@@ -94,33 +94,7 @@ std::unique_ptr<StatsTracker> DoublesLeveling::make_stats() const{
 
 
 
-bool DoublesLeveling::find_encounter(SingleSwitchProgramEnvironment& env) const{
-    BattleMenuWatcher battle_menu_detector(BattleType::WILD);
-    StartBattleDetector start_battle_detector(env.console);
 
-    int result = run_until(
-        env, env.console,
-        [&](const BotBaseContext& context){
-            while (true){
-                TRIGGER_METHOD.run_trigger(context);
-            }
-        },
-        {
-            &battle_menu_detector,
-            &start_battle_detector,
-        }
-    );
-
-    switch (result){
-    case 0:
-        env.console.log("Unexpected Battle.", "red");
-        return false;
-    case 1:
-        env.console.log("Battle started!");
-        return true;
-    }
-    return false;
-}
 bool DoublesLeveling::battle(SingleSwitchProgramEnvironment& env){
     Stats& stats = env.stats<Stats>();
 
@@ -194,7 +168,7 @@ void DoublesLeveling::program(SingleSwitchProgramEnvironment& env){
     //  Encounter Loop
     while (true){
         //  Find encounter.
-        bool battle = find_encounter(env);
+        bool battle = TRIGGER_METHOD.find_encounter(env);
         if (!battle){
             stats.add_error();
             handler.run_away_due_to_error(EXIT_BATTLE_TIMEOUT);

--- a/SerialPrograms/Source/PokemonBDSP/Programs/Farming/PokemonBDSP_DoublesLeveling.h
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/Farming/PokemonBDSP_DoublesLeveling.h
@@ -36,10 +36,8 @@ public:
 
 private:
     struct Stats;
-    bool find_encounter(SingleSwitchProgramEnvironment& env) const;
     bool battle(SingleSwitchProgramEnvironment& env);
 
-private:
     GoHomeWhenDoneOption GO_HOME_WHEN_DONE;
 
     Pokemon::EncounterBotLanguage LANGUAGE;

--- a/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_GameNavigation.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_GameNavigation.cpp
@@ -87,19 +87,7 @@ void save_game(ProgramEnvironment& env, ConsoleHandle& console){
 
 void overworld_to_box(ProgramEnvironment& env, ConsoleHandle& console){
     //  Open menu.
-    pbf_press_button(console, BUTTON_X, 20, 105);
-    console.botbase().wait_for_all_requests();
-    {
-        MenuWatcher detector;
-        int ret = wait_until(
-            env, console, std::chrono::seconds(10),
-            { &detector }
-        );
-        if (ret < 0){
-            PA_THROW_InferenceException(console, "Menu not detected after 10 seconds.");
-        }
-        console.log("Detected menu.");
-    }
+    overworld_to_menu(env, console);
 
     //  Enter Pokemon
     uint16_t MENU_TO_POKEMON_DELAY = GameSettings::instance().MENU_TO_POKEMON_DELAY;

--- a/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_OverworldTrigger.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_OverworldTrigger.cpp
@@ -4,8 +4,15 @@
  *
  */
 
+#include "CommonFramework/Inference/InferenceException.h"
+#include "CommonFramework/Inference/VisualInferenceRoutines.h"
 #include "NintendoSwitch/Commands/NintendoSwitch_PushButtons.h"
+#include "PokemonBDSP/PokemonBDSP_Settings.h"
+#include "PokemonBDSP/Inference/Battles/PokemonBDSP_BattleMenuDetector.h"
+#include "PokemonBDSP/Inference/Battles/PokemonBDSP_StartBattleDetector.h"
 #include "PokemonBDSP_OverworldTrigger.h"
+#include "PokemonBDSP_GameNavigation.h"
+#include <iostream>
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
@@ -23,16 +30,31 @@ OverworldTrigger::OverworldTrigger()
             "Move up/down. (no bias)",
             "Move up/down. (bias up)",
             "Move up/down. (bias down)",
+            "Sweet scent",
         }, 0
     )
     , MOVE_DURATION(
         "<b>Move Duration:</b><br>Move in each direction for this long before turning around.",
         "1 * TICKS_PER_SECOND"
     )
+    , SWEET_SCENT_POKEMON_LOCATION(
+        "<b>Sweet Scent Pokemon Location:</b><br>Which Pokemon in the party knows Sweet Scent.",
+        {
+          "1st",
+          "2nd",
+          "3rd",
+          "4th",
+          "2nd last",
+          "Last",
+        }, 0
+    )
 {
     PA_ADD_OPTION(TRIGGER_METHOD);
     PA_ADD_OPTION(MOVE_DURATION);
+    PA_ADD_OPTION(SWEET_SCENT_POKEMON_LOCATION);
 }
+
+
 void OverworldTrigger::run_trigger(const BotBaseContext& context) const{
     switch (TRIGGER_METHOD){
     case 0:
@@ -62,6 +84,76 @@ void OverworldTrigger::run_trigger(const BotBaseContext& context) const{
     }
 }
 
+bool OverworldTrigger::find_encounter(SingleSwitchProgramEnvironment& env) const {
+    BattleMenuWatcher battle_menu_detector(BattleType::WILD);
+    StartBattleDetector start_battle_detector(env.console);
+
+    int result = 0;
+    if (TRIGGER_METHOD < 6) {
+        // Move character back and forth to trigger encounter.
+        result = run_until(
+            env, env.console,
+            [&](const BotBaseContext& context){
+                while (true) {
+                    run_trigger(context);
+                }
+            },
+            {
+                &battle_menu_detector,
+                &start_battle_detector,
+            }
+        );
+    } else {
+        // Use Sweet Scent to trigger encounter.
+        overworld_to_menu(env, env.console);
+
+        // Go to pokemon page
+        const uint16_t MENU_TO_POKEMON_DELAY = GameSettings::instance().MENU_TO_POKEMON_DELAY;
+        pbf_press_button(env.console, BUTTON_ZL, 20, MENU_TO_POKEMON_DELAY);
+
+        // Go to the pokemon that knows Sweet Scent
+        const size_t location = SWEET_SCENT_POKEMON_LOCATION;
+        const uint16_t change_pokemon_delay = 20;
+        if (location >= 1 && location <= 3) {
+            const size_t move_down_times = location;
+            for(size_t i = 0; i < move_down_times; ++i) {
+                pbf_press_dpad(env.console, DPAD_DOWN, 1, change_pokemon_delay);
+            }
+        } else if (location >= 1) { // for location 4 and 5
+            const size_t move_down_times = 6 - location;
+            for(size_t i = 0; i < move_down_times; ++i) {
+                pbf_press_dpad(env.console, DPAD_UP, 1, change_pokemon_delay);
+            }
+        }
+
+        // Open the pokemon menu of the first pokemon
+        const uint16_t pokemon_to_pokemon_menu_delay = 30;
+        pbf_press_button(env.console, BUTTON_ZL, 20, pokemon_to_pokemon_menu_delay);
+        // Move down one menuitem to select "Sweet Scent"
+        const uint16_t move_pokemon_menu_item_delay = 30;
+        pbf_press_dpad(env.console, DPAD_DOWN, 1, move_pokemon_menu_item_delay);
+        // Use sweet scent
+        pbf_mash_button(env.console, BUTTON_ZL, 30);
+
+        result = wait_until(
+            env, env.console, std::chrono::seconds(30),
+            { &battle_menu_detector, &start_battle_detector }
+        );
+        if (result < 0){
+            PA_THROW_InferenceException(env.console, "Battle not detected after Sweet Scent for 30 seconds.");
+        }
+    }
+
+    switch (result){
+    case 0:
+        env.console.log("Unexpected Battle.", "red");
+        return false;
+    case 1:
+        env.console.log("Battle started!");
+        return true;
+    }
+    return false;
+}
 
 
 }

--- a/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_OverworldTrigger.h
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_OverworldTrigger.h
@@ -9,6 +9,7 @@
 
 #include "CommonFramework/Options/BatchOption.h"
 #include "CommonFramework/Options/EnumDropdownOption.h"
+#include "NintendoSwitch/Framework/SingleSwitchProgram.h"
 #include "NintendoSwitch/Options/TimeExpressionOption.h"
 #include "CommonFramework/Tools/ConsoleHandle.h"
 
@@ -16,16 +17,26 @@ namespace PokemonAutomation{
 namespace NintendoSwitch{
 namespace PokemonBDSP{
 
-
+// Program component to trigger an overworld encounter.
 class OverworldTrigger : public GroupOption{
 public:
     OverworldTrigger();
 
+    // Move character back and forth or use Sweet Scent to trigger an encounter.
+    // Return true if the start of a battle is detected.
+    // Return false if an unexpected battle happens where the battle menu is detected but not
+    //   the starting animation.
+    // Throw exception if inference times out after Sweet Scent is used.
+    bool find_encounter(SingleSwitchProgramEnvironment& env) const;
+
+private:
+    // Move character up and down or left and right once.
     void run_trigger(const BotBaseContext& context) const;
 
 public:
     EnumDropdownOption TRIGGER_METHOD;
     TimeExpressionOption<uint16_t> MOVE_DURATION;
+    EnumDropdownOption SWEET_SCENT_POKEMON_LOCATION;
 };
 
 

--- a/SerialPrograms/Source/PokemonBDSP/Programs/ShinyHunting/PokemonBDSP_ShinyHunt-Overworld.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/ShinyHunting/PokemonBDSP_ShinyHunt-Overworld.cpp
@@ -87,33 +87,6 @@ std::unique_ptr<StatsTracker> ShinyHuntOverworld::make_stats() const{
 
 
 
-bool ShinyHuntOverworld::find_encounter(SingleSwitchProgramEnvironment& env) const{
-    BattleMenuWatcher battle_menu_detector(BattleType::WILD);
-    StartBattleDetector start_battle_detector(env.console);
-
-    int result = run_until(
-        env, env.console,
-        [&](const BotBaseContext& context){
-            while (true){
-                TRIGGER_METHOD.run_trigger(context);
-            }
-        },
-        {
-            &battle_menu_detector,
-            &start_battle_detector,
-        }
-    );
-
-    switch (result){
-    case 0:
-        env.console.log("Unexpected Battle.", "red");
-        return false;
-    case 1:
-        env.console.log("Battle started!");
-        return true;
-    }
-    return false;
-}
 
 void ShinyHuntOverworld::program(SingleSwitchProgramEnvironment& env){
     Stats& stats = env.stats<Stats>();
@@ -132,7 +105,7 @@ void ShinyHuntOverworld::program(SingleSwitchProgramEnvironment& env){
     //  Encounter Loop
     while (true){
         //  Find encounter.
-        bool battle = find_encounter(env);
+        bool battle = TRIGGER_METHOD.find_encounter(env);
         if (!battle){
             stats.add_error();
             handler.run_away_due_to_error(EXIT_BATTLE_TIMEOUT);

--- a/SerialPrograms/Source/PokemonBDSP/Programs/ShinyHunting/PokemonBDSP_ShinyHunt-Overworld.h
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/ShinyHunting/PokemonBDSP_ShinyHunt-Overworld.h
@@ -37,9 +37,7 @@ public:
 
 private:
     struct Stats;
-    bool find_encounter(SingleSwitchProgramEnvironment& env) const;
 
-private:
     GoHomeWhenDoneOption GO_HOME_WHEN_DONE;
 
     Pokemon::EncounterBotLanguage LANGUAGE;

--- a/SerialPrograms/Source/PokemonBDSP/Programs/ShinyHunting/PokemonBDSP_ShinyHunt-Shaymin.h
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/ShinyHunting/PokemonBDSP_ShinyHunt-Shaymin.h
@@ -15,7 +15,6 @@
 #include "Pokemon/Options/Pokemon_EncounterBotOptions.h"
 #include "PokemonBDSP/Options/PokemonBDSP_ShortcutDirection.h"
 #include "PokemonBDSP/Options/PokemonBDSP_EncounterBotCommon.h"
-#include "PokemonBDSP/Programs/PokemonBDSP_OverworldTrigger.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{


### PR DESCRIPTION
- Add usage of Sweet Scent in PokemonBDSP_OverworldTrigger.
- Since OverworldTrigger has two modes of triggering encounter (move back and forth and Sweet Scent), it is cleaner to let OverworldTrigger have a function `find_encounter()` that calls inference callbacks to return when detecting battle start.
- Programs DoubleLeveling and ShinyHuntingOverworld now don't have their own `find_encounter()` but calls `OverworldTrigger::find_encounter()`.
- Hardcode timing on finding the menuitem of Sweet Scent without video feedback. Need discussion on how to harden this.