### PR TITLE
Use Global Room to heal

### DIFF
--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -662,6 +662,8 @@ file(GLOB MAIN_SOURCES
     Source/PokemonBDSP/Programs/PokemonBDSP_GameEntry.h
     Source/PokemonBDSP/Programs/PokemonBDSP_GameNavigation.cpp
     Source/PokemonBDSP/Programs/PokemonBDSP_GameNavigation.h
+    Source/PokemonBDSP/Programs/PokemonBDSP_GlobalRoomHeal.cpp
+    Source/PokemonBDSP/Programs/PokemonBDSP_GlobalRoomHeal.h
     Source/PokemonBDSP/Programs/PokemonBDSP_OverworldTrigger.cpp
     Source/PokemonBDSP/Programs/PokemonBDSP_OverworldTrigger.h
     Source/PokemonBDSP/Programs/PokemonBDSP_RunFromBattle.cpp

--- a/SerialPrograms/Source/CommonFramework/Options/EnumDropdownOption.h
+++ b/SerialPrograms/Source/CommonFramework/Options/EnumDropdownOption.h
@@ -29,6 +29,7 @@ public:
     const QString& label() const{ return m_label; }
     const QString& case_name(size_t index) const{ return m_case_list[index]; }
     const std::vector<QString>& case_list() const{ return m_case_list; }
+    const QString current_case() const { return m_case_list[m_current]; }
 
     operator size_t() const{ return m_current.load(std::memory_order_relaxed); }
     void set(size_t index){ m_current.store(index, std::memory_order_relaxed); }

--- a/SerialPrograms/Source/PokemonBDSP/Options/PokemonBDSP_ShortcutDirection.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Options/PokemonBDSP_ShortcutDirection.cpp
@@ -12,29 +12,48 @@ namespace PokemonAutomation{
 namespace NintendoSwitch{
 namespace PokemonBDSP{
 
+namespace{
+std::vector<QString> buildShortcutValues(bool required){
+    std::vector<QString> values;
+    if (!required){
+        values.emplace_back("None");
+    }
+    values.emplace_back("Up");
+    values.emplace_back("Right");
+    values.emplace_back("Down");
+    values.emplace_back("Left");
+    return values;
+}
+}
 
-ShortcutDirection::ShortcutDirection(QString label)
+ShortcutDirection::ShortcutDirection(QString label, bool required)
     : EnumDropdownOption(
         std::move(label),
-        {
-            "Up",
-            "Right",
-            "Down",
-            "Left",
-        }, 0
-    )
+        buildShortcutValues(required),
+        0
+    ), m_required(required)
 {}
 
 void ShortcutDirection::run(const BotBaseContext& context, uint16_t delay){
     uint8_t shortcut_x = 128;
     uint8_t shortcut_y = 128;
-    switch (*this){
+    size_t index = *this;
+    if (!m_required){
+        // If the shortcut direction is optional, the first value is "None".
+        if (index == 0) {
+            return;
+        }
+        --index;
+    }
+
+    switch (index){
     case 0: shortcut_y = 0; break;
     case 1: shortcut_x = 255; break;
     case 2: shortcut_y = 255; break;
     case 3: shortcut_x = 0; break;
     default: PA_THROW_StringException("Invalid shortcut value: " + std::to_string(*this));
     }
+
     pbf_mash_button(context, BUTTON_PLUS, 125);
     pbf_move_right_joystick(context, shortcut_x, shortcut_y, 20, delay);
 }

--- a/SerialPrograms/Source/PokemonBDSP/Options/PokemonBDSP_ShortcutDirection.h
+++ b/SerialPrograms/Source/PokemonBDSP/Options/PokemonBDSP_ShortcutDirection.h
@@ -17,9 +17,12 @@ namespace PokemonBDSP{
 
 class ShortcutDirection : public EnumDropdownOption{
 public:
-    ShortcutDirection(QString label);
+    ShortcutDirection(QString label, bool required = true);
 
     void run(const BotBaseContext& context, uint16_t delay);
+
+private:
+    bool m_required = true;
 };
 
 

--- a/SerialPrograms/Source/PokemonBDSP/Programs/Farming/PokemonBDSP_DoublesLeveling.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/Farming/PokemonBDSP_DoublesLeveling.cpp
@@ -135,10 +135,8 @@ bool DoublesLeveling::battle(SingleSwitchProgramEnvironment& env){
                 pbf_move_right_joystick(env.console, 128, 255, 20, 105);
                 pbf_press_button(env.console, BUTTON_A, 20, 105);
                 break;
-            }else{
-                return true;
             }
-            break;
+            return true;
         default:
             env.log("Timed out.", COLOR_RED);
             stats.add_error();

--- a/SerialPrograms/Source/PokemonBDSP/Programs/Farming/PokemonBDSP_MoneyFarmerRoute210.h
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/Farming/PokemonBDSP_MoneyFarmerRoute210.h
@@ -33,13 +33,29 @@ public:
 
 private:
     struct Stats;
-    void battle(SingleSwitchProgramEnvironment& env, uint8_t pp0[4], uint8_t pp1[4]);
-    void heal_and_return(ConsoleHandle& console, uint8_t pp0[4], uint8_t pp1[4]);
-    void flyback_heal_and_return(ConsoleHandle& console, uint8_t pp0[4], uint8_t pp1[4]);
+    // Run the battle loop. Return true if the program should stop.
+    bool battle(SingleSwitchProgramEnvironment& env, uint8_t pp0[4], uint8_t pp1[4]);
+    // From the bottom row of the Ace Trainer pair, heal Pokemon and return.
+    // Return true if VS Seeker needs charging.
+    bool heal_after_battle_and_return(SingleSwitchProgramEnvironment& env, ConsoleHandle& console, uint8_t pp0[4], uint8_t pp1[4]);
+    // Starting in front of the Celestic Town Pokecenter, heal and return
+    // to the Ace Trainer pair.
+    void heal_at_center_and_return(ConsoleHandle& console, uint8_t pp0[4], uint8_t pp1[4]);
+    // Fly from the Ace Trainer pair to Hearthome Pokecenter, heal and return.
+    void fly_to_center_heal_and_return(ConsoleHandle& console, uint8_t pp0[4], uint8_t pp1[4]);
+    // Move around to charge VS Seeker.
+    void charge_vs_seeker(ConsoleHandle& console);
+
     static bool has_pp(uint8_t pp0[4], uint8_t pp1[4]);
 
 private:
     ShortcutDirection SHORTCUT;
+
+    EnumDropdownOption START_LOCATION;
+
+    EnumDropdownOption HEALING_METHOD;
+
+    EnumDropdownOption ON_LEARN_MOVE;
 
     SimpleIntegerOption<uint8_t> MON0_MOVE1_PP;
     SimpleIntegerOption<uint8_t> MON0_MOVE2_PP;

--- a/SerialPrograms/Source/PokemonBDSP/Programs/Farming/PokemonBDSP_MoneyFarmerRoute212.h
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/Farming/PokemonBDSP_MoneyFarmerRoute212.h
@@ -34,15 +34,29 @@ public:
 
 private:
     struct Stats;
-    void battle(SingleSwitchProgramEnvironment& env, uint8_t pp[4], bool man);
-    void heal_and_return(ConsoleHandle& console, uint8_t pp[4]);
-    void flyback_heal_and_return(ConsoleHandle& console, uint8_t pp[4]);
+    // Run the battle loop. Return true if the program should stop.
+    bool battle(SingleSwitchProgramEnvironment& env, uint8_t pp[4], bool man);
+    // From the row above the old couple, heal Pokemon and return.
+    // Return true if VS Seeker needs charging.
+    bool heal_after_battle_and_return(SingleSwitchProgramEnvironment& env, ConsoleHandle& console, uint8_t pp[4]);
+    // Starting in front of the Hearthome Pokecenter, heal and return
+    // to the old couple.
+    void heal_at_center_and_return(ConsoleHandle& console, uint8_t pp[4]);
+    // Fly from the old couple to Hearthome Pokecenter, heal and return.
+    void fly_to_center_heal_and_return(ConsoleHandle& console, uint8_t pp[4]);
+    // Move around to charge VS Seeker.
+    void charge_vs_seeker(ConsoleHandle& console);
+
     static size_t total_pp(uint8_t pp[4]);
 
 private:
     ShortcutDirection SHORTCUT;
 
     EnumDropdownOption START_LOCATION;
+
+    EnumDropdownOption HEALING_METHOD;
+
+    EnumDropdownOption ON_LEARN_MOVE;
 
     SimpleIntegerOption<uint8_t> MOVE1_PP;
     SimpleIntegerOption<uint8_t> MOVE2_PP;

--- a/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_GlobalRoomHeal.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_GlobalRoomHeal.cpp
@@ -1,0 +1,59 @@
+/*  Heal the party using Global Room
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "Common/Cpp/Exception.h"
+#include "CommonFramework/Inference/VisualInferenceRoutines.h"
+#include "CommonFramework/Inference/BlackScreenDetector.h"
+#include "NintendoSwitch/Commands/NintendoSwitch_Commands_PushButtons.h"
+#include "PokemonBDSP/Inference/PokemonBDSP_SelectionArrow.h"
+#include "PokemonBDSP_GlobalRoomHeal.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonBDSP{
+
+
+
+bool heal_by_global_room(ProgramEnvironment& env, ConsoleHandle& console){
+    // Go to union room menu.
+    const uint16_t overworld_to_room_delay = 125;
+    pbf_press_button(console, BUTTON_Y, 10, overworld_to_room_delay);
+
+    // Go to global room.
+    pbf_press_dpad(console, DPAD_RIGHT, 10, 100);
+
+    // Press ZL until we are at:
+    // - "Would you like to enter the Global Room?" To select: "Yes" and other options.
+    SelectionArrowFinder arrow(console, {0.50, 0.45, 0.20, 0.20}, COLOR_GREEN);
+    int ret = run_until(
+        env, console,
+        [=](const BotBaseContext& context){
+            for (int i = 0; i < 5; i++){
+                pbf_press_button(context, BUTTON_ZL, 10, 125);
+            }
+        },
+        { &arrow }
+    );
+    if (ret < 0){
+        console.log("No selection arrow detected when using Global Room.", COLOR_RED);
+        PA_THROW_StringException("No selection arrow detected when using Global Room.");
+    }
+
+    // Select "Yes"
+    pbf_press_button(console, BUTTON_ZL, 10, 125);
+    
+    // Then mash B to leave Union Room
+    pbf_mash_button(console, BUTTON_B, 400);
+
+    console.botbase().wait_for_all_requests();
+    return true;
+}
+
+
+
+}
+}
+}

--- a/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_GlobalRoomHeal.h
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_GlobalRoomHeal.h
@@ -1,0 +1,26 @@
+/*  Heal the party using Global Room
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonBDSP_GlobalRoomHeal_H
+#define PokemonAutomation_PokemonBDSP_GlobalRoomHeal_H
+
+#include "CommonFramework/Tools/ProgramEnvironment.h"
+#include "CommonFramework/Tools/ConsoleHandle.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonBDSP{
+
+
+// Use Global Room to heal the party.
+// Must start at overworld and have Y-shotcut to Global Room unlocked.
+bool heal_by_global_room(ProgramEnvironment& env, ConsoleHandle& console);
+
+
+}
+}
+}
+#endif


### PR DESCRIPTION
- Add option to use global room to heal the party in money farmers.
- Add option to skip learning moves when battling in money farmers.
- Add option to money farmer 210 to start the program near the ace trainer pair.
- Change option ShortcutDirection to be able to set to optional. I did this change to add an option of biking to speed up VS Seeker charging in money farmer. But it turns out using bike is not faster than on foot. So the idea is scrapped but the change to ShortcutDirection may be useful in future.