### PR TITLE
Add audio

### DIFF
--- a/Common/Cpp/AlignedVector.tpp
+++ b/Common/Cpp/AlignedVector.tpp
@@ -52,8 +52,9 @@ AlignedVector<Object>::AlignedVector(const AlignedVector& x)
     //  Shrink to fit.
     while (m_capacity > 0){
         size_t half = m_capacity / 2;
-        if (half > x.m_size){
+        if (half >= x.m_size){
             m_capacity = half;
+        } else{
             break;
         }
     }

--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -145,7 +145,20 @@ file(GLOB MAIN_SOURCES
     ../Common/Qt/Options/TimeExpression/TimeExpressionBaseWidget.h
     ../Common/Qt/QtJsonTools.cpp
     ../Common/Qt/QtJsonTools.h
+    Source/CommonFramework/AudioPipeline/AudioDisplayWidget.cpp
+    Source/CommonFramework/AudioPipeline/AudioDisplayWidget.h
+    Source/CommonFramework/AudioPipeline/AudioInfo.h
+    Source/CommonFramework/AudioPipeline/AudioSelector.cpp
+    Source/CommonFramework/AudioPipeline/AudioSelector.h
+    Source/CommonFramework/AudioPipeline/AudioSelectorWidget.cpp
+    Source/CommonFramework/AudioPipeline/AudioSelectorWidget.h
     Source/CommonFramework/AudioPipeline/AudioNormalization.h
+    Source/CommonFramework/AudioPipeline/AudioThreadController.cpp
+    Source/CommonFramework/AudioPipeline/AudioThreadController.h
+    Source/CommonFramework/AudioPipeline/AudioWorker.cpp
+    Source/CommonFramework/AudioPipeline/AudioWorker.h
+    Source/CommonFramework/AudioPipeline/FFTWorker.cpp
+    Source/CommonFramework/AudioPipeline/FFTWorker.h
     Source/CommonFramework/AudioPipeline/TimeSampleBuffer.cpp
     Source/CommonFramework/AudioPipeline/TimeSampleBuffer.h
     Source/CommonFramework/AudioPipeline/TimeSampleBufferReader.cpp
@@ -333,6 +346,7 @@ file(GLOB MAIN_SOURCES
     Source/CommonFramework/Panels/SettingsPanelWidget.h
     Source/CommonFramework/PersistentSettings.cpp
     Source/CommonFramework/PersistentSettings.h
+    Source/CommonFramework/Tools/AudioFeed.h
     Source/CommonFramework/Tools/BotBaseHandle.cpp
     Source/CommonFramework/Tools/BotBaseHandle.h
     Source/CommonFramework/Tools/BlackBorderCheck.cpp

--- a/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioConstants.h
+++ b/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioConstants.h
@@ -1,0 +1,19 @@
+/*  Audio Constants
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_AudioConstants_H
+#define PokemonAutomation_AudioConstants_H
+
+const int AUDIO_SAMPLE_RATE = 44000;
+
+const int FFT_LENGTH_POWER_OF_TWO = 14;
+
+const int NUM_FFT_SAMPLES = 1 << FFT_LENGTH_POWER_OF_TWO;
+const int NUM_FFT_WINDOWS = 20;
+const int FFT_SLIDING_WINDOW_STEP = NUM_FFT_SAMPLES/4;
+
+
+#endif

--- a/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioDisplayWidget.cpp
+++ b/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioDisplayWidget.cpp
@@ -1,0 +1,278 @@
+/*  Audio Display Widget
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "AudioDisplayWidget.h"
+#include "AudioInfo.h"
+#include "AudioThreadController.h"
+#include "CommonFramework/Logging/Logger.h"
+#include "Kernels/AbsFFT/Kernels_AbsFFT.h"
+
+#include <QVBoxLayout>
+#include <QLabel>
+#include <QLinearGradient>
+#include <QResizeEvent>
+#include <QPaintEvent>
+#include <QPainter>
+#include <QColor>
+#include <QIODevice>
+#include <QBuffer>
+
+#include <iostream>
+#include <cfloat>
+
+#ifdef USE_FFTREAL
+#include <fftreal_wrapper.h>
+#else
+const int FFTLengthPowerOfTwo = 14;
+#endif
+
+const int NUM_FFT_SAMPLES = 1 << FFTLengthPowerOfTwo;
+
+namespace PokemonAutomation{
+
+
+AudioDisplayWidget::AudioDisplayWidget(QWidget& parent)
+     : QWidget(&parent)
+     , m_numFreqs(NUM_FFT_SAMPLES/2)
+     , m_numFreqWindows(80)
+     , m_numFreqVisBlocks(32)
+     , m_freqVisBlocks(m_numFreqVisBlocks * m_numFreqWindows){}
+
+AudioDisplayWidget::~AudioDisplayWidget(){ clear(); }
+
+void AudioDisplayWidget::clear(){
+    if (m_audioThreadController){
+        delete m_audioThreadController;
+        m_audioThreadController = nullptr;
+    }
+
+    m_freqVisBlocks.assign(m_freqVisBlocks.size(), 0.f);
+    m_spectrums.clear();
+}
+
+void AudioDisplayWidget::close_audio(){
+    clear();
+
+    update_size();
+}
+
+void AudioDisplayWidget::set_audio(Logger& logger, const AudioInfo& inputInfo, const AudioInfo& outputInfo){
+    clear();
+
+    m_audioThreadController = new AudioThreadController(this, inputInfo, outputInfo);
+
+    update_size();
+}
+
+void AudioDisplayWidget::loadFFTOutput(const QVector<float>& fftOutput){
+    // std::cout << "T" << QThread::currentThread() << " AudioDisplayWidget::loadFFTOutput() called" << std::endl;
+
+    auto spectrum = std::make_shared<AudioSpectrum>(0, std::vector<float>(fftOutput.begin(), fftOutput.end()));
+    {
+        std::lock_guard<std::mutex> lock_gd(m_spectrums_lock);
+        spectrum->stamp = (m_spectrums.size() > 0) ? m_spectrums.back()->stamp + 1 : 0;
+        m_spectrums.push_front(spectrum);
+        if (m_spectrums.size() > m_spectrum_history_length){
+            m_spectrums.pop_back();
+        }
+    }
+
+    // For one window, use how many blocks to show all frequencies:
+    const size_t numFreqPerBlock = m_numFreqs / m_numFreqVisBlocks;
+    for(int i = 0; i < m_numFreqVisBlocks; i++){
+        float mag = 0.0f;
+        for(int j = 0; j < numFreqPerBlock; j++){
+            mag += fftOutput[i*numFreqPerBlock + j];
+        }
+        mag /= numFreqPerBlock;
+        mag = std::log(mag * 10.0f + 1.0f);
+        // TODO: may need to scale based on game audio volume setting
+        // Assuming the max freq magnitude we can get is 20.0, so
+        // log(20 * 10 + 1.0) = log(201)
+        const float max_log = std::log(201.f);
+        mag /= max_log;
+        // Clamp to [0.0, 1.0]
+        mag = std::min(mag, 1.0f);
+        mag = std::max(mag, 0.0f);
+        m_freqVisBlocks[m_nextFFTWindowIndex*m_numFreqVisBlocks + i] = mag;
+    }
+    m_nextFFTWindowIndex = (m_nextFFTWindowIndex+1) % m_numFreqWindows;
+    // std::cout << "Computed FFT! "  << magSum << std::endl;
+
+    // Tell Qt to repaint the widget in the next drawing phase in the main loop.
+    QWidget::update();
+
+    if (m_saveFreqToDisk){
+        for(int i = 0; i < m_numFreqs; i++){
+            m_freqStream << fftOutput[i] << " ";
+        }
+        m_freqStream << std::endl;
+    }
+}
+
+// TODO: move this to a common lib folder:
+QColor jetColorMap(float v){
+    if (v <= 0.f){
+        return QColor(0,0,0);
+    }
+    else if (v < 0.125f){
+        return QColor(0, 0, int((0.5f + 4.f * v) * 255.f));
+    }
+    else if (v < 0.375f){
+        return QColor(0, int((v - 0.125f)*1020.f), 255);
+    }
+    else if (v < 0.625f){
+        int c = int((v - 0.375f) * 1020.f);
+        return QColor(c, 255, 255-c);
+    }
+    else if (v < 0.875f){
+        return QColor(255, 255 - int((v-0.625f) * 1020.f), 0);
+    }
+    else if (v <= 1.0){
+        return QColor(255 - int((v-0.875)*1020.f), 0, 0);
+    }
+    else {
+        return QColor(255, 255, 255);
+    }
+}
+
+void AudioDisplayWidget::paintEvent(QPaintEvent* event){
+    QWidget::paintEvent(event);
+
+    QPainter painter(this);
+    painter.fillRect(rect(), Qt::black);
+
+    const int widgetWidth = this->width();
+    const int widgetHeight = this->height();
+    // num frequency bars
+    // -1 here because we don't show the freq-0 bar
+    const size_t numBars = m_numFreqVisBlocks-1;
+
+    switch (m_audioDisplayType){
+    case AudioDisplayType::FREQ_BARS:
+    {
+        const int barPlusGapWidth = widgetWidth / numBars;
+        const int barWidth = 0.8 * barPlusGapWidth;
+        const int gapWidth = barPlusGapWidth - barWidth;
+        const int paddingWidth = widgetWidth - numBars * (barWidth + gapWidth);
+        const int leftPaddingWidth = (paddingWidth + gapWidth) / 2;
+        const int barHeight = widgetHeight - 2 * gapWidth;
+
+        for (int i = 0; i < numBars; i++){
+            size_t curWindow = (m_nextFFTWindowIndex + m_numFreqWindows - 1) % m_numFreqWindows;
+            // +1 here to skip the freq-0 value
+            float value = m_freqVisBlocks[curWindow * m_numFreqVisBlocks + i+1];
+            QRect bar = rect();
+            bar.setLeft(rect().left() + leftPaddingWidth + (i * (gapWidth + barWidth)));
+            bar.setWidth(barWidth);
+            bar.setTop(rect().top() + gapWidth + (1.0 - value) * barHeight);
+            bar.setBottom(rect().bottom() - gapWidth);
+
+            painter.fillRect(bar, jetColorMap(value));
+        }
+        break;
+    }
+    case AudioDisplayType::SPECTROGRAM:
+    {
+        const int barHeight = widgetHeight / numBars;
+        const int barWidth = widgetWidth;
+        for (int i = 0; i < numBars; i++){
+            QLinearGradient colorGradient(0,barHeight/2,widgetWidth, barHeight/2);
+            colorGradient.setSpread(QGradient::PadSpread);
+            for(int j = 0; j < m_numFreqWindows; j++){
+                // Start with the oldest window in time:
+                size_t curWindow = (m_nextFFTWindowIndex + m_numFreqWindows + j) % m_numFreqWindows;
+                // +1 here to skip the freq-0 value
+                float value = m_freqVisBlocks[curWindow * m_numFreqVisBlocks + i+1];
+
+                float pos = (float)j/(m_numFreqWindows - 1);
+                colorGradient.setColorAt(pos, jetColorMap(value));
+            }
+
+            QRect bar = rect();
+            bar.setLeft(rect().left());
+            bar.setWidth(barWidth);
+            bar.setTop(rect().top() + i * barHeight);
+            bar.setBottom(rect().top() + (i+1) * barHeight);
+
+            painter.fillRect(bar, QBrush(colorGradient));
+        }
+    }
+    default:
+        break;
+    }
+}
+
+void AudioDisplayWidget::setAudioDisplayType(AudioDisplayType type){
+    m_audioDisplayType = type;
+    update_size();
+}
+
+void AudioDisplayWidget::update_size(){
+    int height = m_audioDisplayType == AudioDisplayType::NO_DISPLAY ? 0 : this->width() / 6;
+    this->setFixedHeight(height);
+}
+
+void AudioDisplayWidget::resizeEvent(QResizeEvent* event){
+    QWidget::resizeEvent(event);
+    // std::cout << "Audio widget size: " << this->width() << " x " << this->height() << std::endl;
+
+    int width = this->width();
+
+    //  Safeguard against a resizing loop where the UI bounces between larger
+    //  height with scroll bar and lower height with no scroll bar.
+    auto iter = m_recent_widths.find(width);
+    if (iter != m_recent_widths.end() && std::abs(width - event->oldSize().width()) < 50){
+//        cout << "Supressing potential infinite resizing loop." << endl;
+        return;
+    }
+
+    m_width_history.push_back(width);
+    m_recent_widths.insert(width);
+    if (m_width_history.size() > 10){
+        m_recent_widths.erase(m_width_history[0]);
+        m_width_history.pop_front();
+    }
+
+    update_size();
+}
+
+
+void AudioDisplayWidget::spectrums_since(size_t startingStamp, std::vector<std::shared_ptr<AudioSpectrum>>& spectrums){
+    for(const auto& ptr : m_spectrums){
+        if (ptr->stamp >= startingStamp){
+            spectrums.push_back(ptr);
+        } else{
+            break;
+        }
+    }
+}
+
+void AudioDisplayWidget::spectrums_latest(size_t numLatestSpectrums, std::vector<std::shared_ptr<AudioSpectrum>>& spectrums){
+    size_t i = 0;
+    for(const auto& ptr : m_spectrums){
+        if (i == numLatestSpectrums){
+            break;
+        }
+        spectrums.push_back(ptr);
+        i++;
+    }
+}
+
+
+void AudioDisplayWidget::saveAudioFrequenciesToDisk(bool enable){
+    if (enable){
+        if (m_saveFreqToDisk == false){
+            m_saveFreqToDisk = enable;
+            m_freqStream.open("./frequencies.txt");
+        }
+    } else if (m_saveFreqToDisk){
+        m_saveFreqToDisk = enable;
+        m_freqStream.close();
+    }
+}
+
+}

--- a/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioDisplayWidget.h
+++ b/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioDisplayWidget.h
@@ -1,0 +1,135 @@
+/*  Audio Display Widget
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_AudioDisplayWidget_H
+#define PokemonAutomation_AudioDisplayWidget_H
+
+#include <QWidget>
+#include <QThread>
+#include <deque>
+#include <set>
+#include <list>
+#include <fstream>
+#include <memory>
+#include <QAudioFormat>
+
+#include "AudioSelector.h"
+#include "CommonFramework/Tools/AudioFeed.h"
+
+class QBuffer;
+
+#include <QtGlobal>
+
+#if QT_VERSION_MAJOR == 5
+#include <QAudioDeviceInfo>
+class QAudioInput;
+class QAudioOutput;
+#elif QT_VERSION_MAJOR == 6
+#include <QAudioDevice>
+class QAudioSource;
+class QAudioSink;
+#endif
+
+namespace PokemonAutomation{
+
+class AudioThreadController;
+
+class AudioIODevice;
+class AudioInfo;
+class Logger;
+
+// Display audio on the UI panel.
+// This class will use AudioThreadController to control an audio thread doing the
+// work of receiving audio streams from the capture card and playing it on the computer.
+// The controller will also launch an FFT thread to do FFT computations on the audio
+// stream and the resulting frequencies and the spectrogram can be visualized by this
+// audio display widget class.
+// The control of the audio, like which input and output audio device and which
+// audio display mode to use, is made by AudioSelectorWidget.
+// AudioSelectorWidget owns a reference of this class, and control this class based
+// on the audio configuration the selector widget manages.
+class AudioDisplayWidget : public QWidget{
+    //  Need to define this Q_OBJECT to use Qt's extra features
+    //  like signals and slots on this class.
+    Q_OBJECT
+
+public:
+    using AudioDisplayType = AudioSelector::AudioDisplayType;
+
+    AudioDisplayWidget(QWidget& parent);
+    virtual ~AudioDisplayWidget();
+
+    void set_audio(Logger& logger, const AudioInfo& inputInfo, const AudioInfo& outputInfo);
+
+    void close_audio();
+
+    void resizeEvent(QResizeEvent* event) override;
+
+    void paintEvent(QPaintEvent* event) override;
+
+    // Set audio display type: no display, frequency bars or spectrogram.
+    void setAudioDisplayType(AudioDisplayType type);
+
+    void spectrums_since(size_t startingStamp, std::vector<std::shared_ptr<AudioSpectrum>>& spectrums);
+
+    void spectrums_latest(size_t numLatestSpectrums, std::vector<std::shared_ptr<AudioSpectrum>>& spectrums);
+
+    // Development usage: save the FFT results to disk so that it can be examined
+    // and edited to be used as samples for future audio matching.
+    void saveAudioFrequenciesToDisk(bool enable);
+
+public slots:
+    // The audio thread (managed by m_audioThreadController) send signal
+    // to this slot to pass FFT outputs to the display.
+    void loadFFTOutput(const QVector<float>& fftOutput);
+
+private:
+    void update_size();
+
+    void clear();
+
+private:
+
+    AudioThreadController* m_audioThreadController = nullptr;
+
+    // Num frequencies to store for the output of one fft computation.
+    size_t m_numFreqs = 0;
+    // Num sliding fft windows to visualize.
+    size_t m_numFreqWindows = 0;
+    // Num blocks of frequencies to visualize for one sliding window.
+    size_t m_numFreqVisBlocks = 0;
+    // Group nearby frequencies into blocks.
+    // Each block uses the log scaled averaged magnitude of the frequencies.
+    // stores those blocks together for visualization.
+    std::vector<float> m_freqVisBlocks;
+    // The index of the next window in m_freqVisBlocks.
+    size_t m_nextFFTWindowIndex = 0;
+
+    std::deque<int> m_width_history;
+    std::set<int> m_recent_widths;
+
+    AudioDisplayType m_audioDisplayType = AudioDisplayType::NO_DISPLAY;
+
+    // record the past FFT output frequencies to serve as the interface
+    // of audio inference for automation programs.
+    // The head of the list is the most recent FFT window, while the tail
+    // is the oldest in history.
+    std::list<std::shared_ptr<AudioSpectrum>> m_spectrums;
+    size_t m_spectrum_history_length = 10;
+    // Since the spectrums will be probided to the automation programs in
+    // other threads, we need to have a lock here.
+    std::mutex m_spectrums_lock;
+
+    // Develop purpose: used to save received frequencies to disk
+    bool m_saveFreqToDisk = false;
+    std::ofstream m_freqStream;
+};
+
+
+
+
+}
+#endif

--- a/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioInfo.h
+++ b/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioInfo.h
@@ -1,0 +1,38 @@
+/*  Audio Input Device Info
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_AudioInfo_H
+#define PokemonAutomation_AudioInfo_H
+
+#include <string>
+
+namespace PokemonAutomation{
+
+
+class AudioInfo{
+public:
+    AudioInfo() = default;
+    explicit AudioInfo(std::string device_name)
+        : m_device_name(std::move(device_name))
+    {}
+
+    operator bool() const{ return !m_device_name.empty(); }
+
+    //  Unique device identifier.
+    const std::string& device_name() const{ return m_device_name; }
+
+    bool operator==(const AudioInfo& info){
+        return m_device_name == info.m_device_name;
+    }
+
+private:
+    std::string m_device_name;
+};
+
+
+
+}
+#endif

--- a/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioSelector.cpp
+++ b/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioSelector.cpp
@@ -1,0 +1,77 @@
+/*  Audio Selector
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include <QJsonArray>
+#include <QJsonObject>
+#include "Common/Compiler.h"
+#include "Common/Qt/QtJsonTools.h"
+#include "AudioSelector.h"
+#include "AudioSelectorWidget.h"
+
+namespace PokemonAutomation{
+
+
+const QString AudioSelector::JSON_INPUT_DEVICE = "InputDevice";
+const QString AudioSelector::JSON_OUTPUT_DEVICE = "OutputDevice";
+const QString AudioSelector::JSON_AUDIO_VIS = "AudioVisualization";
+
+AudioSelector::AudioDisplayType AudioSelector::stringToAudioDisplayType(const std::string& value){
+    if (value == "FREQ_BARS"){
+        return AudioDisplayType::FREQ_BARS;
+    } else if (value == "SPECTROGRAM"){
+        return AudioDisplayType::SPECTROGRAM;
+    }
+    return AudioDisplayType::NO_DISPLAY;
+}
+
+std::string AudioSelector::audioDisplayTypeToString(AudioSelector::AudioDisplayType type){
+    switch(type){
+        case AudioDisplayType::FREQ_BARS:
+            return "FREQ_BARS";
+        case AudioDisplayType::SPECTROGRAM:
+            return "SPECTROGRAM";
+        case AudioDisplayType::NO_DISPLAY:
+        default:
+            return "NO_DISPLAY";
+    }
+}
+
+AudioSelector::AudioSelector() {}
+AudioSelector::AudioSelector(const QJsonValue& json)
+{
+    load_json(json);
+}
+
+void AudioSelector::load_json(const QJsonValue& json){
+    QJsonObject obj = json.toObject();
+    QString name;
+    if (json_get_string(name, obj, JSON_INPUT_DEVICE)){
+        m_inputDevice = AudioInfo(name.toStdString());
+    }
+    if (json_get_string(name, obj, JSON_OUTPUT_DEVICE)){
+        m_outputDevice = AudioInfo(name.toStdString());
+    }
+    if (json_get_string(name, obj, JSON_AUDIO_VIS)){
+        m_audioDisplayType = stringToAudioDisplayType(name.toStdString());
+    }
+}
+
+QJsonValue AudioSelector::to_json() const{
+    QJsonObject root;
+    root.insert(JSON_INPUT_DEVICE, QString::fromStdString(m_inputDevice.device_name()));
+    root.insert(JSON_OUTPUT_DEVICE, QString::fromStdString(m_outputDevice.device_name()));
+    root.insert(JSON_AUDIO_VIS, QString::fromStdString(audioDisplayTypeToString(m_audioDisplayType)));
+    return root;
+}
+
+AudioSelectorWidget* AudioSelector::make_ui(QWidget& parent, Logger& logger, AudioDisplayWidget& holder){
+    return new AudioSelectorWidget(parent, logger, *this, holder);
+}
+
+
+
+
+}

--- a/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioSelector.h
+++ b/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioSelector.h
@@ -1,0 +1,62 @@
+/*  Audio Input Device Selector
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_AudioSelector_H
+#define PokemonAutomation_AudioSelector_H
+
+#include "CommonFramework/Logging/Logger.h"
+#include "AudioInfo.h"
+
+class QJsonValue;
+class QWidget;
+
+namespace PokemonAutomation{
+
+class AudioDisplayWidget;
+
+
+class AudioSelectorWidget;
+
+// Handles the state of audio: the audio source.
+// Call make_ui() to generate the UI friend class AudioSelectorWidget,
+// which directly modifies AudioSelector's internal state.
+// This separates state from UI.
+// TODO: if needed, can add state of FFT parameters (FFT length, sliding
+// window step, etc.) here.
+class AudioSelector{
+    static const QString JSON_INPUT_DEVICE;
+    static const QString JSON_OUTPUT_DEVICE;
+    static const QString JSON_AUDIO_VIS;
+
+public:
+    enum class AudioDisplayType{
+        NO_DISPLAY,
+        FREQ_BARS,
+        SPECTROGRAM
+    };
+    static AudioDisplayType stringToAudioDisplayType(const std::string& value);
+    static std::string audioDisplayTypeToString(AudioDisplayType type);
+
+    AudioSelector();
+    AudioSelector(const QJsonValue& json);
+
+    void load_json(const QJsonValue& json);
+    QJsonValue to_json() const;
+
+    AudioSelectorWidget* make_ui(QWidget& parent, Logger& logger, AudioDisplayWidget& holder);
+
+private:
+    friend class AudioSelectorWidget;
+    AudioInfo m_inputDevice, m_outputDevice;
+    AudioDisplayType m_audioDisplayType = AudioDisplayType::NO_DISPLAY;
+};
+
+
+
+
+
+}
+#endif

--- a/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioSelectorWidget.cpp
+++ b/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioSelectorWidget.cpp
@@ -1,0 +1,269 @@
+/*  Audio Selector Widget
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QComboBox>
+#include <QPushButton>
+#include "Common/Qt/NoWheelComboBox.h"
+#include "AudioDisplayWidget.h"
+#include "AudioSelectorWidget.h"
+#include "CommonFramework/GlobalSettingsPanel.h"
+
+#if QT_VERSION_MAJOR == 5
+#include <QAudioDeviceInfo>
+#elif QT_VERSION_MAJOR == 6
+#include <QMediaDevices>
+#include <QAudioDevice>
+#endif
+
+#include <iostream>
+#include <tuple>
+
+namespace PokemonAutomation{
+
+// Get all system audio input devices and their human readable descriptions.
+std::tuple<std::vector<AudioInfo>, std::vector<QString>> get_all_audio_inputs(){
+    std::tuple<std::vector<AudioInfo>, std::vector<QString>> ret;
+#if QT_VERSION_MAJOR == 5
+    const auto audioInfos = QAudioDeviceInfo::availableDevices(QAudio::AudioInput);
+    for (const auto &audioInfo : audioInfos){
+        std::get<0>(ret).emplace_back(audioInfo.deviceName().toStdString());
+        std::get<1>(ret).emplace_back(audioInfo.deviceName());
+    }
+#elif QT_VERSION_MAJOR == 6
+    const auto audioInfos = QMediaDevices::audioInputs();
+    for (const auto &audioInfo : audioInfos){
+        std::get<0>(ret).emplace_back(audioInfo.id().toStdString());
+        std::get<1>(ret).emplace_back(audioInfo.description());
+    }
+#endif
+
+    return ret;
+}
+
+// Get all system audio output devices and their human readable descriptions.
+std::tuple<std::vector<AudioInfo>, std::vector<QString>> get_all_audio_outputs(){
+    std::tuple<std::vector<AudioInfo>, std::vector<QString>> ret;
+#if QT_VERSION_MAJOR == 5
+    const auto audioInfos = QAudioDeviceInfo::availableDevices(QAudio::AudioOutput);
+    for (const auto &audioInfo : audioInfos){
+        std::get<0>(ret).emplace_back(audioInfo.deviceName().toStdString());
+        std::get<1>(ret).emplace_back(audioInfo.deviceName());
+    }
+#elif QT_VERSION_MAJOR == 6
+    const auto audioInfos = QMediaDevices::audioOutputs();
+    for (const auto &audioInfo : audioInfos){
+        std::get<0>(ret).emplace_back(audioInfo.id().toStdString());
+        std::get<1>(ret).emplace_back(audioInfo.description());
+    }
+#endif
+
+    return ret;
+}
+
+AudioSelectorWidget::~AudioSelectorWidget(){}
+
+AudioSelectorWidget::AudioSelectorWidget(
+    QWidget& parent,
+    Logger& logger,
+    AudioSelector& value,
+    AudioDisplayWidget& holder
+)
+    : QWidget(&parent)
+    , m_logger(logger)
+    , m_value(value)
+    , m_display(holder)
+{
+    QHBoxLayout* audio_row = new QHBoxLayout(this);
+    audio_row->setContentsMargins(0, 0, 0, 0);
+
+    audio_row->addWidget(new QLabel("<b>Audio Input:</b>", this), 1);
+    audio_row->addSpacing(5);
+
+    m_audio_input_box = new NoWheelComboBox(this);
+    audio_row->addWidget(m_audio_input_box, 5);
+    audio_row->addSpacing(5);
+
+    audio_row->addWidget(new QLabel("<b>Audio Output:</b>", this), 1);
+    m_audio_output_box = new NoWheelComboBox(this);
+    audio_row->addWidget(m_audio_output_box, 5);
+    audio_row->addSpacing(5);
+
+    m_audio_vis_box = new NoWheelComboBox(this);
+    audio_row->addWidget(m_audio_vis_box, 5);
+    audio_row->addSpacing(5);
+    m_audio_vis_box->addItem("No Audio Display");
+    m_audio_vis_box->addItem("Frequency Bars");
+    m_audio_vis_box->addItem("Spectrogram");
+
+    refresh();
+
+    m_reset_button = new QPushButton("Reset Audio", this);
+    audio_row->addWidget(m_reset_button, 1);
+
+    connect(
+        m_audio_input_box, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+        this, [=](int index){
+            AudioInfo& current = m_value.m_inputDevice;
+            if (index <= 0 || index > (int)m_input_audios.size()){
+                current = AudioInfo();
+            }else{
+                const AudioInfo& audio = m_input_audios[index - 1];
+                if (current == audio){
+                    return;
+                }
+                current = audio;
+            }
+            reset_audio();
+        }
+    );
+    connect(
+        m_audio_output_box, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+        this, [=](int index){
+            AudioInfo& current = m_value.m_outputDevice;
+            if (index <= 0 || index > (int)m_output_audios.size()){
+                current = AudioInfo();
+            }else{
+                const AudioInfo& audio = m_output_audios[index - 1];
+                if (current == audio){
+                    return;
+                }
+                current = audio;
+            }
+            reset_audio();
+        }
+    );
+    connect(
+        m_reset_button, &QPushButton::clicked,
+        this, [=](bool){
+            reset_audio();
+        }
+    );
+    connect(
+        this, &AudioSelectorWidget::internal_async_reset_audio,
+        this, [=]{
+            reset_audio();
+        }
+    );
+    connect(
+        m_audio_vis_box, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+        this, [=](int index){
+            switch(index){
+                case 0:
+                    m_value.m_audioDisplayType = AudioSelector::AudioDisplayType::NO_DISPLAY;
+                    break;
+                case 1:
+                    m_value.m_audioDisplayType = AudioSelector::AudioDisplayType::FREQ_BARS;
+                    break;
+                case 2:
+                    m_value.m_audioDisplayType = AudioSelector::AudioDisplayType::SPECTROGRAM;
+                    break;
+                default:
+                    m_value.m_audioDisplayType = AudioSelector::AudioDisplayType::NO_DISPLAY;
+            }
+            m_display.setAudioDisplayType(m_value.m_audioDisplayType);
+        }
+    );
+
+    // only in developer mode:
+    // record audio
+    if (GlobalSettings::instance().DEVELOPER_MODE){
+        m_record_button = new QPushButton("Record Frequencies", this);
+        audio_row->addWidget(m_record_button, 1);
+
+        connect(m_record_button, &QPushButton::clicked, this, [=](bool){
+            m_record_is_on = !m_record_is_on;
+            m_display.saveAudioFrequenciesToDisk(m_record_is_on);
+            if (m_record_is_on){
+                m_record_button->setText("Stop recording");
+            } else{
+                m_record_button->setText("Record Frequencies");
+            }
+        });
+    }
+}
+void AudioSelectorWidget::refresh(){
+
+    auto build_device_menu = [](
+            QComboBox* box,
+            const std::vector<AudioInfo>& audios,
+            const std::vector<QString>& descriptions,
+            AudioInfo& current_device){
+        
+        box->clear();
+        box->addItem("(none)");
+
+        size_t index = 0;
+        for (size_t c = 0; c < audios.size(); c++){
+            const AudioInfo& audio = audios[c];
+            box->addItem(descriptions[c]);
+
+            if (current_device == audio){
+                index = c + 1;
+            }
+        }
+        if (index != 0){
+            box->setCurrentIndex((int)index);
+        }else{
+            current_device = AudioInfo();
+            box->setCurrentIndex(0);
+        }
+    };
+
+    std::vector<QString> descriptions;
+    std::tie(m_input_audios, descriptions) = get_all_audio_inputs();
+    build_device_menu(m_audio_input_box, m_input_audios, descriptions, m_value.m_inputDevice);
+
+    std::tie(m_output_audios, descriptions) = get_all_audio_outputs();
+    build_device_menu(m_audio_output_box, m_output_audios, descriptions, m_value.m_outputDevice);
+
+    // std::cout << "Refresh: " << AudioSelector::audioDisplayTypeToString(m_value.m_audioDisplayType) << std::endl;
+    switch(m_value.m_audioDisplayType){
+        case AudioSelector::AudioDisplayType::NO_DISPLAY:
+            m_audio_vis_box->setCurrentIndex(0);
+            break;
+        case AudioSelector::AudioDisplayType::FREQ_BARS:
+            m_audio_vis_box->setCurrentIndex(1);
+            break;
+        case AudioSelector::AudioDisplayType::SPECTROGRAM:
+            m_audio_vis_box->setCurrentIndex(2);
+            break;
+        default:
+            m_audio_vis_box->setCurrentIndex(0);
+    }
+    m_display.setAudioDisplayType(m_value.m_audioDisplayType);
+}
+
+void AudioSelectorWidget::reset_audio(){
+    std::lock_guard<std::mutex> lg(m_audio_lock);
+    m_display.close_audio();
+
+    const AudioInfo& info = m_value.m_inputDevice;
+    if (info){
+        m_display.set_audio(m_logger, info, m_value.m_outputDevice);
+    }
+}
+void AudioSelectorWidget::async_reset_audio(){
+    emit internal_async_reset_audio();
+}
+
+
+void AudioSelectorWidget::spectrums_since(size_t startingStamp, std::vector<std::shared_ptr<AudioSpectrum>>& spectrums){
+    m_display.spectrums_since(startingStamp, spectrums);
+}
+
+void AudioSelectorWidget::spectrums_latest(size_t numLatestSpectrums, std::vector<std::shared_ptr<AudioSpectrum>>& spectrums){
+    m_display.spectrums_latest(numLatestSpectrums, spectrums);
+}
+
+void AudioSelectorWidget::set_audio_enabled(bool enabled){
+    m_audio_input_box->setEnabled(enabled);
+}
+
+
+
+}

--- a/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioSelectorWidget.h
+++ b/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioSelectorWidget.h
@@ -1,0 +1,84 @@
+/*  Audio Selector Widget
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_AudioSelectorWidget_H
+#define PokemonAutomation_AudioSelectorWidget_H
+
+#include <vector>
+#include <atomic>
+#include <mutex>
+#include <QWidget>
+#include "CommonFramework/Tools/AudioFeed.h"
+#include "AudioSelector.h"
+
+class QComboBox;
+class QPushButton;
+
+namespace PokemonAutomation{
+
+class AudioDisplayWidget;
+
+//  Widget to handle UI that selects audio source.
+//  The audio state is managed by a class AudioSelector object passed in
+//  the constructor.
+//  AudioSelectorWidget is also responsible for updating AudioDisplayWidget,
+//  the UI that visualizes audio, when the audio source is changed. The
+//  AudioDisplayWidget is passed in the constructor too.
+class AudioSelectorWidget : public QWidget, public AudioFeed{
+    //  Need to define this Q_OBJECT to use Qt's extra features
+    //  like signals and slots on this class.
+    Q_OBJECT
+public:
+    AudioSelectorWidget(
+        QWidget& parent,
+        Logger& logger,
+        AudioSelector& value,
+        AudioDisplayWidget& holder
+    );
+    ~AudioSelectorWidget();
+
+    void set_audio_enabled(bool enabled);
+
+    void reset_audio();
+
+    //  Inplement AudioFeed::async_reset_audio().
+    //  Can be called from any thread.
+    virtual void async_reset_audio() override;
+
+    virtual void spectrums_since(size_t startingStamp, std::vector<std::shared_ptr<AudioSpectrum>>& spectrums) override;
+
+    virtual void spectrums_latest(size_t numLatestSpectrums, std::vector<std::shared_ptr<AudioSpectrum>>& spectrums) override;
+
+signals:
+    // Need to define this version of async_reset_audio()
+    // because it will be used as a signal.
+    void internal_async_reset_audio();
+
+private:
+    void refresh();
+
+private:
+    Logger& m_logger;
+    AudioSelector& m_value;
+
+    AudioDisplayWidget& m_display;
+
+    QComboBox* m_audio_input_box = nullptr;
+    QComboBox* m_audio_output_box = nullptr;
+    QComboBox* m_audio_vis_box = nullptr;
+    QPushButton* m_reset_button = nullptr;
+    QPushButton* m_record_button = nullptr;
+    bool m_record_is_on = false;
+
+    std::vector<AudioInfo> m_input_audios;
+    std::vector<AudioInfo> m_output_audios;
+
+    std::mutex m_audio_lock;
+};
+
+
+}
+#endif

--- a/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioThreadController.cpp
+++ b/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioThreadController.cpp
@@ -1,0 +1,79 @@
+/*  Audio Thread Controller
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "AudioConstants.h"
+#include "AudioDisplayWidget.h"
+#include "AudioInfo.h"
+#include "AudioWorker.h"
+#include "AudioThreadController.h"
+#include "FFTWorker.h"
+#include "CommonFramework/Logging/Logger.h"
+
+#include <QIODevice>
+#include <QThread>
+
+#include <iostream>
+
+namespace PokemonAutomation{
+
+
+AudioThreadController::AudioThreadController(AudioDisplayWidget* parent, const AudioInfo& inputInfo, const AudioInfo& outputInfo){
+    QObject::setParent(parent);
+
+    // std::cout << "Controller thread " << QThread::currentThread() << std::endl;
+
+    // Note: there is no audio initialization work in AudioWorker constructor. This is intended.
+    // Starting the audio will register internal QT audio code to the current thread. If the QT audio
+    // classes are started AudioWorker constructor, they are registered to the main UI thread,
+    // causing problems when it's moved to and run in m_audioThread.
+    // So AudioWorker constructor is very light. The work to initialize and start audio processing
+    // is done in AudioWorker::startAudio(). It will be called using a signal AudioThreadController::operate()
+    // which is sent after the worker thread starts.
+    m_AudioWorker = new AudioWorker(inputInfo, outputInfo);
+    m_AudioWorker->moveToThread(&m_audioThread);
+    connect(&m_audioThread, &QThread::finished, m_AudioWorker, &QObject::deleteLater);
+
+    // Connect this controller to the audio worker to start the audio initialization on the audio thread.
+    connect(this, &AudioThreadController::operate, m_AudioWorker, &AudioWorker::startAudio);
+
+    m_fftWorker = new FFTWorker(FFT_LENGTH_POWER_OF_TWO);
+    m_fftWorker->moveToThread(&m_fftThread);
+    connect(&m_fftThread, &QThread::finished, m_fftWorker, &QObject::deleteLater);
+
+    // Connect the audio thread and fft thread to pass fft inputs.
+    connect(m_AudioWorker, &AudioWorker::fftInputReady, m_fftWorker, &FFTWorker::computeFFT);
+
+    // Connect fft thread to audio display widget to pass fft outputs.
+    connect(m_fftWorker, &FFTWorker::FFTFinished, parent, &AudioDisplayWidget::loadFFTOutput);
+    
+    m_audioThread.start();
+    m_fftThread.start();
+
+    // Send the signal to start audio processing after the worker thread is started.
+    emit operate();
+}
+
+AudioThreadController::~AudioThreadController(){
+    m_audioThread.quit();
+    m_fftThread.quit();
+
+    m_audioThread.wait();
+    m_fftThread.wait();
+
+    // We shouldn't need to delete AudioWorker here as its deletion is connected to
+    // QThread::finished.
+    // TODO: if this `deleteLater` handlement is not 100% safe, we should send a signal
+    // from the controller to the AudioWorker to let it close the audio pipeline before
+    // the worker thread is stopped.
+
+    // Same goes to FFTWorker.
+}
+
+
+
+
+
+}

--- a/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioThreadController.h
+++ b/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioThreadController.h
@@ -1,0 +1,62 @@
+/*  Audio Thread Controller
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_AudioThreadController_H
+#define PokemonAutomation_AudioThreadController_H
+
+#include <vector>
+#include <chrono>
+#include <QObject>
+#include <QThread>
+
+
+// #define USE_FFTREAL
+
+namespace PokemonAutomation{
+
+class AudioInfo;
+class AudioDisplayWidget;
+class AudioWorker;
+class FFTWorker;
+
+
+// The class is responsible for the audio loop.
+// When this class is constructed, it launches a QThread to run a QT event loop
+// handling audio input and output.
+// The code that runs the actual audio is AudioWorker `m_AudioWorker` defined in
+// "AudioWorker.h". It will be put into a thread `m_audioThread` to run continuously.
+// The controller also launches a QThread to run FFT computataion asynchronously.
+// It connects signals from the audio thread to the FFT thread to pass FFT input
+// in a thread-safe way.
+// It also connects signals from the FFT thread to the audio display widget (passed
+// as `parent` in the constructor) to return the FFT results to the UI thread.
+class AudioThreadController: public QObject{
+    //  Need to define this Q_OBJECT to use Qt's extra features
+    //  like signals and slots on this class.
+    Q_OBJECT
+
+public:
+    AudioThreadController(AudioDisplayWidget* parent, const AudioInfo& inputInfo, const AudioInfo& outputInfo);
+    virtual ~AudioThreadController();
+
+signals:
+    void operate();
+
+private:
+    QThread m_audioThread;
+
+    AudioWorker* m_AudioWorker = nullptr;
+
+    QThread m_fftThread;
+    FFTWorker* m_fftWorker = nullptr;
+
+};
+
+
+
+
+}
+#endif

--- a/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioWorker.cpp
+++ b/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioWorker.cpp
@@ -1,0 +1,475 @@
+/*  Audio Worker
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "AudioConstants.h"
+#include "AudioInfo.h"
+#include "AudioWorker.h"
+#include "CommonFramework/Logging/Logger.h"
+
+#include <QIODevice>
+#include <QThread>
+
+#include <iostream>
+#include <iomanip>
+#include <cfloat>
+#include <chrono>
+#include <memory>
+#include <cassert>
+
+// #define DEBUG_AUDIO_IO
+
+#if QT_VERSION_MAJOR == 5
+#include <QAudioDeviceInfo>
+#include <QAudioInput>
+#include <QAudioOutput>
+#include <QtEndian>
+
+void printAudioFormat(const QAudioFormat& format){
+    std::string sampleTypeStr = "";
+    switch(format.sampleType()){
+        case QAudioFormat::SampleType::Float:
+            sampleTypeStr="Float";
+            break;
+        case QAudioFormat::SampleType::SignedInt:
+            sampleTypeStr="SignedInt";
+            break;
+        case QAudioFormat::SampleType::UnSignedInt:
+            sampleTypeStr="UnSignedInt";
+            break;
+        default:
+            sampleTypeStr="Error";
+    }
+
+    std::cout << "Audio format: sample type " << sampleTypeStr << 
+        ", bytes per sample " << format.bytesPerFrame() / format.channelCount() << 
+        ", num channels " << format.channelCount() << 
+        ", sample rate " << format.sampleRate() << std::endl;
+}
+#elif QT_VERSION_MAJOR == 6
+#include <QMediaDevices>
+#include <QAudioSource>
+#include <QAudioSink>
+#include <QAudioDevice>
+
+void printAudioFormat(const QAudioFormat& format){
+    std::string sampleFormatStr = "";
+    switch(format.sampleFormat()){
+        case QAudioFormat::SampleFormat::Float:
+            sampleFormatStr="Float";
+            break;
+        case QAudioFormat::SampleFormat::Int16:
+            sampleFormatStr="Int16";
+            break;
+        case QAudioFormat::SampleFormat::Int32:
+            sampleFormatStr="Int32";
+            break;
+        case QAudioFormat::SampleFormat::UInt8:
+            sampleFormatStr="UInt8";
+            break;
+        default:
+            sampleFormatStr="Error";
+    }
+
+    std::string channelConfigStr = "";
+    switch(format.channelConfig()){
+        case QAudioFormat::ChannelConfig::ChannelConfigMono:
+            channelConfigStr = "Mono";
+            break;
+        case QAudioFormat::ChannelConfig::ChannelConfigStereo:
+            channelConfigStr = "Stereo";
+            break;
+        case QAudioFormat::ChannelConfig::ChannelConfigUnknown:
+            channelConfigStr = "Error";
+            break;
+        default:
+            channelConfigStr = "Non Mono or Stereo";
+    }
+    std::cout << "Audio format: sample format " << sampleFormatStr << 
+        ", bytes per sample " << format.bytesPerSample() << 
+        ", channel config " << channelConfigStr <<
+        ", num channels " << format.channelCount() << 
+        ", sample rate " << format.sampleRate() << std::endl;
+}
+
+#endif
+
+
+namespace PokemonAutomation{
+
+
+AudioIODevice::AudioIODevice(const QAudioFormat & audioFormat)
+     : QIODevice(nullptr)
+     , m_audioFormat(audioFormat)
+     , m_fftCircularBuffer(NUM_FFT_SAMPLES * 8)
+     , m_fftInputVector(NUM_FFT_SAMPLES) {}
+
+AudioIODevice::~AudioIODevice() {}
+
+qint64 AudioIODevice::writeData(const char* data, qint64 len)
+{
+    const auto& audioFormat = m_audioFormat;
+    // One audio frame consists of one or more channels.
+    // Each channel in the frame has an audio sample that is made by one or
+    // more bytes.
+    const int frameBytes = audioFormat.bytesPerFrame();
+    const int numChannels = audioFormat.channelCount();
+    const int sampleBytes = frameBytes / numChannels;
+    const size_t numSamples = len / frameBytes;
+    const size_t numFrames = len / frameBytes;
+    // We assert the data is always float with size of 4 bytes.
+    const float * floatData = reinterpret_cast<const float *>(data);
+
+    // We assert audio channel count is 1. This has the benefit that we can use memcpy
+    // to pass audio data to the FFT input buffer. The drawback is the user can not hear
+    // stereo sound.
+    // Note: I tried to do stereo sound but it seems QAudioSink somehow still plays it as
+    // mono sound on my machine.
+    if (numChannels != 1){
+        std::cout << "Error: AudioIODevice receives audio format with more than one channel count: "
+            << numChannels << ". We currently only support one channel" << std::endl;
+        return 0;
+    }
+
+    // Pass audio samples to FFT input buffer:
+
+    // numTotalSamplesCopied: how many samples have been copied in the following loop
+    size_t numTotalSamplesCopied = 0;
+    const size_t circularBufferSize = m_fftCircularBuffer.size();
+
+    // while there are still samples not copied from audio source to the fft buffer:
+    while(numTotalSamplesCopied < numSamples){
+
+        // First, let's calculate how many more samples we need to file a FFT.
+        size_t nextFFTNumSamplesNeeded = computeNextFFTSamplesNeeded();
+
+        // Copy as much data as possible from the audio source until either the input samples are
+        // all used or the circular buffer reaches the end.
+        size_t curNumSamplesCopied = std::min((size_t)m_fftCircularBuffer.size() - m_bufferNext, numSamples - numTotalSamplesCopied);
+        memcpy(m_fftCircularBuffer.data() + m_bufferNext, floatData + numTotalSamplesCopied, sizeof(float) * curNumSamplesCopied);
+        
+        // Update m_bufferNext to reflect new data added:
+        m_bufferNext = (m_bufferNext + curNumSamplesCopied) % circularBufferSize;
+        // Update numTotalSamplesCopied to reflect new data copied:
+        numTotalSamplesCopied += curNumSamplesCopied;
+
+        // With new data added, we need to check whether we can file one or more FFTs:
+
+        size_t numNewDataForFFT = curNumSamplesCopied;
+        // While we have enough new data to file an FFT:
+        while(nextFFTNumSamplesNeeded <= numNewDataForFFT){
+            // copy data from m_fftCircularBuffer to m_fftInputVector:
+            moveDataToFFTInputVector();
+            // std::cout << "FFT input copied " << std::endl;
+
+            // emit signal for FFT:
+            emit fftInputReady(m_fftInputVector);
+
+            // Update numNewDataForFFT to account for fft samples consumed:
+            numNewDataForFFT -= nextFFTNumSamplesNeeded;
+            // Initialize nextFFTNumSamplesNeeded for next FFT:
+            nextFFTNumSamplesNeeded = FFT_SLIDING_WINDOW_STEP;
+            // Move m_fftStart forward for next FFT:
+            m_fftStart = (m_fftStart + FFT_SLIDING_WINDOW_STEP) % circularBufferSize;
+        }
+    }
+
+    // Pass audio data to the audio sink for audio playback.
+    if (m_audioSinkDevice){
+        m_audioSinkDevice->write(data, len);
+    }
+
+#ifdef DEBUG_AUDIO_IO
+    std::vector<float> meanChannelVol(numChannels);
+    std::vector<float> minChannelVol(numChannels, FLT_MAX);
+    std::vector<float> maxChannelVol(numChannels, -FLT_MAX);
+    for(int i = 0; i < numFrames; i++){
+        for(int j = 0; j < numChannels; j++){
+            const float v = floatData[i*numChannels+j]
+            meanChannelVol[j] += v;
+            minChannelVol[j] = std::min(minChannelVol[j], v);
+            maxChannelVol[j] = std::max(maxChannelVol[j], v);
+        }
+    }
+    for(int j = 0; j < numChannels; j++){
+        meanChannelVol[j] /= float(numSamples);
+    }
+    auto currentTimepoint = std::chrono::system_clock::now();
+    const auto dur = std::chrono::duration_cast<std::chrono::microseconds>(currentTimepoint-m_lastWriteTimepoint);
+    m_lastWriteTimepoint = currentTimepoint;
+    std::cout << "T" << QThread::currentThread() << " Wrote " << numSamples << " audio frames after " << 
+        dur.count() << " mircoseconds, mean/min/max volume per channel: [";
+    for(int j = 0; j < audioFormat.channelCount(); j++){
+        std::cout << std::setprecision(3) << meanChannelVol[j] << "/" << 
+            std::setprecision(3) << minChannelVol[j] << "/" << 
+            std::setprecision(3) << maxChannelVol[j] << ", ";
+    }
+    std::cout << "]" << std::endl;
+#endif
+    return len;
+}
+
+size_t AudioIODevice::computeNextFFTSamplesNeeded() const{
+    // nextFFTNumSamplesFilled: how many samples already in the buffer to be used for the next FFT:
+    size_t nextFFTNumSamplesFilled = 0;
+    if (m_bufferNext >= m_fftStart){
+        nextFFTNumSamplesFilled = m_bufferNext - m_fftStart;
+    } else{
+        nextFFTNumSamplesFilled = m_bufferNext + m_fftCircularBuffer.size() - m_fftStart;
+    }
+    if (nextFFTNumSamplesFilled >= NUM_FFT_SAMPLES){
+        std::cout << "ERROR: internal buffer error, stored more than enough FFT samples but did not launch FFT "
+            << nextFFTNumSamplesFilled << " " << m_bufferNext << " " << m_fftStart << std::endl;
+    }
+    assert(nextFFTNumSamplesFilled < NUM_FFT_SAMPLES);
+
+    return NUM_FFT_SAMPLES - nextFFTNumSamplesFilled;
+}
+
+void AudioIODevice::moveDataToFFTInputVector(){
+    size_t num = std::min(m_fftCircularBuffer.size() - m_fftStart, (size_t)NUM_FFT_SAMPLES);
+    memcpy(m_fftInputVector.data(), m_fftCircularBuffer.data() + m_fftStart, sizeof(float) * num);
+    if (num < NUM_FFT_SAMPLES){
+        // We reach the end of the circular buffer, start from its beginning to copy the remaining part:
+        memcpy(m_fftInputVector.data() + num, m_fftCircularBuffer.data(), sizeof(float) * (NUM_FFT_SAMPLES - num));
+    }   
+}
+
+AudioWorker::AudioWorker(const AudioInfo& inputInfo, const AudioInfo& outputInfo){
+    m_inputInfo = inputInfo;
+    m_outputInfo = outputInfo;
+}
+
+
+void AudioWorker::startAudio(){
+#ifdef DEBUG_AUDIO_IO
+    std::cout << "T" << QThread::currentThread() << " AudioWorker::startAudio()" << std::endl;
+#endif
+
+    bool foundAudioInputInfo = false;
+    bool foundAudioOutputInfo = false;
+    
+#if QT_VERSION_MAJOR == 5
+    // We need QVector<float> to be able to pass around by signals and slots mechanism to pass
+    // FFT input and output data across threads.
+    // In Qt6 it automatically registers QVector<float>. But in Qt5 we need to manually register
+    // the class.
+    qRegisterMetaType<QVector<float>>("QVector<float>");
+
+    using AudioSource = QAudioInput;
+    using AudioSink = QAudioOutput;
+
+    const auto audioInputs = QAudioDeviceInfo::availableDevices(QAudio::AudioInput);
+    QAudioDeviceInfo chosenAudioInputDevice;
+    for (const auto &audioDevice : audioInputs){
+        if (audioDevice.deviceName().toStdString() == m_inputInfo.device_name()){
+            foundAudioInputInfo = true;
+            chosenAudioInputDevice = audioDevice;
+            break;
+        }
+    }
+    
+    const auto audioOutputs = QAudioDeviceInfo::availableDevices(QAudio::AudioOutput);
+    QAudioDeviceInfo chosenAudioOutputDevice;
+    for (const auto &audioDevice : audioOutputs){
+        if (audioDevice.deviceName().toStdString() == m_outputInfo.device_name()){
+            foundAudioOutputInfo = true;
+            chosenAudioOutputDevice = audioDevice;
+            break;
+        }
+    }
+#elif QT_VERSION_MAJOR == 6
+    using AudioSource = QAudioSource;
+    using AudioSink = QAudioSink;
+
+    const auto audioInputs = QMediaDevices::audioInputs();
+    QAudioDevice chosenAudioInputDevice;
+    for (const auto &audioDevice : audioInputs){
+        if (audioDevice.id().toStdString() == m_inputInfo.device_name()){
+                foundAudioInputInfo = true;
+            chosenAudioInputDevice = audioDevice;
+            break;
+        }
+    }
+
+    const auto audioOutputs = QMediaDevices::audioOutputs();
+    QAudioDevice chosenAudioOutputDevice;
+    for (const auto &audioDevice : audioOutputs){
+        if (audioDevice.id().toStdString() == m_outputInfo.device_name()){
+                foundAudioOutputInfo = true;
+            chosenAudioOutputDevice = audioDevice;
+            break;
+        }
+    }
+#endif
+
+    if (foundAudioInputInfo == false){
+        // std::cout << "Cannot build Qt6VideoWidget: cannot found audio device name matching: " << inputInfo.device_name() << std::endl;
+        return;
+    }
+
+    m_audioFormat = chosenAudioInputDevice.preferredFormat();
+    m_audioFormat.setSampleRate(AUDIO_SAMPLE_RATE);
+#if QT_VERSION_MAJOR == 5
+    m_audioFormat.setChannelCount(1);
+    m_audioFormat.setSampleType(QAudioFormat::SampleType::Float);
+    m_audioFormat.setSampleSize(32);
+#elif QT_VERSION_MAJOR == 6
+    m_audioFormat.setChannelConfig(QAudioFormat::ChannelConfig::ChannelConfigMono);
+    m_audioFormat.setSampleFormat(QAudioFormat::SampleFormat::Float);
+#endif
+    
+    if (!chosenAudioInputDevice.isFormatSupported(m_audioFormat)){
+        std::cout << "Error: audio input device cannot support desired audio format" << std::endl;
+        return;
+    }
+
+    const int bytesPerSample = m_audioFormat.bytesPerFrame() / m_audioFormat.channelCount();
+    if (bytesPerSample != sizeof(float)){
+        std::cout << "Error: audio format is wrong. Set its sample format to float but the bytesPerSample is "
+            << bytesPerSample << ", different from float size " << sizeof(float) << std::endl;
+        return;
+    }
+
+#ifdef DEBUG_AUDIO_IO
+    std::cout << "Audio input format:" << std::endl;
+    printAudioFormat(m_audioFormat);
+#endif
+    
+    m_audioSource = new AudioSource(chosenAudioInputDevice, m_audioFormat, this);
+
+    connect(m_audioSource, &AudioSource::stateChanged, this, [&](QAudio::State newState){
+        // TODO connect logger output to it
+        switch (newState) {
+        case QAudio::StoppedState:
+            switch (m_audioSource->error()) {
+            case QAudio::NoError:
+                std::cout << "AudioSource stopped normally" << std::endl;
+                break;
+            case QAudio::OpenError:
+                std::cout << "AudioSource OpenError" << std::endl;
+                break;
+            case QAudio::IOError:
+                std::cout << "AudioSource IOError" << std::endl;
+                break;
+            case QAudio::UnderrunError:
+                std::cout << "AudioSource UnderrunError" << std::endl;
+                break;
+            case QAudio::FatalError:
+                std::cout << "AudioSource FatalError" << std::endl;
+                break;
+            }
+            break;
+
+        case QAudio::ActiveState:
+            // Started recording - read from IO device
+            // std::cout << "Audio started" << std::endl;
+            break;
+        
+        case QAudio::SuspendedState:
+            std::cout << "AudioSource is suspended" << std::endl;
+            break;
+
+        case QAudio::IdleState:
+            // std::cout << "AudioSource is idle, no input" << std::endl;
+            break;
+#if QT_VERSION_MAJOR == 5
+        case QAudio::InterruptedState:
+            std::cout << "AudioSource is interrupted, no input" << std::endl;
+            break;
+#endif
+        }
+    });
+
+    m_audioIODevice = new AudioIODevice(m_audioFormat);
+    m_audioIODevice->open(QIODevice::ReadWrite | QIODevice::Unbuffered);
+    
+    m_audioSource->start(m_audioIODevice);
+
+    if (foundAudioOutputInfo){
+        bool outputSupported = chosenAudioOutputDevice.isFormatSupported(m_audioFormat);
+        if (!outputSupported){
+            std::cout << "Error the audio output device does not support the audio format used by the audio input device" << std::endl;
+        } else{
+            m_audioSink = new AudioSink(chosenAudioOutputDevice, m_audioFormat, this);
+            m_audioIODevice->setAudioSinkDevice(m_audioSink->start());
+#ifdef DEBUG_AUDIO_IO
+            std::cout << "Audio output format: " << std::endl;
+            printAudioFormat(m_audioSink->format());
+#endif
+            connect(m_audioSink, &AudioSink::stateChanged, this, [&](QAudio::State newState){
+                switch (newState) {
+                case QAudio::StoppedState:
+                    switch (m_audioSource->error()) {
+                    case QAudio::NoError:
+                        std::cout << "AudioSink stopped normally" << std::endl;
+                        break;
+                    case QAudio::OpenError:
+                        std::cout << "AudioSink OpenError" << std::endl;
+                        break;
+                    case QAudio::IOError:
+                        std::cout << "AudioSink IOError" << std::endl;
+                        break;
+                    case QAudio::UnderrunError:
+                        // Underrun error happens when the audio thread is closing.
+                        // std::cout << "AudioSink UnderrunError" << std::endl;
+                        break;
+                    case QAudio::FatalError:
+                        std::cout << "AudioSink FatalError" << std::endl;
+                        break;
+                    }
+                    break;
+
+                case QAudio::ActiveState:
+                    break;
+                
+                case QAudio::SuspendedState:
+                    std::cout << "AudioSink is suspended" << std::endl;
+                    break;
+
+                case QAudio::IdleState:
+                    // std::cout << "Audio is idle, no input" << std::endl;
+                    break;
+#if QT_VERSION_MAJOR == 5
+                case QAudio::InterruptedState:
+                    std::cout << "AudioSink is interrupted, no input" << std::endl;
+                    break;
+#endif
+                }
+            });
+        }
+    }
+
+    connect(m_audioIODevice, &AudioIODevice::fftInputReady, this, &AudioWorker::fftInputReady);
+}
+
+AudioWorker::~AudioWorker(){
+    if (m_audioIODevice){
+        // Close the connection between m_audioIODevice and 
+        // m_audioSink.
+        m_audioIODevice->setAudioSinkDevice(nullptr);
+    }
+
+    if (m_audioSink){
+        m_audioSink->stop();
+        delete m_audioSink;
+
+        m_audioSink = nullptr;
+    }
+
+    if (m_audioSource){
+        m_audioSource->stop();
+        delete m_audioSource;
+        m_audioSource = nullptr;
+    }
+
+    if (m_audioIODevice){
+        delete m_audioIODevice;
+        m_audioIODevice = nullptr;
+    }
+}
+
+
+}

--- a/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioWorker.h
+++ b/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioWorker.h
@@ -1,0 +1,147 @@
+/*  Audio Worker
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_AudioWorker_H
+#define PokemonAutomation_AudioWorker_H
+
+#include <vector>
+#include <chrono>
+#include <QObject>
+#include <QThread>
+#include <QVector>
+#include <QIODevice>
+#include <QAudioFormat>
+#include "Common/Cpp/AlignedVector.h"
+
+
+#if QT_VERSION_MAJOR == 5
+    class QAudioInput;
+    class QAudioOutput;
+#elif QT_VERSION_MAJOR == 6
+    class QAudioSource;
+    class QAudioSink;
+#endif
+
+namespace PokemonAutomation{
+
+class AudioInfo;
+class AudioIODevice;
+
+
+// This is the main Audio IO class, which owns all the audio input/output component.
+// This class will be moved into a QThread, separate from the main Qt UI thread so
+// that audio processing does not block the UI and vice versa.
+// The class, AudioThreadController is responsible for the management of the QThread.
+class AudioWorker: public QObject{
+    //  Need to define this Q_OBJECT to use Qt's extra features
+    //  like signals and slots on this class.
+    Q_OBJECT
+public:
+    AudioWorker(const AudioInfo& inputInfo, const AudioInfo& outputInfo);
+    virtual ~AudioWorker();
+
+    // Initialize all the Qt audio components to start all audio work: read from audio input device,
+    // save audio samples for FFT and pass audio to audio output device.
+    void startAudio();
+
+signals:
+    // We would like to connect signals of FFT input from the audio thread to the FFT thread.
+    // The main work that passes around audio data is in m_audioIODevice. To expose this signal
+    // to AudioThreadController, we have this signal in AudioWorker that serves as relaying the
+    // signal from m_audioIODevice to anywhere that sees this AudioWorker.
+    void fftInputReady(const QVector<float>& fftInput);
+
+private:
+    QAudioFormat m_audioFormat;
+    AudioInfo m_inputInfo;
+    AudioInfo m_outputInfo;
+
+    AudioIODevice* m_audioIODevice = nullptr;
+
+#if QT_VERSION_MAJOR == 5
+    QAudioInput* m_audioSource = nullptr;
+    QAudioOutput* m_audioSink = nullptr;
+#elif QT_VERSION_MAJOR == 6
+    QAudioSource* m_audioSource = nullptr;
+    QAudioSink* m_audioSink = nullptr;
+#endif
+};
+
+
+// QIODevice defines an interface for IO.
+// QAudioSource reads from an audio input device and writes data to a QIODevice.
+// The data is then passed to QAudioSink's internal QIODevice and sends to an audio output device.
+// This class inherits a QIODevice to receive data from QAudioSource and push the data to
+// QAudioSink.
+// When enough audio samples are collected for the next FFT window, this class also emits a signal
+// containing the FFT input samples so that the FFTWorker in the FFT thread can receive it
+// to do FFT asynchronously, without blocking the audio thread.
+class AudioIODevice : public QIODevice
+{
+    //  Need to define this Q_OBJECT to use Qt's extra features
+    //  like signals and slots on this class.
+    Q_OBJECT
+
+public:
+    AudioIODevice(const QAudioFormat& audioFormat);
+    virtual ~AudioIODevice();
+
+    // Called by QAudioSource to write data to AudioIODevice's buffer.
+    // The function also does FFT if enough sample is collected on the next
+    // windows.
+    // if an QAudioSink's internal QIODevice is set via setAudioSinkDevice(),
+    // also pass data to the audio sink.
+    qint64 writeData(const char *data, qint64 len) override;
+
+    qint64 readData(char *data, qint64 maxlen) override { return 0; }
+
+    bool isSequential() const override { return true; }
+
+    void setAudioSinkDevice(QIODevice* audioSinkDevice) { m_audioSinkDevice = audioSinkDevice; }
+
+signals:
+    // Signal filed whenever the FFT input buffer is filled.
+    void fftInputReady(const QVector<float>& fftInput);
+
+private:
+    // how many more samples needed to file the next FFT
+    size_t computeNextFFTSamplesNeeded() const;
+
+    // move audio samples from m_fftCircularBuffer starting at m_fftStart to m_fftInputVector
+    // to ready for next FFT signal.
+    void moveDataToFFTInputVector();
+
+    QAudioFormat m_audioFormat;
+
+    // A large circular buffer to store multiple sliding windows of FFT inputs.
+    // Because FFT windows may overlap, it may be more efficient to store
+    // them in this buffer.
+    std::vector<float> m_fftCircularBuffer;
+
+    // The index on m_fftCircularBuffer where to receive next incoming audio sample.
+    size_t m_bufferNext = 0;
+    
+    // The index on the m_fftCircularBuffer as the next chunk of FFT input.
+    size_t m_fftStart = 0;
+
+    // The vector to store the input of one fft call.
+    QVector<float> m_fftInputVector;
+
+    QIODevice* m_audioSinkDevice = nullptr;
+
+    using TimePoint = std::chrono::system_clock::time_point;
+    // Used to measure the frequency of the audio loop for debugging.
+    TimePoint m_lastWriteTimepoint;
+
+#ifdef USE_FFTREAL
+    FFTRealWrapper m_fft;
+#endif
+};
+
+
+
+}
+#endif

--- a/SerialPrograms/Source/CommonFramework/AudioPipeline/FFTWorker.cpp
+++ b/SerialPrograms/Source/CommonFramework/AudioPipeline/FFTWorker.cpp
@@ -1,0 +1,91 @@
+/*  Audio Thread Controller
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "AudioConstants.h"
+#include "AudioDisplayWidget.h"
+#include "Common/Cpp/AlignedVector.tpp"
+#include "CommonFramework/Logging/Logger.h"
+#include "Kernels/AbsFFT/Kernels_AbsFFT.h"
+#include "FFTWorker.h"
+#include <QThread>
+
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <cfloat>
+#include <chrono>
+#include <memory>
+#include <cmath>
+
+
+// #define USE_FFTREAL
+
+#ifdef USE_FFTREAL
+#include <fftreal_wrapper.h>
+#endif
+
+// #define DEBUG_AUDIO_IO
+
+namespace PokemonAutomation{
+
+
+FFTWorker::FFTWorker(int fftLengthPowerOfTwo) : m_fftLengthPowerOfTwo(fftLengthPowerOfTwo){
+    const int numFFTSamples = 1 << m_fftLengthPowerOfTwo;
+
+    m_fftInputBuffer = Vector(numFFTSamples);
+    m_fftOutputBuffer = Vector(numFFTSamples/2);
+
+    m_outputVector.resize(numFFTSamples/2);
+}
+
+FFTWorker::~FFTWorker(){}
+
+void FFTWorker::computeFFT(const QVector<float>& fftInput){
+    // float sum = 0.0;
+    // for(auto v : rawAudioSamples) sum += v;
+    // std::cout << "FFTWorker::computeFFT, receive fft input, sum " << sum << std::endl;;
+
+    // We need to copy data from one buffer to another because m_fftInputBuffer is 
+    // memory aligned. This is required for the FFT function.
+    memcpy(m_fftInputBuffer.data(), fftInput.data(), sizeof(float) * m_fftInputBuffer.size());
+
+    // raw audio samples are in range [-1.0, 1.0]. Need to convert it to [0.0, 1.0]
+    // for(size_t i = 0; i < m_fftInputBuffer.size(); i++){
+    //     m_fftInputBuffer[i] = (rawAudioSamples[i] + 1.0) / 2.0;
+    // }
+
+    auto startTime = std::chrono::system_clock::now();
+
+#ifdef USE_FFTREAL
+    FFTRealWrapper fft;
+    fft.calculateFFT(m_fftOutputBuffer.data(), m_fftInputBuffer.data());
+
+    for(int i = 2; i <= NUM_FFT_SAMPLES/2; i++){
+        float real = m_fftOutputBuffer[i];
+        float imag = 0.0;
+        if (i>0 && i<NUM_FFT_SAMPLES/2) {
+            imag = m_fftOutputBuffer[NUM_FFT_SAMPLES/2 + i];
+        }
+        float mag = std::sqrt(real * real + imag * imag);
+        // std::cout << mag << " ";
+        m_fftOutputBuffer[i-2] = mag;
+    }
+#else
+    Kernels::AbsFFT::fft_abs(m_fftLengthPowerOfTwo, m_fftOutputBuffer.data(), m_fftInputBuffer.data());
+#endif
+
+    auto endTime = std::chrono::system_clock::now();
+    std::chrono::microseconds dur = std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime);
+    // std::cout << "T" << QThread::currentThread() << " FFTWorker::computeFFT() finished, time " dur.count() <<
+    //     " ms" << std::endl;
+
+    memcpy(m_outputVector.data(), m_fftOutputBuffer.data(), sizeof(float) * m_outputVector.size());
+    emit FFTFinished(m_outputVector);
+}
+
+
+
+}

--- a/SerialPrograms/Source/CommonFramework/AudioPipeline/FFTWorker.h
+++ b/SerialPrograms/Source/CommonFramework/AudioPipeline/FFTWorker.h
@@ -1,0 +1,63 @@
+/*  Audio Thread Controller
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_FFTWorker_H
+#define PokemonAutomation_FFTWorker_H
+
+#include <vector>
+#include <chrono>
+#include <QObject>
+#include <QVector>
+#include <QAudioFormat>
+#include "Common/Cpp/AlignedVector.h"
+#include "FFTWorker.h"
+
+namespace PokemonAutomation{
+
+
+
+// This is the main class to compute FFT. It receives signals from the audio IO code
+// to get FFT input audio samples, and send signals of the computed FFT results to
+// the audio UI in the UI thread for visualization.
+// This class will be moved into a QThread, separate from the main Qt UI thread and
+// audio IO thread so that FFT computation does not block them.
+// The class, AudioThreadController is responsible for the management of the QThread.
+class FFTWorker: public QObject{
+    //  Need to define this Q_OBJECT to use Qt's extra features
+    //  like signals and slots on this class.
+    Q_OBJECT
+
+    using Vector = std::vector<float>;
+    // using Vector = AlignedVector<float>;
+
+public:
+    FFTWorker(int fftLengthPowerOfTwo);
+    virtual ~FFTWorker();
+
+public slots:
+    // Will be connected to the audio IO code to receive fft input audio sample vector.
+    void computeFFT(const QVector<float>& rawAudioSamples);
+
+signals:
+    // Will be connected to the audio UI widget to display FFT results.
+    void FFTFinished(const QVector<float>& fftOutput);
+
+private:
+
+    int m_fftLengthPowerOfTwo = 0;
+
+    // The buffer to store fft input
+    Vector m_fftInputBuffer;
+    // The buffer to save fft output.
+    Vector m_fftOutputBuffer;
+
+    QVector<float> m_outputVector;
+};
+
+
+
+}
+#endif

--- a/SerialPrograms/Source/CommonFramework/AudioPipeline/TimeSampleWriter.h
+++ b/SerialPrograms/Source/CommonFramework/AudioPipeline/TimeSampleWriter.h
@@ -47,6 +47,7 @@ public:
     void fill_rest_with_zeros(){
         memset(m_output, 0, m_samples_left * sizeof(Type));
         m_output += m_samples_left;
+        m_samples_left = 0;
     }
 
 

--- a/SerialPrograms/Source/CommonFramework/Tools/AudioFeed.h
+++ b/SerialPrograms/Source/CommonFramework/Tools/AudioFeed.h
@@ -1,0 +1,53 @@
+/*  Audio Feed Interface
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_AudioFeedInterface_H
+#define PokemonAutomation_AudioFeedInterface_H
+
+#include <vector>
+#include <memory>
+
+class QImage;
+
+namespace PokemonAutomation{
+
+//  The result of one FFT computation, an array of the magnitudes of different
+//  frequencies.
+//  Each spectrum is computed using a sliding window on the incoming audio stream.
+//  It has a stamp to denote which window it is from.
+struct AudioSpectrum{
+    //  The stamp to denote which audio window it is from.
+    //  the stamp starts at 0 and becomes larger for later windows in the stream.
+    size_t stamp = 0;
+    //  The frequency magnitudes from FFT. The order in the vector is from lower to
+    //  higher frequencies.
+    std::vector<float> magnitudes;
+
+    AudioSpectrum(size_t s, const std::vector<float>& m) : stamp(s), magnitudes(m) {}
+    AudioSpectrum(size_t s, std::vector<float>&& m) : stamp(s), magnitudes(std::move(m)) {}
+    AudioSpectrum(const AudioSpectrum&) = default;
+    AudioSpectrum(AudioSpectrum&&) = default;
+};
+
+//  Define basic interface of an audio feed to be used
+//  by programs.
+class AudioFeed{
+public:
+    //  Can call from anywhere.
+    virtual void async_reset_audio() = 0;
+
+    //  Return all the computed spectrums which stamps are greater
+    //  or equal to `startingStamp`
+    virtual void spectrums_since(size_t startingStamp, std::vector<std::shared_ptr<AudioSpectrum>>& spectrums) = 0;
+
+    //  Return the latest spectrums.
+    virtual void spectrums_latest(size_t numLatestSpectrums, std::vector<std::shared_ptr<AudioSpectrum>>& spectrums) = 0;
+};
+
+
+
+}
+#endif

--- a/SerialPrograms/Source/CommonFramework/Tools/ConsoleHandle.h
+++ b/SerialPrograms/Source/CommonFramework/Tools/ConsoleHandle.h
@@ -14,6 +14,7 @@ namespace PokemonAutomation{
 
 class VideoFeed;
 class VideoOverlay;
+class AudioFeed;
 
 
 class ConsoleHandle{
@@ -23,13 +24,15 @@ public:
         Logger& logger,
         BotBase& botbase,
         VideoFeed& video,
-        VideoOverlay& overlay
+        VideoOverlay& overlay,
+        AudioFeed& audio
     )
         : m_index(index)
         , m_logger(logger, "Switch " + std::to_string(index))
         , m_context(botbase)
         , m_video(video)
         , m_overlay(overlay)
+        , m_audio(audio)
     {}
 
     template <class... Args>
@@ -44,12 +47,14 @@ public:
     BotBaseContext& context(){ return m_context; }
     VideoFeed& video(){ return m_video; }
     VideoOverlay& overlay(){ return m_overlay; }
+    AudioFeed& audio(){ return m_audio; }
 
     operator Logger&(){ return m_logger; }
     operator BotBase&(){ return m_context.botbase(); }
     operator BotBaseContext&(){ return m_context; }
     operator VideoFeed&(){ return m_video; }
     operator VideoOverlay&(){ return m_overlay; }
+    operator AudioFeed&() { return m_audio; }
 
 private:
     size_t m_index;
@@ -57,6 +62,7 @@ private:
     BotBaseContext m_context;
     VideoFeed& m_video;
     VideoOverlay& m_overlay;
+    AudioFeed& m_audio;
 };
 
 

--- a/SerialPrograms/Source/Integrations/ProgramTracker.h
+++ b/SerialPrograms/Source/Integrations/ProgramTracker.h
@@ -17,6 +17,7 @@
 #include "CommonFramework/Globals.h"
 #include "CommonFramework/Tools/BotBaseHandle.h"
 #include "CommonFramework/Tools/VideoFeed.h"
+#include "CommonFramework/Tools/AudioFeed.h"
 
 namespace PokemonAutomation{
 

--- a/SerialPrograms/Source/NintendoSwitch/Framework/NintendoSwitch_MultiSwitchProgramWidget.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/Framework/NintendoSwitch_MultiSwitchProgramWidget.cpp
@@ -50,7 +50,8 @@ void MultiSwitchProgramWidget::run_program(
             m_logger.base_logger(),
             sanitize_botbase(system.botbase()),
             system.camera(),
-            system.overlay()
+            system.overlay(),
+            system.audio()
         );
     }
     MultiSwitchProgramEnvironment env(

--- a/SerialPrograms/Source/NintendoSwitch/Framework/NintendoSwitch_SingleSwitchProgramWidget.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/Framework/NintendoSwitch_SingleSwitchProgramWidget.cpp
@@ -40,7 +40,8 @@ void SingleSwitchProgramWidget::run_program(
         m_logger.base_logger(),
         sanitize_botbase(system().botbase()),
         system().camera(),
-        system().overlay()
+        system().overlay(),
+        system().audio()
     );
     connect(
         this, &RunnableSwitchProgramWidget::signal_cancel,

--- a/SerialPrograms/Source/NintendoSwitch/Framework/NintendoSwitch_SwitchSystem.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/Framework/NintendoSwitch_SwitchSystem.cpp
@@ -15,6 +15,7 @@ namespace NintendoSwitch{
 
 const QString SwitchSystemFactory::JSON_SERIAL  = "Serial";
 const QString SwitchSystemFactory::JSON_CAMERA  = "Camera";
+const QString SwitchSystemFactory::JSON_AUDIO  = "Audio";
 
 
 SwitchSystemFactory::SwitchSystemFactory(
@@ -28,6 +29,7 @@ SwitchSystemFactory::SwitchSystemFactory(
 //    , m_settings_visible(true)
     , m_serial("<b>Serial Port:</b>", m_logger_tag, min_pabotbase)
     , m_camera(DEFAULT_RESOLUTION)
+    , m_audio()
 {}
 SwitchSystemFactory::SwitchSystemFactory(
     size_t console_id,
@@ -48,12 +50,14 @@ void SwitchSystemFactory::load_json(const QJsonValue& json){
 //    json_get_bool(m_settings_visible, obj, "SettingsVisible");
     m_serial.load_json(json_get_value_nothrow(obj, JSON_SERIAL));
     m_camera.load_json(json_get_value_nothrow(obj, JSON_CAMERA));
+    m_audio.load_json(json_get_value_nothrow(obj, JSON_AUDIO));
 }
 QJsonValue SwitchSystemFactory::to_json() const{
     QJsonObject root;
 //    root.insert("SettingsVisible", m_settings_visible);
     root.insert(JSON_SERIAL, m_serial.to_json());
     root.insert(JSON_CAMERA, m_camera.to_json());
+    root.insert(JSON_AUDIO, m_audio.to_json());
     return root;
 }
 

--- a/SerialPrograms/Source/NintendoSwitch/Framework/NintendoSwitch_SwitchSystem.h
+++ b/SerialPrograms/Source/NintendoSwitch/Framework/NintendoSwitch_SwitchSystem.h
@@ -7,6 +7,7 @@
 #ifndef PokemonAutomation_NintendoSwitch_SwitchSystem_H
 #define PokemonAutomation_NintendoSwitch_SwitchSystem_H
 
+#include "CommonFramework/AudioPipeline/AudioSelector.h"
 #include "CommonFramework/ControllerDevices/SerialSelector.h"
 #include "CommonFramework/VideoPipeline/CameraSelector.h"
 #include "NintendoSwitch_SwitchSetup.h"
@@ -20,6 +21,7 @@ class SwitchSystemWidget;
 class SwitchSystemFactory : public SwitchSetupFactory{
     static const QString JSON_SERIAL;
     static const QString JSON_CAMERA;
+    static const QString JSON_AUDIO;
 
 public:
     SwitchSystemFactory(
@@ -49,6 +51,7 @@ private:
 //    bool m_settings_visible;
     SerialSelector m_serial;
     CameraSelector m_camera;
+    AudioSelector m_audio;
 };
 
 

--- a/SerialPrograms/Source/NintendoSwitch/Framework/NintendoSwitch_SwitchSystemWidget.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/Framework/NintendoSwitch_SwitchSystemWidget.cpp
@@ -11,6 +11,8 @@
 #include "Common/Cpp/PrettyPrint.h"
 #include "Common/Cpp/FireForgetDispatcher.h"
 #include "Common/Qt/CollapsibleGroupBox.h"
+#include "CommonFramework/AudioPipeline/AudioDisplayWidget.h"
+#include "CommonFramework/AudioPipeline/AudioSelectorWidget.h"
 #include "CommonFramework/ControllerDevices/SerialSelectorWidget.h"
 #include "CommonFramework/VideoPipeline/CameraSelectorWidget.h"
 #include "CommonFramework/VideoPipeline/VideoDisplayWidget.h"
@@ -50,9 +52,13 @@ SwitchSystemWidget::SwitchSystemWidget(
         group_layout->addWidget(m_serial);
 
         m_video_display = new VideoDisplayWidget(*this);
+        m_audio_display = new AudioDisplayWidget(*this);
 
         m_camera = factory.m_camera.make_ui(*widget, logger, *m_video_display);
         group_layout->addWidget(m_camera);
+
+        m_audio = factory.m_audio.make_ui(*widget, logger, *m_audio_display);
+        group_layout->addWidget(m_audio);
 
         m_command = new CommandRow(
             *widget,
@@ -63,8 +69,10 @@ SwitchSystemWidget::SwitchSystemWidget(
         group_layout->addWidget(m_command);
     }
 
+    layout->addWidget(m_audio_display);
     layout->addWidget(m_video_display);
     m_camera->reset_video();
+    m_audio->reset_audio();
 
 //    m_controller.reset(new VirtualController(m_serial->botbase()));
     setFocusPolicy(Qt::StrongFocus);
@@ -130,6 +138,9 @@ VideoFeed& SwitchSystemWidget::camera(){
 }
 VideoOverlay& SwitchSystemWidget::overlay(){
     return *m_video_display;
+}
+AudioFeed& SwitchSystemWidget::audio(){
+    return *m_audio;
 }
 void SwitchSystemWidget::stop_serial(){
     m_serial->stop();

--- a/SerialPrograms/Source/NintendoSwitch/Framework/NintendoSwitch_SwitchSystemWidget.h
+++ b/SerialPrograms/Source/NintendoSwitch/Framework/NintendoSwitch_SwitchSystemWidget.h
@@ -13,6 +13,8 @@
 
 namespace PokemonAutomation{
     class CollapsibleGroupBox;
+    class AudioDisplayWidget;
+
 namespace NintendoSwitch{
 
 class CommandRow;
@@ -40,6 +42,7 @@ public:
     BotBase* botbase();
     VideoFeed& camera();
     VideoOverlay& overlay();
+    AudioFeed& audio();
     virtual void update_ui(ProgramState state) override;
 
     virtual VideoFeed& video() override;
@@ -61,7 +64,10 @@ private:
     SerialSelectorWidget* m_serial;
     CommandRow* m_command;
     CameraSelectorWidget* m_camera;
+    AudioSelectorWidget* m_audio;
+    
     VideoDisplayWidget* m_video_display;
+    AudioDisplayWidget* m_audio_display;
 };
 
 


### PR DESCRIPTION
Example code of reading audio and doing FFT.
- The UI to select audio source is implemented.
- The code to get audio from capture card, do FFT and visualize spectrogram are implemented.
- It uses a large buffer to hold raw audio data and do FFT on the same UI thread. This needs to be changed according to the discussion on Discord.

Feel free to pull it into a develop branch and change it as will.