### PR TITLE
Fix Qt6CmeraWidget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 SerialPrograms/bin/*
+
+.vscode
+
+# macOS hidden system file
+.DS_Store

--- a/SerialPrograms/Source/CommonFramework/Widgets/CameraSelectorWidget.cpp
+++ b/SerialPrograms/Source/CommonFramework/Widgets/CameraSelectorWidget.cpp
@@ -141,6 +141,10 @@ QString CameraSelectorWidget::aspect_ratio(const QSize& size){
     h /= gcd;
     return "(" + QString::number(w) + ":" + QString::number(h) + ")";
 }
+
+
+
+
 void CameraSelectorWidget::reset_video(){
     std::lock_guard<std::mutex> lg(m_camera_lock);
     m_display.close_video();
@@ -177,7 +181,8 @@ void CameraSelectorWidget::reset_video(){
         m_resolution_box->setCurrentIndex(index);
         m_resolution_box->activated(index);
     }else{
-        m_value.m_resolution = QSize();
+        // Reset to default resolution.
+        m_value.m_resolution = QSize(1920, 1080);
     }
 }
 void CameraSelectorWidget::async_reset_video(){

--- a/SerialPrograms/Source/CommonFramework/Widgets/Qt6CameraWidget.h
+++ b/SerialPrograms/Source/CommonFramework/Widgets/Qt6CameraWidget.h
@@ -56,9 +56,9 @@ private:
     QMediaCaptureSession m_captureSession;
     QVideoSink* m_videoSink = nullptr;
     QVideoFrame m_videoFrame;
+    std::vector<QCameraFormat> m_formats;
 
     mutable std::mutex m_lock;
-    QSize m_resolution;
 };
 
 


### PR DESCRIPTION
- Add hidden files to .gitignore
- Fix bug that default resolution is (-1 x -1)
- Fix Qt6CameraWidget to remove redundant resolutions. Previously it will give multiple menuitems on UI  with the same resolutions because internally the available camera formats include several with same resolutions but different pixel formats. This PR removes those redundant ones by simply preseving only the first formats with the same resolutions when initializing Qt6CameraWidget.
- Remove unused var Qt6CameraWidget::m_resolution.