### PR TITLE
Fix compile error and warning on macOS

### DIFF
--- a/SerialPrograms/Source/CommonFramework/ImageMatch/ExactImageDictionaryMatcher.cpp
+++ b/SerialPrograms/Source/CommonFramework/ImageMatch/ExactImageDictionaryMatcher.cpp
@@ -5,6 +5,8 @@
  */
 
 #include <cmath>
+#include <vector>
+#include <QImage>
 #include "Common/Cpp/Exception.h"
 #include "CommonFramework/ImageTools/ImageBoxes.h"
 #include "ImageDiff.h"

--- a/SerialPrograms/Source/PokemonSwSh/MaxLair/Inference/PokemonSwSh_MaxLair_Detect_PathSide.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/MaxLair/Inference/PokemonSwSh_MaxLair_Detect_PathSide.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <cmath>
+#include "Kernels/BinaryMatrix/Kernels_SparseBinaryMatrixBase.tpp"
 #include "Kernels/Waterfill/Kernels_Waterfill.h"
 #include "CommonFramework/ImageTools/ImageStats.h"
 #include "CommonFramework/ImageTools/SolidColorTest.h"


### PR DESCRIPTION
- Fix unable to compile because of no definition on vector<QImage> in ExactImageDictionaryMatcher.cpp
- Fix compiler warning of no definition of ZERO_TILE and tile() in Kernels_SparseBinaryMatrixBase.h when compiling PokemonSwSh_MaxLair_Detect_PathSide.cpp.