### PR TITLE
Fix compile warning and misc

### DIFF
--- a/SerialPrograms/Source/CommonFramework/ImageTools/SolidColorTest.h
+++ b/SerialPrograms/Source/CommonFramework/ImageTools/SolidColorTest.h
@@ -32,6 +32,8 @@ bool is_grey(
     double min_rgb_sum, double max_rgb_sum,
     double max_stddev_sum = 10
 );
+
+// expected_color_ratio: ratio of color channels to match, e.g. if a color is (127, 127, 254), it's color ratio is (0.25, 0.25, 0.5)
 bool is_solid(
     const ImageStats& stats,
     const FloatPixel& expected_color_ratio,
@@ -63,6 +65,8 @@ inline bool is_grey(
 ){
     return is_grey(image_stats(image), min_rgb_sum, max_rgb_sum, max_stddev_sum);
 }
+
+// expected_color_ratio: ratio of color channels to match, e.g. if a color is (127, 127, 254), it's color ratio is (0.25, 0.25, 0.5)
 inline bool is_solid(
     const ConstImageRef& image,
     const FloatPixel& expected_color_ratio,

--- a/SerialPrograms/Source/PokemonLA/Programs/Farming/PokemonLA_IngoBattleGrinder.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/Farming/PokemonLA_IngoBattleGrinder.cpp
@@ -245,8 +245,8 @@ bool IngoBattleGrinder::run_iteration(SingleSwitchProgramEnvironment& env, BotBa
     auto switch_cur_pokemon = [&](){
         cur_move = 0;
         num_turns = 0;
-        next_pokemon_to_switch_to++;
         next_pokemon_to_switch_to = switch_pokemon(env.console, context, next_pokemon_to_switch_to);
+        next_pokemon_to_switch_to++;
         cur_pokemon++;
     };
 

--- a/SerialPrograms/Source/PokemonSwSh/Inference/Dens/PokemonSwSh_BeamSetter.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Inference/Dens/PokemonSwSh_BeamSetter.cpp
@@ -27,9 +27,9 @@ namespace NintendoSwitch{
 namespace PokemonSwSh{
 
 
-BeamSetter::BeamSetter(ProgramEnvironment& env, ConsoleHandle& console, BotBaseContext& context)
-    : m_env(env)
-    , m_console(console)
+BeamSetter::BeamSetter(ProgramEnvironment& /*env*/, ConsoleHandle& console, BotBaseContext& context)
+    // : m_env(env)
+    : m_console(console)
     , m_context(context)
     , m_text_box(console, 0.400, 0.825, 0.05, 0.05, COLOR_RED)
     , m_box(console, 0.10, 0.005, 0.8, 0.470, COLOR_RED)

--- a/SerialPrograms/Source/PokemonSwSh/Inference/Dens/PokemonSwSh_BeamSetter.h
+++ b/SerialPrograms/Source/PokemonSwSh/Inference/Dens/PokemonSwSh_BeamSetter.h
@@ -44,7 +44,7 @@ public:
 
 
 private:
-    ProgramEnvironment& m_env;
+    // ProgramEnvironment& m_env;
     ConsoleHandle& m_console;
     BotBaseContext& m_context;
     InferenceBoxScope m_text_box;


### PR DESCRIPTION
- Add some comments
- Fix warnings: unused var
- Fix a bug in Ingo Battle Grinder that will skip the first pokemon in the party if you start the battle with a pokemon not as party lead.