### PR TITLE
Workaround for Tesseract 5 bug

### DIFF
--- a/SerialPrograms/Source/CommonFramework/OCR/OCR_RawOCR.cpp
+++ b/SerialPrograms/Source/CommonFramework/OCR/OCR_RawOCR.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <deque>
 #include <QFile>
+#include <iostream>
 #include "Common/Cpp/Exception.h"
 #include "Common/Cpp/SpinLock.h"
 #include "CommonFramework/Globals.h"
@@ -97,6 +98,26 @@ public:
             ? QString()
             : QString::fromUtf8(str.c_str());
     }
+
+    ~TesseractPool(){
+#ifdef __APPLE__
+#ifdef UNIX_LINK_TESSERACT
+        // As of Feb 05, 2022, the newest Tesseract (5.0.1) installed by HomeBrew on macOS
+        // has a bug that will crash the program when deleting internal Tesseract API intances,
+        // giving error: 
+        // libc++abi.dylib: terminating with uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument
+        // A similar issue is posted on Tesseract Github: https://github.com/tesseract-ocr/tesseract/issues/3655
+        // There is no way of using HomeBrew to reinstall the older version.
+        // Fortunately this class TesseractPool will not get built and destroyed repeatedly in
+        // runtime. It will only get initialized once for each supported language. So I am able
+        // to use this ugly workaround by not deleting the Tesseract API intances.
+        std::cout << "Warning: not release Tesseract API istance due to mutex bug similar to https://github.com/tesseract-ocr/tesseract/issues/3655" << std::endl;
+        for(auto& api : m_instances){
+            api.release();
+        }
+    }
+#endif
+#endif
 
 private:
     const std::string& m_language_code;


### PR DESCRIPTION
On MacOS Tesseract 5 will crash the program if you release its internal data when closing the program, preventing the program from saving the settings to the json file.

So I have to add this ugly workaround until Tesseract is fixed. 