### PR TITLE
Add auto catch

### DIFF
--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -575,6 +575,8 @@ file(GLOB MAIN_SOURCES
     Source/PokemonBDSP/Inference/Battles/PokemonBDSP_BattleMenuDetector.h
     Source/PokemonBDSP/Inference/Battles/PokemonBDSP_EndBattleDetector.cpp
     Source/PokemonBDSP/Inference/Battles/PokemonBDSP_EndBattleDetector.h
+    Source/PokemonBDSP/Inference/Battles/PokemonBDSP_ExperienceGainDetector.cpp
+    Source/PokemonBDSP/Inference/Battles/PokemonBDSP_ExperienceGainDetector.h
     Source/PokemonBDSP/Inference/Battles/PokemonBDSP_StartBattleDetector.cpp
     Source/PokemonBDSP/Inference/Battles/PokemonBDSP_StartBattleDetector.h
     Source/PokemonBDSP/Inference/BoxSystem/PokemonBDSP_BoxDetector.cpp
@@ -593,6 +595,8 @@ file(GLOB MAIN_SOURCES
     Source/PokemonBDSP/Inference/PokemonBDSP_MenuDetector.h
     Source/PokemonBDSP/Inference/PokemonBDSP_PokeballSpriteMatcher.cpp
     Source/PokemonBDSP/Inference/PokemonBDSP_PokeballSpriteMatcher.h
+    Source/PokemonBDSP/Inference/PokemonBDSP_ReceivePokemonDetector.cpp
+    Source/PokemonBDSP/Inference/PokemonBDSP_ReceivePokemonDetector.h
     Source/PokemonBDSP/Inference/PokemonBDSP_SelectionArrow.cpp
     Source/PokemonBDSP/Inference/PokemonBDSP_SelectionArrow.h
     Source/PokemonBDSP/Inference/PokemonBDSP_VSSeekerReaction.cpp
@@ -616,6 +620,8 @@ file(GLOB MAIN_SOURCES
     Source/PokemonBDSP/Options/EncounterFilter/PokemonBDSP_EncounterFilterWidget.h
     Source/PokemonBDSP/Options/PokemonBDSP_ShortcutDirection.cpp
     Source/PokemonBDSP/Options/PokemonBDSP_ShortcutDirection.h
+    Source/PokemonBDSP/Programs/PokemonBDSP_BasicCatcher.cpp
+    Source/PokemonBDSP/Programs/PokemonBDSP_BasicCatcher.h
     Source/PokemonBDSP/Programs/PokemonBDSP_BoxRelease.cpp
     Source/PokemonBDSP/Programs/PokemonBDSP_BoxRelease.h
     Source/PokemonBDSP/Programs/Eggs/PokemonBDSP_EggAutonomous.cpp

--- a/SerialPrograms/Source/CommonFramework/Options/BatchOption/BatchOption.h
+++ b/SerialPrograms/Source/CommonFramework/Options/BatchOption/BatchOption.h
@@ -16,7 +16,7 @@
 
 namespace PokemonAutomation{
 
-
+// A ConfigOption that groups one or more options.
 class BatchOption : public ConfigOption{
 public:
 //    BatchOption();

--- a/SerialPrograms/Source/CommonFramework/Options/ConfigOption.h
+++ b/SerialPrograms/Source/CommonFramework/Options/ConfigOption.h
@@ -23,6 +23,11 @@ enum class ConfigOptionState{
 
 class ConfigWidget;
 
+// An option of a program, like the number of boxes of eggs to hatch,
+// the number of frames to skip, or what type of pokeballs to throw.
+// It is responsible for setting the UI (by calling make_ui()) of this option.
+// It also uses load_json() and to_json() to load and save the option to
+// a json file, so that the program can remember what user has selected.
 class ConfigOption{
 public:
     virtual ~ConfigOption() = default;

--- a/SerialPrograms/Source/PokemonBDSP/Inference/Battles/PokemonBDSP_ExperienceGainDetector.h
+++ b/SerialPrograms/Source/PokemonBDSP/Inference/Battles/PokemonBDSP_ExperienceGainDetector.h
@@ -1,0 +1,58 @@
+/*  Battle Won Detector
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonBDSP_BattleWonDetector_H
+#define PokemonAutomation_PokemonBDSP_BattleWonDetector_H
+
+#include "Common/Cpp/FixedLimitVector.h"
+#include "CommonFramework/Tools/VideoFeed.h"
+#include "CommonFramework/Inference/ImageTools.h"
+#include "CommonFramework/Inference/VisualDetector.h"
+#include "CommonFramework/Inference/VisualInferenceCallback.h"
+#include "PokemonBDSP/Inference/PokemonBDSP_DialogDetector.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonBDSP{
+
+// Detect the screen showing the party pokemon are about to gain experience.
+// This is useful to detect whether you have caught or defeated a wild pokemon.
+// The experience screen still shows even if all party pokemon are max leveled and have max EVs.
+class ExperienceGainDetector : public StaticScreenDetector{
+public:
+    ~ExperienceGainDetector();
+    ExperienceGainDetector(Color color = COLOR_RED);
+
+    virtual void make_overlays(VideoOverlaySet& items) const override;
+    virtual bool detect(const QImage& screen) const override;
+
+private:
+    Color m_color;
+    ShortDialogDetector m_dialog;
+    ImageFloatBox m_middle_column;
+    ImageFloatBox m_left_column;
+    ImageFloatBox m_lower_left_region;
+};
+
+// Watch for the screen that the party pokemon are about to gain experience.
+// The experience screen still shows even if all party pokemon are max leveled and have max EVs.
+class ExperienceGainWatcher : public ExperienceGainDetector, public VisualInferenceCallback{
+public:
+    using ExperienceGainDetector::ExperienceGainDetector;
+
+    virtual void make_overlays(VideoOverlaySet& items) const override;
+    // Return true when the screen that the party pokemon are about to gain experience is found.
+    virtual bool process_frame(
+        const QImage& frame,
+        std::chrono::system_clock::time_point timestamp
+    ) override final;
+};
+
+
+}
+}
+}
+#endif

--- a/SerialPrograms/Source/PokemonBDSP/Inference/PokemonBDSP_DialogDetector.h
+++ b/SerialPrograms/Source/PokemonBDSP/Inference/PokemonBDSP_DialogDetector.h
@@ -15,7 +15,9 @@ namespace PokemonAutomation{
 namespace NintendoSwitch{
 namespace PokemonBDSP{
 
-
+// Detect short dialog boxes that are used in all kinds of ingame situations where texts are displayed.
+// The only place the long dialog boxes appear is during pokemon battles. But after battle, the exp gain
+// text is in a short dialog box.
 class ShortDialogDetector : public StaticScreenDetector{
 public:
     ShortDialogDetector(Color color = COLOR_RED);
@@ -44,7 +46,8 @@ public:
 
 
 
-
+// Detect the long dialog boxes that only appear during pokemon battles.
+// Note after battle, the exp gain text is in a short dialog box.
 class BattleDialogDetector : public StaticScreenDetector{
 public:
     BattleDialogDetector(Color color = COLOR_RED);

--- a/SerialPrograms/Source/PokemonBDSP/Inference/PokemonBDSP_ReceivePokemonDetector.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Inference/PokemonBDSP_ReceivePokemonDetector.cpp
@@ -1,0 +1,51 @@
+/*  Receive Pokemon (Blue Background) Detector
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "Common/Compiler.h"
+#include "CommonFramework/ImageTools/SolidColorTest.h"
+#include "CommonFramework/Tools/VideoOverlaySet.h"
+#include "PokemonBDSP_ReceivePokemonDetector.h"
+
+
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonBDSP{
+
+
+
+ReceivePokemonDetector::ReceivePokemonDetector(Color color)
+    : m_color(color)
+    , m_box0(0.05, 0.10, 0.10, 0.80)
+    , m_box1(0.87, 0.10, 0.10, 0.80)
+{}
+
+
+void ReceivePokemonDetector::make_overlays(VideoOverlaySet& items) const{
+    items.add(m_color, m_box0);
+    items.add(m_color, m_box1);
+}
+
+bool ReceivePokemonDetector::process_frame(
+    const QImage& frame,
+    std::chrono::system_clock::time_point timestamp
+){
+    const ImageStats stats0 = image_stats(extract_box(frame, m_box0));
+    if (!is_solid(stats0, {0.22951, 0.340853, 0.429638}, 0.15, 20)){
+        return m_received;
+    }
+    const ImageStats stats1 = image_stats(extract_box(frame, m_box1));
+    if (!is_solid(stats1, {0.22951, 0.340853, 0.429638}, 0.15, 20)){
+        return m_received;
+    }
+    m_received = true;
+    return false;
+}
+
+
+}
+}
+}

--- a/SerialPrograms/Source/PokemonBDSP/Inference/PokemonBDSP_ReceivePokemonDetector.h
+++ b/SerialPrograms/Source/PokemonBDSP/Inference/PokemonBDSP_ReceivePokemonDetector.h
@@ -1,0 +1,50 @@
+/*  Receive Pokemon (Blue Background) Detector
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ *
+ *      Returns true after the background of receiving a pokemon
+ *  has been detected and has ended.
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonBDSP_ReceivePokemonDetector_H
+#define PokemonAutomation_PokemonBDSP_ReceivePokemonDetector_H
+
+#include "CommonFramework/Tools/VideoFeed.h"
+#include "CommonFramework/Logging/Logger.h"
+#include "CommonFramework/Inference/VisualInferenceCallback.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonBDSP{
+
+// Detect the end of receiving a pokemon or an egg.
+class ReceivePokemonDetector : public VisualInferenceCallback{
+public:
+    ReceivePokemonDetector(Color color = COLOR_RED);
+
+    // Whether a receive event happened or is happening.
+    bool received() const { return m_received; }
+
+    virtual void make_overlays(VideoOverlaySet& items) const override;
+
+    // Return true only when a receiving event happened and ended.
+    virtual bool process_frame(
+        const QImage& frame,
+        std::chrono::system_clock::time_point timestamp
+    ) override;
+
+private:
+    bool m_received = false;
+    Color m_color;
+    ImageFloatBox m_box0;
+    ImageFloatBox m_box1;
+};
+
+
+
+}
+}
+}
+#endif

--- a/SerialPrograms/Source/PokemonBDSP/Programs/Farming/PokemonBDSP_DoublesLeveling.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/Farming/PokemonBDSP_DoublesLeveling.cpp
@@ -133,7 +133,7 @@ bool DoublesLeveling::battle(SingleSwitchProgramEnvironment& env){
             env.log("Detected move learn!", COLOR_BLUE);
             if (ON_LEARN_MOVE == 0){
                 pbf_move_right_joystick(env.console, 128, 255, 20, 105);
-                pbf_press_button(env.console, BUTTON_A, 20, 105);
+                pbf_press_button(env.console, BUTTON_ZL, 20, 105);
                 break;
             }
             return true;
@@ -169,6 +169,7 @@ void DoublesLeveling::program(SingleSwitchProgramEnvironment& env){
         //  Find encounter.
         bool battle = TRIGGER_METHOD.find_encounter(env);
         if (!battle){
+            // Unexpected battle: detect battle menu but not battle starting animation.
             stats.add_error();
             handler.run_away_due_to_error(EXIT_BATTLE_TIMEOUT);
             continue;

--- a/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_BasicCatcher.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_BasicCatcher.cpp
@@ -1,0 +1,271 @@
+/*  Basic Pokemon Catcher
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "Common/Cpp/Exception.h"
+#include "CommonFramework/Globals.h"
+#include "CommonFramework/Tools/InterruptableCommands.h"
+#include "CommonFramework/Inference/VisualInferenceRoutines.h"
+// #include "CommonFramework/Inference/BlackScreenDetector.h"
+#include "NintendoSwitch/Commands/NintendoSwitch_Commands_PushButtons.h"
+#include "PokemonBDSP/Inference/PokemonBDSP_ReceivePokemonDetector.h"
+#include "PokemonBDSP/Inference/Battles/PokemonBDSP_ExperienceGainDetector.h"
+#include "PokemonBDSP/Inference/Battles/PokemonBDSP_BattleMenuDetector.h"
+#include "PokemonBDSP/Inference/Battles/PokemonBDSP_EndBattleDetector.h"
+#include "PokemonBDSP_BasicCatcher.h"
+
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonBDSP{
+
+
+//  Returns the # of slots scrolled. Returns -1 if not found.
+int move_to_ball(
+    const BattleBallReader& reader,
+    ConsoleHandle& console,
+    const std::string& ball_slug,
+    bool forward, int attempts, uint16_t delay
+){
+    QImage frame = console.video().snapshot();
+    std::string first_ball = reader.read_ball(frame);
+    if (first_ball == ball_slug){
+        return 0;
+    }
+
+    size_t repeat_counter = 0;
+    for (int c = 1; c < attempts; c++){
+        pbf_press_dpad(console, forward ? DPAD_RIGHT : DPAD_LEFT, 10, delay);
+        console.botbase().wait_for_all_requests();
+        frame = console.video().snapshot();
+        std::string current_ball = reader.read_ball(frame);
+        if (current_ball == ball_slug){
+            return c;
+        }
+        if (current_ball == first_ball){
+            repeat_counter++;
+            if (repeat_counter == 3){
+                return -1;
+            }
+        }
+    }
+    return -1;
+}
+
+
+//  Returns the quantity of the ball.
+//  Returns -1 if unable to read.
+int16_t move_to_ball(
+    const BattleBallReader& reader,
+    ConsoleHandle& console,
+    const std::string& ball_slug
+){
+    //  Search forward at high speed.
+    int ret = move_to_ball(reader, console, ball_slug, true, 50, 30);
+    if (ret < 0){
+        return 0;
+    }
+    if (ret == 0){
+        uint16_t quantity = reader.read_quantity(console.video().snapshot());
+        return quantity == 0 ? -1 : quantity;
+    }
+
+    //  Wait a second to let the video catch up.
+    pbf_wait(console, TICKS_PER_SECOND);
+    console.botbase().wait_for_all_requests();
+
+    //  Now try again in reverse at a lower speed in case we overshot.
+    //  This will return immediately if we got it right the first time.
+    ret = move_to_ball(reader, console, ball_slug, false, 5, TICKS_PER_SECOND);
+    if (ret < 0){
+        return 0;
+    }
+    if (ret > 0){
+        console.log("BasicCatcher: Fast ball scrolling overshot by " +
+            std::to_string(ret) + " slot(s).", COLOR_RED);
+    }
+    uint16_t quantity = reader.read_quantity(console.video().snapshot());
+    return quantity == 0 ? -1 : quantity;
+}
+
+
+CatchResults throw_balls(
+    ProgramEnvironment& env,
+    ConsoleHandle& console,
+    Language language,
+    const std::string& ball_slug
+){
+    uint16_t balls_used = 0;
+    while (true){
+        // Test code for checking catch outcome handling: if the wild pokemon fainted:
+// #define TEST_WILD_POKEMON_FAINTED
+#ifdef TEST_WILD_POKEMON_FAINTED
+        pbf_mash_button(console, BUTTON_ZL, TICKS_PER_SECOND);
+        console.botbase().wait_for_all_requests();
+        if (0)
+#endif
+        {
+            BattleBallReader reader(console, language);
+
+            pbf_press_button(console, BUTTON_X, 10, 50);
+            console.botbase().wait_for_all_requests();
+
+            const int16_t num_balls = move_to_ball(reader, console, ball_slug);
+            if (num_balls < 0){
+                console.log("BasicCatcher: Unable to read quantity of ball " + ball_slug + ".");
+            }
+            if (num_balls == 0){
+                console.log("BasicCatcher: No ball " + ball_slug +
+                    " found in bag or used them all during catching.");
+//                PA_THROW_StringException("Unable to find appropriate ball.");
+                return {CatchResult::OUT_OF_BALLS, balls_used};
+            }
+
+            console.log("BasicCatcher: Found " + ball_slug + " with amount " + 
+                std::to_string(num_balls));
+            pbf_mash_button(console, BUTTON_ZL, 125);
+            console.botbase().wait_for_all_requests();
+        }
+        balls_used++;
+
+        auto start = std::chrono::system_clock::now();
+
+        BattleMenuWatcher menu_detector(BattleType::WILD);
+        ExperienceGainWatcher experience_detector;
+        SelectionArrowFinder own_fainted_detector(console, {0.18, 0.64, 0.46, 0.3}, COLOR_YELLOW);
+        int result = wait_until(
+            env, console,
+            std::chrono::seconds(60),
+            {
+                &menu_detector,
+                &experience_detector,
+                &own_fainted_detector,
+            }
+        );
+        switch (result){
+        case 0:
+            if (std::chrono::system_clock::now() < start + std::chrono::seconds(5)){
+                return {CatchResult::CANNOT_THROW_BALL, balls_used};
+            }
+            env.log("BasicCatcher: Failed to catch.", COLOR_ORANGE);
+            continue;
+        case 1:
+            env.log("BasicCatcher: End of battle detected.", COLOR_PURPLE);
+            // It's actually fainted or caught. The logic to find out which one
+            // is in basic_catcher().
+            return {CatchResult::POKEMON_FAINTED, balls_used};
+        case 2:
+            return {CatchResult::OWN_FAINTED, balls_used};
+        default:
+            return {CatchResult::TIMEOUT, balls_used};
+        }
+    }
+}
+
+
+CatchResults basic_catcher(
+    ProgramEnvironment& env,
+    ConsoleHandle& console,
+    Language language,
+    const std::string& ball_slug
+){
+    console.botbase().wait_for_all_requests();
+    env.log("Attempting to catch with: " + ball_slug);
+
+    CatchResults results = throw_balls(env, console, language, ball_slug);
+    const QString s = (results.balls_used <= 1 ? "" : "s");
+    const QString pokeball_str = QString::number(results.balls_used) + " " +
+        QString(ball_slug.c_str()) + s;
+
+    if (results.result == CatchResult::OUT_OF_BALLS){
+        env.log("BasicCatcher: Out of balls after throwing " + pokeball_str, COLOR_RED);
+        return results;
+    }
+    if (results.result == CatchResult::CANNOT_THROW_BALL){
+        env.log("BasicCatcher: cannot throw ball for some reason.", COLOR_RED);
+        return results;
+    }
+    if (results.result == CatchResult::OWN_FAINTED){
+        env.log("BasicCatcher: own pokemon fainted after throwing " + pokeball_str, COLOR_RED);
+        return results;
+    }
+    if (results.result == CatchResult::TIMEOUT){
+        env.log("BasicCatcher: time out.");
+        return results;
+    }
+
+    //  Need to distinguish between caught or faint.
+    //  Where there is no pokemon evolving, the order of events in BDSP is:
+    //  exp screen -> lvl up and learn new move dialog -> new pokemon received screen if caught
+    //  -> black screen -> return to overworld
+    //  Wthere there is pokemon evolving, the order becomes:
+    //  exp screen -> lvl up and learn new move dialog -> black screen -> pokemon evolving
+    //  -> new pokemon received screen if caught.
+    //  In this basic_catcher() we don't handle pokemon evolving.
+
+    //  First, default the result to be fainted.
+    results.result = CatchResult::POKEMON_FAINTED;
+    size_t num_learned_moves = 0;
+    while (true){
+        console.botbase().wait_for_all_requests();
+        //  Wait for end of battle.
+        // BlackScreenOverWatcher black_screen_detector;
+        EndBattleWatcher end_battle;
+        //  Look for a pokemon learning a new move.
+        SelectionArrowFinder learn_move(console, {0.50, 0.62, 0.40, 0.18}, COLOR_YELLOW);
+        //  Look for the pokemon caught screen.
+        ReceivePokemonDetector caught_detector;
+        int ret = run_until(
+            env, console,
+            [=](const BotBaseContext& context){
+                pbf_mash_button(context, BUTTON_B, 120 * TICKS_PER_SECOND);
+            },
+            {
+                &end_battle,
+                &caught_detector,
+                &learn_move,
+            }
+        );
+        switch (ret){
+        case 0:
+            if (results.result == CatchResult::POKEMON_FAINTED){
+                env.log("BasicCatcher: The wild " + STRING_POKEMON + " fainted after " +
+                    pokeball_str, COLOR_RED);
+            }
+            env.log("BasicCatcher: Battle finished!", COLOR_BLUE);
+            pbf_wait(console, TICKS_PER_SECOND);
+            console.botbase().wait_for_all_requests();
+            return results;
+        case 1:
+            if (results.result == CatchResult::POKEMON_CAUGHT){
+                PA_THROW_StringException("BasicCatcher: found receive pokemon screen two times.");
+            }
+            env.log("BasicCatcher: The wild " + STRING_POKEMON + " was caught by " + 
+            pokeball_str, COLOR_BLUE);
+            results.result = CatchResult::POKEMON_CAUGHT;
+            break; //  Continue the loop.
+        case 2:
+            env.log("BasicCatcher: Detected move learn! Don't learn the new move.", COLOR_BLUE);
+            num_learned_moves++;
+            if (num_learned_moves == 100){
+                PA_THROW_StringException("BasicCatcher: Learn new move attempts reach 100.");
+            }
+            pbf_move_right_joystick(console, 128, 255, 20, 105);
+            pbf_press_button(console, BUTTON_ZL, 20, 105);
+            break; //  Continue the loop.
+
+        default:
+            env.log("BasicCatcher: Timed out.", COLOR_RED);
+            // PA_THROW_StringException("Timed out after 2 minutes.");
+            results.result = CatchResult::TIMEOUT;
+            return results;
+        }
+    }
+}
+
+
+}
+}
+}

--- a/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_BasicCatcher.h
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_BasicCatcher.h
@@ -1,0 +1,61 @@
+/*  Basic Pokemon Catcher
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonBDSP_BasicCatcher_H
+#define PokemonAutomation_PokemonBDSP_BasicCatcher_H
+
+#include "CommonFramework/Language.h"
+#include "CommonFramework/Tools/ProgramEnvironment.h"
+#include "CommonFramework/Tools/ConsoleHandle.h"
+#include "PokemonBDSP/Inference/Battles/PokemonBDSP_BattleBallReader.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonBDSP{
+    
+
+//  Throws the specified ball until:
+//      1.  The Pokemon is caught. Returns # of balls used.
+//      2.  The Pokemon faints. Returns -# of balls used.
+//      3.  Your Pokemon faints. Throws an error. (will change in the future)
+//      4.  You run of the ball. Throws an error.
+enum class CatchResult{
+    POKEMON_CAUGHT,
+    POKEMON_FAINTED,
+    OWN_FAINTED,    //  Not implemented yet. Will show up as TIMEOUT for now.
+    OUT_OF_BALLS,
+    CANNOT_THROW_BALL,  // The Pokemon is in Fly or Underground, or it's a story pokemon
+                        // that cannot be caught.
+    TIMEOUT,
+};
+
+struct CatchResults{
+    CatchResult result = CatchResult::TIMEOUT;
+    uint16_t balls_used = 0;
+};
+
+// Throw balls repeatedly to catch wild pokemon.
+// It can detect whether the wild pokemon is caught, the wild pokemon is fainted,
+// cannot throw balls, own pokemon fainted, out of balls or timeout.
+// If both own and wild pokemon fainted and not blackout, count as wild pokemon fainted.
+// If own pokemon level up and want to learn new moves, choose to not learn them.
+// If the wild pokemon is caught or fainted, the game returns to the overworld when
+// basic_catcher() returns.
+//
+// Don't handle the case that own pokemon evolving or black out to Pokecenter.
+CatchResults basic_catcher(
+    ProgramEnvironment& env,
+    ConsoleHandle& console,
+    Language language,
+    const std::string& ball_slug
+);
+
+
+
+}
+}
+}
+#endif

--- a/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_EncounterHandler.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_EncounterHandler.cpp
@@ -7,8 +7,10 @@
 #include "Common/Cpp/Exception.h"
 #include "NintendoSwitch/Commands/NintendoSwitch_Commands_PushButtons.h"
 #include "Pokemon/Pokemon_Types.h"
-#include "PokemonBDSP_RunFromBattle.h"
+#include "PokemonBDSP_BasicCatcher.h"
 #include "PokemonBDSP_EncounterHandler.h"
+#include "PokemonBDSP_GameNavigation.h"
+#include "PokemonBDSP_RunFromBattle.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
@@ -87,31 +89,6 @@ void StandardEncounterHandler::update_frequencies(StandardEncounterDetection& en
     if (left.exists || right.exists){
         m_env.log(m_frequencies.dump_sorted_map("Encounter Stats:\n"));
     }
-}
-void StandardEncounterHandler::run_away_and_update_stats(
-    StandardEncounterDetection& encounter,
-    uint16_t exit_battle_time,
-    const DoublesShinyDetection& result
-){
-    pbf_press_dpad(m_console, DPAD_UP, 10, 0);
-
-    bool enable_names = m_language != Language::None;
-    update_frequencies(encounter);
-    send_encounter_notification(
-        m_console,
-        m_settings.NOTIFICATION_NONSHINY,
-        m_settings.NOTIFICATION_SHINY,
-        m_env.program_info(),
-        enable_names, is_shiny(result.shiny_type),
-        results(encounter),
-        result.best_screenshot,
-        &m_session_stats,
-        enable_names ? &m_frequencies : nullptr
-    );
-
-    m_console.botbase().wait_for_all_requests();
-
-    run_from_battle(m_env, m_console, exit_battle_time);
 }
 
 
@@ -211,20 +188,15 @@ bool StandardEncounterHandler::handle_standard_encounter_end_battle(
 
     std::pair<EncounterAction, std::string> action = encounter.get_action();
 
-    //  Fast run-away sequence to save time.
-    if (action.first == EncounterAction::RunAway){
-        run_away_and_update_stats(encounter, exit_battle_time, result);
-        return false;
-    }
-
     bool enable_names = m_language != Language::None;
     update_frequencies(encounter);
+
     send_encounter_notification(
         m_console,
         m_settings.NOTIFICATION_NONSHINY,
         m_settings.NOTIFICATION_SHINY,
         m_env.program_info(),
-        m_language != Language::None, is_shiny(result.shiny_type),
+        enable_names, is_shiny(result.shiny_type),
         results(encounter),
         result.best_screenshot,
         &m_session_stats,
@@ -235,7 +207,46 @@ bool StandardEncounterHandler::handle_standard_encounter_end_battle(
     case EncounterAction::StopProgram:
         return true;
     case EncounterAction::RunAway:
+        //  Fast run-away sequence to save time.
+        pbf_press_dpad(m_console, DPAD_UP, 10, 0);
+        m_console.botbase().wait_for_all_requests();
+
+        run_from_battle(m_env, m_console, exit_battle_time);
         return false;
+    
+    case EncounterAction::ThrowBalls:
+    case EncounterAction::ThrowBallsAndSave:
+        {
+            const auto result = basic_catcher(m_env, m_console, m_language, action.second);
+            if (result.result == CatchResult::POKEMON_CAUGHT){
+                m_session_stats.add_caught();
+                send_program_status_notification(
+                    m_env.logger(), m_settings.NOTIFICATION_CATCH_SUCCESS,
+                    m_env.program_info(),
+                    "Threw " + QString::number(result.balls_used) + " ball(s) and caught it.",
+                    m_session_stats.to_str()
+                );
+                m_env.update_stats();
+                
+                if (action.first == EncounterAction::ThrowBallsAndSave){
+                    //  Save the game
+                    save_game(m_env, m_console);
+                }
+                return false;
+            }
+            else if (result.result == CatchResult::POKEMON_FAINTED){
+                send_program_status_notification(
+                    m_env.logger(), m_settings.NOTIFICATION_CATCH_FAILED,
+                    m_env.program_info(),
+                    "Threw " + QString::number(result.balls_used) + " ball(s) and did not catch it.",
+                    m_session_stats.to_str()
+                );
+                return false;
+            }
+            //  For all other situations: out of balls, cannot throw ball, own fainted, timeout,
+            //  stop program.
+            return true;
+        }
     default:
         return true;
     }

--- a/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_EncounterHandler.h
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_EncounterHandler.h
@@ -20,7 +20,7 @@ namespace PokemonAutomation{
 namespace NintendoSwitch{
 namespace PokemonBDSP{
 
-
+//  Handle wild encounters using feedback.
 class StandardEncounterHandler{
 public:
     StandardEncounterHandler(
@@ -32,21 +32,30 @@ public:
     );
 
     //  Run away sequence for unexpected battle.
+    //  Must be called during a battle. Hit "Run" and go through the dialogue until
+    //  end of battle is detected.
+    //  The pokemon must be able to run successfully with no trapping or run away failure.
+    //
+    //  exit_battle_time: number of ticks to wait for battle ends after pressing "Run" button.
+    //    If end of battle not detected in time, log the error but don't throw exception.
     void run_away_due_to_error(uint16_t exit_battle_time);
 
+    //  Use shiny detection result and inference of pokemon species to determine whether
+    //  to stop the program according to the user setting.
     //  Return true if program should stop.
     bool handle_standard_encounter(const DoublesShinyDetection& result);
+    //  Use shiny detection result and inference of pokemon species to determine whether
+    //  to stop the program, run away from battle or catch the pokemon according to the user
+    //  setting.
+    //  Return true if program should stop.
     bool handle_standard_encounter_end_battle(const DoublesShinyDetection& result, uint16_t exit_battle_time);
 
 
 private:
     std::vector<EncounterResult> results(StandardEncounterDetection& encounter);
+    // Record the types of pokemon encountered into encounter stats.
+    // The stats are then logged.
     void update_frequencies(StandardEncounterDetection& encounter);
-    void run_away_and_update_stats(
-        StandardEncounterDetection& encounter,
-        uint16_t exit_battle_time,
-        const DoublesShinyDetection& result
-    );
 
 private:
     ProgramEnvironment& m_env;

--- a/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_RunFromBattle.h
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_RunFromBattle.h
@@ -14,8 +14,11 @@ namespace PokemonAutomation{
 namespace NintendoSwitch{
 namespace PokemonBDSP{
 
-
-//  The cursor must be over the "Run" button.
+// Run from a wild battle.
+// The cursor must be over the "Run" button when starting this function.
+// It uses feedback to ensure battle ends by detecting a black screen.
+// Return true if a black screen is detected, false if not detected after
+// `exit_battle_time` of ticks have passed. 
 bool run_from_battle(
     ProgramEnvironment& env,
     ConsoleHandle& console,

--- a/SerialPrograms/Source/PokemonBDSP/Programs/ShinyHunting/PokemonBDSP_ShinyHunt-Overworld.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/ShinyHunting/PokemonBDSP_ShinyHunt-Overworld.cpp
@@ -36,7 +36,7 @@ ShinyHuntOverworld_Descriptor::ShinyHuntOverworld_Descriptor()
 ShinyHuntOverworld::ShinyHuntOverworld(const ShinyHuntOverworld_Descriptor& descriptor)
     : SingleSwitchProgramInstance(descriptor)
     , GO_HOME_WHEN_DONE(false)
-    , ENCOUNTER_BOT_OPTIONS(true, false)
+    , ENCOUNTER_BOT_OPTIONS(true, true)
     , NOTIFICATION_PROGRAM_FINISH("Program Finished", true, true)
     , NOTIFICATIONS({
         &ENCOUNTER_BOT_OPTIONS.NOTIFICATION_NONSHINY,

--- a/SerialPrograms/Source/PokemonSwSh/ShinyHuntTracker.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/ShinyHuntTracker.cpp
@@ -15,6 +15,7 @@ namespace PokemonSwSh{
 
 ShinyHuntTracker::ShinyHuntTracker(bool shiny_types)
     : m_encounters(m_stats["Encounters"])
+    , m_caught(m_stats["Caught"])
     , m_errors(m_stats["Errors"])
     , m_unknown_shinies(m_stats[shiny_types ? "Unknown Shinies" : "Shinies"])
     , m_star_shinies(m_stats["Star Shinies"])
@@ -29,6 +30,7 @@ ShinyHuntTracker::ShinyHuntTracker(bool shiny_types)
     }else{
         m_display_order.emplace_back("Shinies");
     }
+    m_display_order.emplace_back("Caught", true);
 }
 ShinyHuntTracker::ShinyHuntTracker(bool shiny_types, std::map<std::string, std::string> aliases)
     : ShinyHuntTracker(shiny_types)
@@ -75,6 +77,9 @@ void ShinyHuntTracker::add_star_shiny(){
 void ShinyHuntTracker::add_square_shiny(){
     m_encounters++;
     m_square_shinies++;
+}
+void ShinyHuntTracker::add_caught(){
+    m_caught++;
 }
 
 

--- a/SerialPrograms/Source/PokemonSwSh/ShinyHuntTracker.h
+++ b/SerialPrograms/Source/PokemonSwSh/ShinyHuntTracker.h
@@ -28,9 +28,11 @@ public:
     void add_unknown_shiny();
     void add_star_shiny();
     void add_square_shiny();
+    void add_caught();
 
 private:
     std::atomic<uint64_t>& m_encounters;
+    std::atomic<uint64_t>& m_caught;
     std::atomic<uint64_t>& m_errors;
 
     std::atomic<uint64_t>& m_unknown_shinies;


### PR DESCRIPTION
- Allow auto shiny overworld to catch pokemon automatically by calling basic_catcher()
- basic_catcher() is the same logic as SwSh basic_catcher()
- Plus can detect own fainted using arrow detector.
- And can handle learning new move by arrow detector and not learning them
- Tested on cases: wild pokemon caught, wild pokemon fainted, own pokemon fainted, learning new moves after gaining exp.
- Does not work on the situation that own pokemon evolves after battle or blacks out returning to Pokecenter.