### PR TITLE
Alpha music

### DIFF
--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -849,6 +849,8 @@ file(GLOB MAIN_SOURCES
     Source/PokemonLA/Inference/Objects/PokemonLA_ShinySymbolDetector.h
     Source/PokemonLA/Inference/Objects/PokemonLA_WhiteObjectDetector.cpp
     Source/PokemonLA/Inference/Objects/PokemonLA_WhiteObjectDetector.h
+    Source/PokemonLA/Inference/PokemonLA_AlphaMusicDetector.cpp
+    Source/PokemonLA/Inference/PokemonLA_AlphaMusicDetector.h
     Source/PokemonLA/Inference/PokemonLA_AlphaRoarDetector.cpp
     Source/PokemonLA/Inference/PokemonLA_AlphaRoarDetector.h
     Source/PokemonLA/Inference/PokemonLA_BattleMenuDetector.cpp
@@ -934,6 +936,8 @@ file(GLOB MAIN_SOURCES
     Source/PokemonLA/Programs/ShinyHunting/PokemonLA_ShinyHunt-FlagPin.h
     Source/PokemonLA/Programs/ShinyHunting/PokemonLA_ShinyHunt-LakeTrio.cpp
     Source/PokemonLA/Programs/ShinyHunting/PokemonLA_ShinyHunt-LakeTrio.h
+    Source/PokemonLA/Programs/TestPrograms/PokemonLA_AlphaMusicListener.cpp
+    Source/PokemonLA/Programs/TestPrograms/PokemonLA_AlphaMusicListener.h
     Source/PokemonLA/Programs/TestPrograms/PokemonLA_AlphaRoarListener.cpp
     Source/PokemonLA/Programs/TestPrograms/PokemonLA_AlphaRoarListener.h
     Source/PokemonLA/Programs/TestPrograms/PokemonLA_FlagNavigationTest.cpp

--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -244,6 +244,8 @@ file(GLOB MAIN_SOURCES
     Source/CommonFramework/ImageTools/SolidColorTest.h
     Source/CommonFramework/Inference/AnomalyDetector.cpp
     Source/CommonFramework/Inference/AnomalyDetector.h
+    Source/CommonFramework/Inference/AudioPerSpectrumDetectorBase.cpp
+    Source/CommonFramework/Inference/AudioPerSpectrumDetectorBase.h
     Source/CommonFramework/Inference/AudioTemplateCache.cpp
     Source/CommonFramework/Inference/AudioTemplateCache.h
     Source/CommonFramework/Inference/BlackBorderDetector.cpp

--- a/SerialPrograms/Source/CommonFramework/Inference/AudioPerSpectrumDetectorBase.cpp
+++ b/SerialPrograms/Source/CommonFramework/Inference/AudioPerSpectrumDetectorBase.cpp
@@ -1,0 +1,131 @@
+/*  Audio Template Cache
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include <QString>
+#include <sstream>
+#include <cfloat>
+
+#include "Common/Cpp/Exceptions.h"
+#include "CommonFramework/Globals.h"
+#include "CommonFramework/AudioPipeline/AudioTemplate.h"
+#include "CommonFramework/Inference/SpectrogramMatcher.h"
+#include "CommonFramework/Tools/VideoFeed.h"
+#include "CommonFramework/Tools/AudioFeed.h"
+#include "CommonFramework/Tools/ConsoleHandle.h"
+#include "AudioPerSpectrumDetectorBase.h"
+
+namespace PokemonAutomation{
+
+
+AudioPerSpectrumDetectorBase::~AudioPerSpectrumDetectorBase(){
+    log_results();
+}
+AudioPerSpectrumDetectorBase::AudioPerSpectrumDetectorBase(
+    std::string label, std::string audio_name, Color detection_color, ConsoleHandle& console, bool stop_on_detected)
+    : AudioInferenceCallback(std::move(label))
+    , m_audio_name(std::move(audio_name))
+    , m_detection_color(detection_color)
+    , m_console(console)
+    , m_stop_on_detected(stop_on_detected)
+    , m_detected(false)
+    , m_time_detected(WallClock::min())
+    , m_error_coefficient(1.0f)
+{}
+
+void AudioPerSpectrumDetectorBase::log_results(){
+    std::stringstream ss;
+    ss << m_error_coefficient;
+    if (detected()){
+        m_console.log(m_audio_name + " detected! Error Coefficient = " + ss.str(), COLOR_BLUE);
+    }else{
+        m_console.log(m_audio_name + " not detected. Error Coefficient = " + ss.str(), COLOR_PURPLE);
+    }
+}
+
+bool AudioPerSpectrumDetectorBase::process_spectrums(
+    const std::vector<AudioSpectrum>& newSpectrums,
+    AudioFeed& audioFeed
+){
+    if (newSpectrums.empty()){
+        return false;
+    }
+
+    WallClock now = current_time();
+
+    size_t sampleRate = newSpectrums[0].sample_rate;
+    if (m_matcher == nullptr || m_matcher->sampleRate() != sampleRate){
+        m_console.log("Loading spectrogram...");
+        m_matcher = build_spectrogram_matcher(sampleRate);
+    }
+
+    // Feed spectrum one by one to the matcher:
+    // newSpectrums are ordered from newest (largest timestamp) to oldest (smallest timestamp).
+    // To feed the spectrum from old to new, we need to go through the vector in the reverse order:
+    
+    for(auto it = newSpectrums.rbegin(); it != newSpectrums.rend(); it++){
+        std::vector<AudioSpectrum> singleSpectrum = {*it};
+        float matcherScore = m_matcher->match(singleSpectrum);
+
+        if (matcherScore == FLT_MAX){
+            continue; // error or not enough spectrum history
+        }
+
+        const float threshold = get_score_threshold();
+        const bool found = matcherScore <= threshold;
+//        cout << matcherScore << endl;
+
+        m_error_coefficient = std::min(m_error_coefficient, matcherScore);
+
+        size_t curStamp = m_matcher->latestTimestamp();
+        // std::cout << "(" << curStamp+1-m_matcher->numTemplateWindows() << ", " <<  curStamp+1 << "): " << matcherScore << 
+        //     (found ? " FOUND!" : "") << std::endl;
+
+        if (found){
+            {
+                SpinLockGuard lg(m_lock);
+                m_screenshot = m_console.video().snapshot();
+            }
+            std::ostringstream os;
+            os << m_audio_name << " found, score " << matcherScore << "/" << threshold << ", scale: " << m_matcher->lastMatchedScale();
+            m_console.log(os.str(), COLOR_BLUE);
+            audioFeed.add_overlay(curStamp+1-m_matcher->numTemplateWindows(), curStamp+1, m_detection_color);
+            // Tell m_matcher to skip the remaining spectrums so that if `process_spectrums()` gets
+            // called again on a newer batch of spectrums, m_matcher is happy.
+            m_matcher->skip(std::vector<AudioSpectrum>(
+                newSpectrums.begin(),
+                newSpectrums.begin() + std::distance(it + 1, newSpectrums.rend())
+            ));
+
+            if (!m_detected.load(std::memory_order_acquire)){
+                m_time_detected = now;
+                m_detected.store(true, std::memory_order_release);
+            }
+
+            break;
+        }
+    }
+
+    if (!m_stop_on_detected){
+        return false;
+    }
+    if (!m_detected.load(std::memory_order_acquire)){
+        return false;
+    }
+
+    //  Don't return true for another 200ms so we can get a measurement of how strong this detection is.
+    return m_time_detected + std::chrono::milliseconds(200) <= now;
+}
+
+void AudioPerSpectrumDetectorBase::clear(){
+    m_matcher->clear();
+}
+
+
+
+
+
+
+}

--- a/SerialPrograms/Source/CommonFramework/Inference/AudioPerSpectrumDetectorBase.cpp
+++ b/SerialPrograms/Source/CommonFramework/Inference/AudioPerSpectrumDetectorBase.cpp
@@ -17,6 +17,8 @@
 #include "CommonFramework/Tools/ConsoleHandle.h"
 #include "AudioPerSpectrumDetectorBase.h"
 
+// #include <iostream>
+
 namespace PokemonAutomation{
 
 
@@ -77,6 +79,7 @@ bool AudioPerSpectrumDetectorBase::process_spectrums(
     for(auto it = newSpectrums.rbegin(); it != newSpectrums.rend(); it++){
         std::vector<AudioSpectrum> singleSpectrum = {*it};
         const float matcherScore = m_matcher->match(singleSpectrum);
+        // std::cout << "error: " << matcherScore << std::endl;
 
         if (matcherScore == FLT_MAX){
             continue; // error or not enough spectrum history

--- a/SerialPrograms/Source/CommonFramework/Inference/AudioPerSpectrumDetectorBase.h
+++ b/SerialPrograms/Source/CommonFramework/Inference/AudioPerSpectrumDetectorBase.h
@@ -1,0 +1,94 @@
+/*  Audio Per-Spectrum Detector Base
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ *  A base class for any audio detector that tries to match an audio template starting at each 
+ *  incoming spectrum in the audio stream (hence the "PerSpectrum").
+ *  This means that, if called with three newest unseen spectrums from the audio feed, the detector
+ *  will check whether the audio template matches audio starting at the first of the three spectrums,
+ *  then check the second, and finally the third.
+ *  Basically, it will try to match the audio template to any possible past location in the audio
+ *  stream. So it will not miss any match if the audio template is short in duration and the matching
+ *  algorithm needs to be very precise.
+ *  This is opposite to the other design choice that only matches the audio starting at the newest
+ *  spectrum when called. That design choice is better suited to non-time-critical audio matching and
+ *  the matching algorithm can tolerate a few spectrums off on time axis.
+ */
+
+#ifndef PokemonAutomation_CommonFramework_AudioPerSpectrumDetectorBase_H
+#define PokemonAutomation_CommonFramework_AudioPerSpectrumDetectorBase_H
+
+#include <QImage>
+
+#include <string>
+
+#include "Common/Cpp/Color.h"
+#include "Common/Cpp/SpinLock.h"
+#include "Common/Cpp/Time.h"
+#include "CommonFramework/InferenceInfra/AudioInferenceCallback.h"
+
+namespace PokemonAutomation{
+
+class ConsoleHandle;
+class SpectrogramMatcher;
+
+// A base class for audio detectors to match an audio template starting at each incoming spectrum in 
+// the audio stream.
+class AudioPerSpectrumDetectorBase : public AudioInferenceCallback{
+public:
+    // label: a name for this detector. Used for logging and profiling.
+    // audio_name: the name of the audio to be detected (shiny sound etc). Capitalize first letter.
+    // detection_color: the color to visualize the detection on audio spectrogram UI.
+    AudioPerSpectrumDetectorBase(std::string label, std::string audio_name, Color detection_color,
+        ConsoleHandle& console, bool stop_on_detected);
+
+    virtual ~AudioPerSpectrumDetectorBase();
+
+    // To be implemented by derived classes:
+    // The match threshold for the target audio.
+    virtual float get_score_threshold() const = 0;
+
+    // Implement AudioInferenceCallback::process_spectrums()
+    virtual bool process_spectrums(
+        const std::vector<AudioSpectrum>& newSpectrums,
+        AudioFeed& audioFeed
+    ) override;
+
+    // Clear internal data to be used on another audio stream.
+    void clear();
+
+    // Log whether the target audio is detected or not
+    void log_results();
+
+    bool detected() const{
+        return m_detected.load(std::memory_order_acquire);
+    }
+
+protected:
+    // To be implemented by derived classes:
+    // build the actual spectrogram matcher for the target audio.
+    virtual std::unique_ptr<SpectrogramMatcher> build_spectrogram_matcher(size_t sampleRate) = 0;
+
+    // Name of the target audio to be detected. Used for logging.
+    std::string m_audio_name;
+    Color m_detection_color;
+    
+    ConsoleHandle& m_console;
+    bool m_stop_on_detected = false;
+
+    SpinLock m_lock;
+    std::atomic<bool> m_detected;
+    WallClock m_time_detected;
+
+    float m_error_coefficient = 1.0f;
+    QImage m_screenshot;
+
+    std::unique_ptr<SpectrogramMatcher> m_matcher;
+};
+
+
+
+
+
+}
+#endif

--- a/SerialPrograms/Source/CommonFramework/Inference/SpectrogramMatcher.cpp
+++ b/SerialPrograms/Source/CommonFramework/Inference/SpectrogramMatcher.cpp
@@ -273,7 +273,7 @@ float SpectrogramMatcher::match(const std::vector<AudioSpectrum>& newSpectrums){
         return FLT_MAX;
     }
 
-    if (m_spectrums.size() < m_template.numWindows()){
+    if (m_spectrums.size() < m_numSpectrumsNeeded){
         return FLT_MAX;
     }
 

--- a/SerialPrograms/Source/CommonFramework/Inference/SpectrogramMatcher.h
+++ b/SerialPrograms/Source/CommonFramework/Inference/SpectrogramMatcher.h
@@ -65,7 +65,8 @@ public:
     // Clear internal data to be used on another audio stream.
     void clear();
 
-    size_t numTemplateWindows() const { return m_template.numWindows(); }
+    // How many windows are used for matching.
+    size_t numMatchedWindows() const { return m_numSpectrumsNeeded; }
 
     // Return latest timestamp from the stored audio spectrum stream.
     // Return SIZE_MAX if there is no stored spectrum yet.

--- a/SerialPrograms/Source/CommonFramework/Tools/ConsoleHandle.h
+++ b/SerialPrograms/Source/CommonFramework/Tools/ConsoleHandle.h
@@ -40,6 +40,8 @@ public:
         AudioFeed& audio
     );
 
+    // log(string-like msg, Color color = Color())
+    // string-like can be const char*, std::string or QString
     template <class... Args>
     void log(Args&&... args){
         m_logger.log(std::forward<Args>(args)...);

--- a/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_AlphaMusicDetector.cpp
+++ b/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_AlphaMusicDetector.cpp
@@ -1,0 +1,52 @@
+/*  Alpha Music Detector
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include <QString>
+#include "CommonFramework/Inference/SpectrogramMatcher.h"
+#include "CommonFramework/Inference/AudioTemplateCache.h"
+#include "CommonFramework/Tools/VideoFeed.h"
+#include "CommonFramework/Tools/AudioFeed.h"
+#include "CommonFramework/Tools/ConsoleHandle.h"
+#include "PokemonLA/PokemonLA_Settings.h"
+#include "PokemonLA_AlphaMusicDetector.h"
+
+#include <sstream>
+#include <cfloat>
+#include <iostream>
+using std::cout;
+using std::endl;
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonLA{
+
+
+
+AlphaMusicDetector::AlphaMusicDetector(ConsoleHandle& console, OnShinyCallback on_shiny_callback)
+    // Use a red as the detection color because the alpha symbol is red.
+    : AudioPerSpectrumDetectorBase("AlphaMusicDetector", "Alpha music", COLOR_RED, console, on_shiny_callback)
+{}
+
+float AlphaMusicDetector::get_score_threshold() const{
+    return (float)GameSettings::instance().ALPHA_MUSIC_THRESHOLD;
+}
+
+std::unique_ptr<SpectrogramMatcher> AlphaMusicDetector::build_spectrogram_matcher(size_t sampleRate){
+    const double lowFrequencyFilter = 50.0; // we don't match frequencies under 50.0 Hz
+    const size_t templateSubdivision = 12;
+    return std::make_unique<SpectrogramMatcher>(
+        AudioTemplateCache::instance().get_throw("PokemonLA/AlphaMusic", sampleRate),
+        SpectrogramMatcher::Mode::AVERAGE_5, sampleRate,
+        lowFrequencyFilter, templateSubdivision
+    );
+}
+
+
+
+
+}
+}
+}

--- a/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_AlphaMusicDetector.h
+++ b/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_AlphaMusicDetector.h
@@ -1,0 +1,44 @@
+/*  Alpha Music Detector
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonLA_AlphaMusicDetector_H
+#define PokemonAutomation_PokemonLA_AlphaMusicDetector_H
+
+#include <QImage>
+#include "Common/Cpp/SpinLock.h"
+#include "CommonFramework/Logging/LoggerQt.h"
+#include "CommonFramework/Inference/AudioPerSpectrumDetectorBase.h"
+#include "PokemonLA/Options/PokemonLA_ShinyDetectedAction.h"
+
+#include <memory>
+
+namespace PokemonAutomation{
+
+class ConsoleHandle;
+class SpectrogramMatcher;
+
+namespace NintendoSwitch{
+namespace PokemonLA{
+
+
+class AlphaMusicDetector : public AudioPerSpectrumDetectorBase{
+public:
+    AlphaMusicDetector(ConsoleHandle& console, OnShinyCallback on_shiny_callback);
+
+    // Implement AudioPerSpectrumDetectorBase::get_score_threshold()
+    virtual float get_score_threshold() const override;
+
+protected:
+    // Implement AudioPerSpectrumDetectorBase::build_spectrogram_matcher()
+    virtual std::unique_ptr<SpectrogramMatcher> build_spectrogram_matcher(size_t sampleRate) override;
+};
+
+
+
+}
+}
+}
+#endif

--- a/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_AlphaRoarDetector.cpp
+++ b/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_AlphaRoarDetector.cpp
@@ -70,7 +70,7 @@ bool AlphaRoarDetector::process_spectrums(
         const double lowFrequencyFilter = 100.0; // we don't match frequencies under 100.0 Hz
         m_matcher = std::make_unique<SpectrogramMatcher>(
             AudioTemplateCache::instance().get_throw("PokemonLA/AlphaRoar", sampleRate),
-            SpectrogramMatcher::Mode::NO_CONV, sampleRate,
+            SpectrogramMatcher::Mode::RAW, sampleRate,
             lowFrequencyFilter
         );
     }

--- a/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_AlphaRoarDetector.cpp
+++ b/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_AlphaRoarDetector.cpp
@@ -25,20 +25,11 @@ namespace PokemonLA{
 
 
 
-AlphaRoarDetector::AlphaRoarDetector(ConsoleHandle& console, bool stop_on_detected)
+AlphaRoarDetector::AlphaRoarDetector(ConsoleHandle& console, OnShinyCallback on_shiny_callback)
     // Use a purple as the detection color because the alpha symbol is red. To differentiate with the
     // detection color of alpha music, the roar (which is loud -> heavy -> darker color) uses purple.
-    : AudioPerSpectrumDetectorBase("AlphaRoarDetector", "Alpha roar", COLOR_PURPLE, console, stop_on_detected)
+    : AudioPerSpectrumDetectorBase("AlphaRoarDetector", "Alpha roar", COLOR_PURPLE, console, on_shiny_callback)
 {}
-
-ShinySoundResults AlphaRoarDetector::results(){
-    ShinySoundResults results;
-    SpinLockGuard lg(m_lock);
-    results.screenshot = m_screenshot;
-    results.error_coefficient = m_error_coefficient;
-    return results;
-}
-
 
 float AlphaRoarDetector::get_score_threshold() const{
     return (float)GameSettings::instance().ALPHA_ROAR_THRESHOLD;

--- a/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_AlphaRoarDetector.cpp
+++ b/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_AlphaRoarDetector.cpp
@@ -25,26 +25,12 @@ namespace PokemonLA{
 
 
 
-AlphaRoarDetector::~AlphaRoarDetector(){
-    log_results();
-}
 AlphaRoarDetector::AlphaRoarDetector(ConsoleHandle& console, bool stop_on_detected)
-    : AudioInferenceCallback("AlphaRoarDetector")
-    , m_console(console)
-    , m_stop_on_detected(stop_on_detected)
-    , m_detected(false)
-    , m_time_detected(WallClock::min())
-    , m_error_coefficient(1.0)
+    // Use a purple as the detection color because the alpha symbol is red. To differentiate with the
+    // detection color of alpha music, the roar (which is loud -> heavy -> darker color) uses purple.
+    : AudioPerSpectrumDetectorBase("AlphaRoarDetector", "Alpha roar", COLOR_PURPLE, console, stop_on_detected)
 {}
-void AlphaRoarDetector::log_results(){
-    std::stringstream ss;
-    ss << m_error_coefficient;
-    if (detected()){
-        m_console.log("Alpha roar detected! Error Coefficient = " + ss.str(), COLOR_BLUE);
-    }else{
-        m_console.log("No alpha roar detected. Error Coefficient = " + ss.str(), COLOR_PURPLE);
-    }
-}
+
 ShinySoundResults AlphaRoarDetector::results(){
     ShinySoundResults results;
     SpinLockGuard lg(m_lock);
@@ -54,88 +40,19 @@ ShinySoundResults AlphaRoarDetector::results(){
 }
 
 
-bool AlphaRoarDetector::process_spectrums(
-    const std::vector<AudioSpectrum>& newSpectrums,
-    AudioFeed& audioFeed
-){
-    if (newSpectrums.empty()){
-        return false;
-    }
-
-    WallClock now = current_time();
-
-    size_t sampleRate = newSpectrums[0].sample_rate;
-    if (m_matcher == nullptr || m_matcher->sampleRate() != sampleRate){
-        m_console.log("Loading spectrogram...");
-        const double lowFrequencyFilter = 100.0; // we don't match frequencies under 100.0 Hz
-        m_matcher = std::make_unique<SpectrogramMatcher>(
-            AudioTemplateCache::instance().get_throw("PokemonLA/AlphaRoar", sampleRate),
-            SpectrogramMatcher::Mode::RAW, sampleRate,
-            lowFrequencyFilter
-        );
-    }
-
-    // Feed spectrum one by one to the matcher:
-    // newSpectrums are ordered from newest (largest timestamp) to oldest (smallest timestamp).
-    // To feed the spectrum from old to new, we need to go through the vector in the reverse order:
-    
-    for(auto it = newSpectrums.rbegin(); it != newSpectrums.rend(); it++){
-        std::vector<AudioSpectrum> singleSpectrum = {*it};
-        float matcherScore = m_matcher->match(singleSpectrum);
-
-        if (matcherScore == FLT_MAX){
-            continue; // error or not enough spectrum history
-        }
-
-        const float threshold = (float)GameSettings::instance().ALPHA_ROAR_THRESHOLD;
-        const bool found = matcherScore <= threshold;
-//        cout << matcherScore << endl;
-
-        m_error_coefficient = std::min(m_error_coefficient, matcherScore);
-
-        size_t curStamp = m_matcher->latestTimestamp();
-        // std::cout << "(" << curStamp+1-m_matcher->numTemplateWindows() << ", " <<  curStamp+1 << "): " << matcherScore << 
-        //     (found ? " FOUND!" : "") << std::endl;
-
-        if (found){
-            {
-                SpinLockGuard lg(m_lock);
-                m_screenshot = m_console.video().snapshot();
-            }
-            std::ostringstream os;
-            os << "Alpha roar find, score " << matcherScore << "/" << threshold << ", scale: " << m_matcher->lastMatchedScale();
-            m_console.log(os.str(), COLOR_BLUE);
-            audioFeed.add_overlay(curStamp+1-m_matcher->numTemplateWindows(), curStamp+1, COLOR_RED);
-            // Tell m_matcher to skip the remaining spectrums so that if `process_spectrums()` gets
-            // called again on a newer batch of spectrums, m_matcher is happy.
-            m_matcher->skip(std::vector<AudioSpectrum>(
-                newSpectrums.begin(),
-                newSpectrums.begin() + std::distance(it + 1, newSpectrums.rend())
-            ));
-
-            if (!m_detected.load(std::memory_order_acquire)){
-                m_time_detected = now;
-                m_detected.store(true, std::memory_order_release);
-            }
-
-            break;
-        }
-    }
-
-    if (!m_stop_on_detected){
-        return false;
-    }
-    if (!m_detected.load(std::memory_order_acquire)){
-        return false;
-    }
-
-    //  Don't return true for another 200ms so we can get a measurement of how strong this detection is.
-    return m_time_detected + std::chrono::milliseconds(200) <= now;
+float AlphaRoarDetector::get_score_threshold() const{
+    return (float)GameSettings::instance().ALPHA_ROAR_THRESHOLD;
 }
 
-void AlphaRoarDetector::clear(){
-    m_matcher->clear();
+std::unique_ptr<SpectrogramMatcher> AlphaRoarDetector::build_spectrogram_matcher(size_t sampleRate){
+    const double lowFrequencyFilter = 100.0; // we don't match frequencies under 100.0 Hz
+    return std::make_unique<SpectrogramMatcher>(
+        AudioTemplateCache::instance().get_throw("PokemonLA/AlphaRoar", sampleRate),
+        SpectrogramMatcher::Mode::RAW, sampleRate,
+        lowFrequencyFilter
+    );
 }
+
 
 
 

--- a/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_AlphaRoarDetector.h
+++ b/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_AlphaRoarDetector.h
@@ -10,7 +10,7 @@
 #include <QImage>
 #include "Common/Cpp/SpinLock.h"
 #include "CommonFramework/Logging/LoggerQt.h"
-#include "CommonFramework/InferenceInfra/AudioInferenceCallback.h"
+#include "CommonFramework/Inference/AudioPerSpectrumDetectorBase.h"
 #include "PokemonLA/Options/PokemonLA_ShinyDetectedAction.h"
 
 #include <memory>
@@ -24,38 +24,18 @@ namespace NintendoSwitch{
 namespace PokemonLA{
 
 
-class AlphaRoarDetector : public AudioInferenceCallback{
+class AlphaRoarDetector : public AudioPerSpectrumDetectorBase{
 public:
-    virtual ~AlphaRoarDetector();
     AlphaRoarDetector(ConsoleHandle& console, bool stop_on_detected);
 
-    void log_results();
-
-    bool detected() const{
-        return m_detected.load(std::memory_order_acquire);
-    }
     ShinySoundResults results();
 
-    virtual bool process_spectrums(
-        const std::vector<AudioSpectrum>& newSpectrums,
-        AudioFeed& audioFeed
-    ) override;
+    // Implement AudioPerSpectrumDetectorBase::get_score_threshold()
+    virtual float get_score_threshold() const override;
 
-    // Clear internal data to be used on another audio stream.
-    void clear();
-
-private:
-    ConsoleHandle& m_console;
-    bool m_stop_on_detected;
-
-    SpinLock m_lock;
-    std::atomic<bool> m_detected;
-    WallClock m_time_detected;
-
-    float m_error_coefficient;
-    QImage m_screenshot;
-
-    std::unique_ptr<SpectrogramMatcher> m_matcher;
+protected:
+    // Implement AudioPerSpectrumDetectorBase::build_spectrogram_matcher()
+    virtual std::unique_ptr<SpectrogramMatcher> build_spectrogram_matcher(size_t sampleRate) override;
 };
 
 

--- a/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_AlphaRoarDetector.h
+++ b/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_AlphaRoarDetector.h
@@ -26,9 +26,7 @@ namespace PokemonLA{
 
 class AlphaRoarDetector : public AudioPerSpectrumDetectorBase{
 public:
-    AlphaRoarDetector(ConsoleHandle& console, bool stop_on_detected);
-
-    ShinySoundResults results();
+    AlphaRoarDetector(ConsoleHandle& console, OnShinyCallback on_shiny_callback);
 
     // Implement AudioPerSpectrumDetectorBase::get_score_threshold()
     virtual float get_score_threshold() const override;

--- a/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_ShinySoundDetector.cpp
+++ b/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_ShinySoundDetector.cpp
@@ -106,7 +106,8 @@ bool ShinySoundDetector::process_spectrums(
             std::ostringstream os;
             os << "Shiny sound find, score " << matcherScore << "/" << threshold << ", scale: " << m_matcher->lastMatchedScale();
             m_console.log(os.str(), COLOR_BLUE);
-            audioFeed.add_overlay(curStamp+1-m_matcher->numTemplateWindows(), curStamp+1, COLOR_RED);
+            // Add a green box to the matched sound. Use color green because the shiny symbol in LA is green.
+            audioFeed.add_overlay(curStamp+1-m_matcher->numTemplateWindows(), curStamp+1, COLOR_GREEN);
             // Tell m_matcher to skip the remaining spectrums so that if `process_spectrums()` gets
             // called again on a newer batch of spectrums, m_matcher is happy.
             m_matcher->skip(std::vector<AudioSpectrum>(

--- a/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_ShinySoundDetector.cpp
+++ b/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_ShinySoundDetector.cpp
@@ -24,18 +24,10 @@ namespace NintendoSwitch{
 namespace PokemonLA{
 
 
-ShinySoundDetector::ShinySoundDetector(ConsoleHandle& console, bool stop_on_detected)
+ShinySoundDetector::ShinySoundDetector(ConsoleHandle& console, OnShinyCallback on_shiny_callback)
     // Use a green as the detection color because the shiny symbol in LA is green.
-    : AudioPerSpectrumDetectorBase("ShinySoundDetector", "Shiny sound", COLOR_GREEN, console, stop_on_detected)
+    : AudioPerSpectrumDetectorBase("ShinySoundDetector", "Shiny sound", COLOR_GREEN, console, on_shiny_callback)
 {}
-
-ShinySoundResults ShinySoundDetector::results(){
-    ShinySoundResults results;
-    SpinLockGuard lg(m_lock);
-    results.screenshot = m_screenshot;
-    results.error_coefficient = m_error_coefficient;
-    return results;
-}
 
 
 float ShinySoundDetector::get_score_threshold() const{
@@ -49,136 +41,6 @@ std::unique_ptr<SpectrogramMatcher> ShinySoundDetector::build_spectrogram_matche
         GameSettings::instance().SHINY_SHOUND_LOW_FREQUENCY
     );
 }
-
-
-
-
-
-
-
-
-ShinySoundDetector2::~ShinySoundDetector2(){
-    try{
-        log_results();
-    }catch (...){}
-}
-ShinySoundDetector2::ShinySoundDetector2(ConsoleHandle& console, std::function<bool(float error_coefficient)> on_shiny_callback)
-    : AudioInferenceCallback("ShinySoundDetector")
-    , m_console(console)
-    , m_on_shiny_callback(std::move(on_shiny_callback))
-    , m_lowest_error(1.0)
-    , m_last_timestamp(WallClock::min())
-    , m_last_error(1.0)
-    , m_last_reported(false)
-{}
-void ShinySoundDetector2::log_results(){
-    std::stringstream ss;
-    ss << m_lowest_error;
-    if (m_last_timestamp != WallClock::min()){
-        m_console.log("Shiny detected! Error Coefficient = " + ss.str(), COLOR_BLUE);
-    }else{
-        m_console.log("No shiny detected. Error Coefficient = " + ss.str(), COLOR_PURPLE);
-    }
-}
-
-
-bool ShinySoundDetector2::process_spectrums(
-    const std::vector<AudioSpectrum>& newSpectrums,
-    AudioFeed& audioFeed
-){
-    if (newSpectrums.empty()){
-        return false;
-    }
-
-    WallClock now = current_time();
-
-    //  Clear last detection.
-    if (m_last_timestamp + std::chrono::milliseconds(1000) <= now){
-        m_last_error = 1.0;
-        m_last_reported = false;
-    }
-
-    size_t sampleRate = newSpectrums[0].sample_rate;
-    if (m_matcher == nullptr || m_matcher->sampleRate() != sampleRate){
-        m_console.log("Loading spectrogram...");
-        m_matcher = std::make_unique<SpectrogramMatcher>(
-            AudioTemplateCache::instance().get_throw("PokemonLA/ShinySound", sampleRate),
-            SpectrogramMatcher::Mode::SPIKE_CONV, sampleRate,
-            GameSettings::instance().SHINY_SHOUND_LOW_FREQUENCY
-        );
-    }
-
-    // Feed spectrum one by one to the matcher:
-    // newSpectrums are ordered from newest (largest timestamp) to oldest (smallest timestamp).
-    // To feed the spectrum from old to new, we need to go through the vector in the reverse order:
-
-//    static int c = 0;
-//    c++;
-    bool found = false;
-    for (auto it = newSpectrums.rbegin(); it != newSpectrums.rend(); it++){
-        std::vector<AudioSpectrum> singleSpectrum = {*it};
-        float matcherScore = m_matcher->match(singleSpectrum);
-
-        if (matcherScore == FLT_MAX){
-            continue; // error or not enough spectrum history
-        }
-
-        const float threshold = (float)GameSettings::instance().SHINY_SHOUND_THRESHOLD2;
-        found = matcherScore <= threshold;
-//        cout << matcherScore << endl;
-
-        m_lowest_error = std::min(m_lowest_error, matcherScore);
-
-        size_t curStamp = m_matcher->latestTimestamp();
-        // std::cout << "(" << curStamp+1-m_matcher->numTemplateWindows() << ", " <<  curStamp+1 << "): " << matcherScore <<
-        //     (found ? " FOUND!" : "") << std::endl;
-
-        if (found){
-            if (m_last_error >= 1.0){
-                m_last_timestamp = now;
-            }
-            m_last_error = std::min(m_last_error, matcherScore);
-
-            std::ostringstream os;
-            os << "Shiny sound find, score " << matcherScore << "/" << threshold << ", scale: " << m_matcher->lastMatchedScale();
-            m_console.log(os.str(), COLOR_BLUE);
-            audioFeed.add_overlay(curStamp+1-m_matcher->numTemplateWindows(), curStamp+1, COLOR_RED);
-            // Tell m_matcher to skip the remaining spectrums so that if `process_spectrums()` gets
-            // called again on a newer batch of spectrums, m_matcher is happy.
-            m_matcher->skip(std::vector<AudioSpectrum>(
-                newSpectrums.begin(),
-                newSpectrums.begin() + std::distance(it + 1, newSpectrums.rend())
-            ));
-
-            break;
-        }
-    }
-
-    //  No shiny detected.
-    if (!found){
-        return false;
-    }
-
-    //  Shiny detected, but haven't waited long enough to measure its magnitude.
-    if (m_last_timestamp + std::chrono::milliseconds(200) > now){
-        return false;
-    }
-
-    //  Already reported this shiny. Don't report again.
-    if (m_last_reported){
-        return false;
-    }
-
-    //  No callback. Can't report.
-    if (m_on_shiny_callback == nullptr){
-        return false;
-    }
-
-    bool ret = m_on_shiny_callback(m_last_error);
-    m_last_reported = true;
-    return ret;
-}
-
 
 
 

--- a/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_ShinySoundDetector.h
+++ b/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_ShinySoundDetector.h
@@ -11,7 +11,7 @@
 #include <QImage>
 #include "Common/Cpp/SpinLock.h"
 #include "CommonFramework/Logging/LoggerQt.h"
-#include "CommonFramework/InferenceInfra/AudioInferenceCallback.h"
+#include "CommonFramework/Inference/AudioPerSpectrumDetectorBase.h"
 #include "PokemonLA/Options/PokemonLA_ShinyDetectedAction.h"
 
 #include <memory>
@@ -25,38 +25,18 @@ namespace NintendoSwitch{
 namespace PokemonLA{
 
 
-class ShinySoundDetector : public AudioInferenceCallback{
+class ShinySoundDetector : public AudioPerSpectrumDetectorBase{
 public:
-    virtual ~ShinySoundDetector();
     ShinySoundDetector(ConsoleHandle& console, bool stop_on_detected);
 
-    void log_results();
-
-    bool detected() const{
-        return m_detected.load(std::memory_order_acquire);
-    }
     ShinySoundResults results();
 
-    virtual bool process_spectrums(
-        const std::vector<AudioSpectrum>& newSpectrums,
-        AudioFeed& audioFeed
-    ) override;
+    // Implement AudioPerSpectrumDetectorBase::get_score_threshold()
+    virtual float get_score_threshold() const override;
 
-    // Clear internal data to be used on another audio stream.
-    void clear();
-
-private:
-    ConsoleHandle& m_console;
-    bool m_stop_on_detected;
-
-    SpinLock m_lock;
-    std::atomic<bool> m_detected;
-    WallClock m_time_detected;
-
-    float m_error_coefficient;
-    QImage m_screenshot;
-
-    std::unique_ptr<SpectrogramMatcher> m_matcher;
+protected:
+    // Implement AudioPerSpectrumDetectorBase::build_spectrogram_matcher()
+    virtual std::unique_ptr<SpectrogramMatcher> build_spectrogram_matcher(size_t sampleRate) override;
 };
 
 

--- a/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_ShinySoundDetector.h
+++ b/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_ShinySoundDetector.h
@@ -27,9 +27,7 @@ namespace PokemonLA{
 
 class ShinySoundDetector : public AudioPerSpectrumDetectorBase{
 public:
-    ShinySoundDetector(ConsoleHandle& console, bool stop_on_detected);
-
-    ShinySoundResults results();
+    ShinySoundDetector(ConsoleHandle& console, OnShinyCallback on_shiny_callback);
 
     // Implement AudioPerSpectrumDetectorBase::get_score_threshold()
     virtual float get_score_threshold() const override;
@@ -37,42 +35,6 @@ public:
 protected:
     // Implement AudioPerSpectrumDetectorBase::build_spectrogram_matcher()
     virtual std::unique_ptr<SpectrogramMatcher> build_spectrogram_matcher(size_t sampleRate) override;
-};
-
-
-
-//  New version that fires callback on shiny instead of setting internal state.
-//  This one will fire multiple times if multiple shinies are detected with
-//  sufficient time separation.
-class ShinySoundDetector2 : public AudioInferenceCallback{
-public:
-    virtual ~ShinySoundDetector2();
-
-    //  The return value of "on_shiny_callback" will be passed to the return
-    //  value of "process_spectrums()". Thus returning true will stop the session.
-    ShinySoundDetector2(
-        ConsoleHandle& console,
-        std::function<bool(float error_coefficient)> on_shiny_callback
-    );
-
-    void log_results();
-
-    virtual bool process_spectrums(
-        const std::vector<AudioSpectrum>& newSpectrums,
-        AudioFeed& audioFeed
-    ) override;
-
-private:
-    ConsoleHandle& m_console;
-    std::function<bool(float error_coefficient)> m_on_shiny_callback;
-
-    float m_lowest_error;
-
-    WallClock m_last_timestamp;
-    float m_last_error;
-    bool m_last_reported;
-
-    std::unique_ptr<SpectrogramMatcher> m_matcher;
 };
 
 

--- a/SerialPrograms/Source/PokemonLA/Panels_PokemonLA.cpp
+++ b/SerialPrograms/Source/PokemonLA/Panels_PokemonLA.cpp
@@ -36,6 +36,7 @@
 #include "Programs/TestPrograms/PokemonLA_ShinySoundListener.h"
 #include "Programs/TestPrograms/PokemonLA_FlagNavigationTest.h"
 #include "Programs/TestPrograms/PokemonLA_AlphaRoarListener.h"
+#include "Programs/TestPrograms/PokemonLA_AlphaMusicListener.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
@@ -82,6 +83,7 @@ Panels::Panels(QTabWidget& parent, PanelListener& listener)
         add_program<OverworldWatcher_Descriptor, OverworldWatcher>();
         add_program<ShinySoundListener_Descriptor, ShinySoundListener>();
         add_program<AlphaRoarListener_Descriptor, AlphaRoarListener>();
+        add_program<AlphaMusicListener_Descriptor, AlphaMusicListener>();
         add_program<FlagNavigationTest_Descriptor, FlagNavigationTest>();
     }
 

--- a/SerialPrograms/Source/PokemonLA/PokemonLA_Settings.cpp
+++ b/SerialPrograms/Source/PokemonLA/PokemonLA_Settings.cpp
@@ -72,6 +72,10 @@ GameSettings::GameSettings()
         "<b>Alpha Roar Threshold:</b><br>Maximum error coefficient to trigger an alpha roar detection.",
         0.65, 0, 1.0
     )
+    , ALPHA_MUSIC_THRESHOLD(
+        "<b>Alpha Music Threshold:</b><br>Maximum error coefficient to trigger an alpha music detection.",
+        0.61, 0, 1.0
+    )
 {
     PA_ADD_STATIC(m_general);
     PA_ADD_OPTION(POST_WARP_DELAY);

--- a/SerialPrograms/Source/PokemonLA/PokemonLA_Settings.h
+++ b/SerialPrograms/Source/PokemonLA/PokemonLA_Settings.h
@@ -42,6 +42,7 @@ public:
     FloatingPointOption SHINY_SHOUND_THRESHOLD2;
     FloatingPointOption SHINY_SHOUND_LOW_FREQUENCY;
     FloatingPointOption ALPHA_ROAR_THRESHOLD;
+    FloatingPointOption ALPHA_MUSIC_THRESHOLD;
 };
 
 

--- a/SerialPrograms/Source/PokemonLA/Programs/PokemonLA_EscapeFromAttack.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/PokemonLA_EscapeFromAttack.cpp
@@ -18,25 +18,21 @@ namespace PokemonLA{
 EscapeFromAttack::EscapeFromAttack(
     ProgramEnvironment& env, ConsoleHandle& console, BotBaseContext& context,
     std::chrono::seconds time_min,
-    std::chrono::seconds time_limit,
-    bool stop_on_shiny
+    std::chrono::seconds time_limit
 )
     : SuperControlSession(env, console, context)
     , m_min_stop(current_time() + time_min)
     , m_deadline(current_time() + time_limit)
-    , m_stop_on_shiny(stop_on_shiny)
     , m_attacked(console)
     , m_mount(console)
     , m_centerA(console, console, ButtonType::ButtonA, {0.40, 0.50, 0.40, 0.50}, std::chrono::milliseconds(200), false)
     , m_leftB(console, console, ButtonType::ButtonB, {0.02, 0.40, 0.05, 0.20}, std::chrono::milliseconds(200), false)
-    , m_shiny_listener(console, false)
     , m_get_on_sneasler_time(WallClock::min())
 {
     *this += m_attacked;
     *this += m_mount;
     *this += m_centerA;
     *this += m_leftB;
-    *this += m_shiny_listener;
 
     const std::chrono::milliseconds GET_ON_BRAVIARY_TIME_MILLIS(GET_ON_BRAVIARY_TIME * 1000 / TICKS_PER_SECOND);
 
@@ -139,10 +135,6 @@ bool EscapeFromAttack::run_state(AsyncCommandSession& commands, WallClock timest
         return true;
     }
     if (m_attacked.state() == UnderAttackState::SAFE && timestamp >= m_min_stop){
-        return true;
-    }
-    if (m_stop_on_shiny && m_shiny_listener.detected()){
-//        cout << "EscapeFromAttack::run_state(): shiny out" << endl;
         return true;
     }
 

--- a/SerialPrograms/Source/PokemonLA/Programs/PokemonLA_EscapeFromAttack.h
+++ b/SerialPrograms/Source/PokemonLA/Programs/PokemonLA_EscapeFromAttack.h
@@ -23,18 +23,11 @@ public:
     EscapeFromAttack(
         ProgramEnvironment& env, ConsoleHandle& console, BotBaseContext& context,
         std::chrono::seconds time_min,
-        std::chrono::seconds time_limit,
-        bool stop_on_shiny
+        std::chrono::seconds time_limit
     );
 
     UnderAttackState state() const{
         return m_attacked.state();
-    }
-    bool detected_shiny() const{
-        return m_shiny_listener.detected();
-    }
-    ShinySoundResults shiny_sound_results(){
-        return m_shiny_listener.results();
     }
 
 
@@ -71,13 +64,11 @@ private:
 
     const WallClock m_min_stop;
     const WallClock m_deadline;
-    const bool m_stop_on_shiny;
 
     UnderAttackWatcher m_attacked;
     MountTracker m_mount;
     ButtonDetector m_centerA;
     ButtonDetector m_leftB;
-    ShinySoundDetector m_shiny_listener;
 
     WallClock m_get_on_sneasler_time;
 };

--- a/SerialPrograms/Source/PokemonLA/Programs/PokemonLA_FlagNavigationAir.h
+++ b/SerialPrograms/Source/PokemonLA/Programs/PokemonLA_FlagNavigationAir.h
@@ -70,7 +70,6 @@ private:
         return SuperControlSession::run_state_action((size_t)state);
     }
 
-    bool m_stop_on_shiny;
     uint16_t m_stop_radius;
     std::chrono::milliseconds m_flag_reached_delay;
     std::chrono::seconds m_navigate_timeout;

--- a/SerialPrograms/Source/PokemonLA/Programs/PokemonLA_RegionNavigation.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/PokemonLA_RegionNavigation.cpp
@@ -301,23 +301,17 @@ void goto_camp_from_jubilife(
 
 
 void goto_camp_from_overworld(
-    ProgramEnvironment& env, ConsoleHandle& console, BotBaseContext& context,
-    ShinyDetectedActionOption& options,
-    ShinyStatIncrementer& shiny_stat_incrementer
+    ProgramEnvironment& env, ConsoleHandle& console, BotBaseContext& context
 ){
     auto start = current_time();
     std::chrono::seconds grace_period(0);
     while (true){
-        EscapeFromAttack session(
-            env, console, context,
-            grace_period, std::chrono::seconds(10),
-            options.stop_on_shiny()
-        );
-        session.run_session();
-
-        if (session.detected_shiny()){
-            shiny_stat_incrementer.add_shiny();
-            on_shiny_sound(env, console, context, options, session.shiny_sound_results());
+        {
+            EscapeFromAttack session(
+                env, console, context,
+                grace_period, std::chrono::seconds(10)
+            );
+            session.run_session();
         }
 
         if (current_time() - start > std::chrono::seconds(60)){

--- a/SerialPrograms/Source/PokemonLA/Programs/PokemonLA_RegionNavigation.h
+++ b/SerialPrograms/Source/PokemonLA/Programs/PokemonLA_RegionNavigation.h
@@ -38,9 +38,7 @@ void goto_camp_from_jubilife(
 
 
 void goto_camp_from_overworld(
-    ProgramEnvironment& env, ConsoleHandle& console, BotBaseContext& context,
-    ShinyDetectedActionOption& options,
-    ShinyStatIncrementer& shiny_stat_incrementer
+    ProgramEnvironment& env, ConsoleHandle& console, BotBaseContext& context
 );
 
 

--- a/SerialPrograms/Source/PokemonLA/Programs/ShinyHunting/PokemonLA_CrobatFinder.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/ShinyHunting/PokemonLA_CrobatFinder.cpp
@@ -118,7 +118,16 @@ void CrobatFinder::run_iteration(SingleSwitchProgramEnvironment& env, BotBaseCon
     env.console.log("Beginning Shiny Detection...");
     // start the shiny detection, there's nothing initially
     {
-        ShinySoundDetector shiny_detector(env.console, SHINY_DETECTED.stop_on_shiny());
+        bool shiny_detected = false;
+        ShinySoundResults shiny_results;
+        ShinySoundDetector shiny_detector(env.console, [&](float error_coefficient) -> bool{
+            // This lambda function will be called when a shiny is detected.
+            // Its return will determine whether to stop the program:
+            shiny_detected = true;
+            shiny_results.screenshot = env.console.video().snapshot();
+            shiny_results.error_coefficient = error_coefficient;
+            return SHINY_DETECTED.stop_on_shiny();
+        });
         run_until(
             env.console, context,
             [](BotBaseContext& context){
@@ -142,9 +151,9 @@ void CrobatFinder::run_iteration(SingleSwitchProgramEnvironment& env, BotBaseCon
             },
             {{shiny_detector}}
         );
-        if (shiny_detector.detected()){
-           stats.shinies++;
-           on_shiny_sound(env, env.console, context, SHINY_DETECTED, shiny_detector.results());
+        if (shiny_detected){
+            stats.shinies++;
+            on_shiny_sound(env, env.console, context, SHINY_DETECTED, shiny_results);
         }
     };
 

--- a/SerialPrograms/Source/PokemonLA/Programs/ShinyHunting/PokemonLA_ShinyHunt-FlagPin.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/ShinyHunting/PokemonLA_ShinyHunt-FlagPin.cpp
@@ -99,7 +99,17 @@ void ShinyHuntFlagPin::run_iteration(SingleSwitchProgramEnvironment& env, BotBas
 
     {
         //  Outer scope with shiny detection wrapping everything.
-        ShinySoundDetector shiny_detector(env.console, SHINY_DETECTED.stop_on_shiny());
+        bool shiny_detected = false;
+        ShinySoundResults shiny_results;
+        ShinySoundDetector shiny_detector(env.console, [&](float error_coefficient) -> bool{
+            // This lambda function will be called when a shiny is detected.
+            // Its return will determine whether to stop the program:
+            shiny_detected = true;
+            
+            shiny_results.screenshot = env.console.video().snapshot();
+            shiny_results.error_coefficient = error_coefficient;
+            return SHINY_DETECTED.stop_on_shiny();
+        });
         run_until(
             env.console, context,
             [&](BotBaseContext& context){
@@ -115,9 +125,9 @@ void ShinyHuntFlagPin::run_iteration(SingleSwitchProgramEnvironment& env, BotBas
             },
             {{shiny_detector}}
         );
-        if (shiny_detector.detected()){
+        if (shiny_detected){
             stats.shinies++;
-            on_shiny_sound(env, env.console, context, SHINY_DETECTED, shiny_detector.results());
+            on_shiny_sound(env, env.console, context, SHINY_DETECTED, shiny_results);
         }
     }
 

--- a/SerialPrograms/Source/PokemonLA/Programs/TestPrograms/PokemonLA_AlphaMusicListener.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/TestPrograms/PokemonLA_AlphaMusicListener.cpp
@@ -1,0 +1,81 @@
+/*  Alpha Music Listener
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include <float.h>
+#include <chrono>
+#include <map>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include "CommonFramework/Tools/AudioFeed.h"
+#include "CommonFramework/Tools/StatsTracking.h"
+#include "CommonFramework/Tools/VideoOverlaySet.h"
+#include "CommonFramework/AudioPipeline/AudioTemplate.h"
+#include "CommonFramework/InferenceInfra/InferenceSession.h"
+#include "CommonFramework/Inference/AudioTemplateCache.h"
+#include "CommonFramework/Inference/SpectrogramMatcher.h"
+#include "NintendoSwitch/Commands/NintendoSwitch_Commands_PushButtons.h"
+#include "NintendoSwitch/NintendoSwitch_Settings.h"
+#include "PokemonLA/PokemonLA_Settings.h"
+#include "PokemonLA_AlphaMusicListener.h"
+#include "PokemonLA/Inference/PokemonLA_AlphaMusicDetector.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonLA{
+
+AlphaMusicListener_Descriptor::AlphaMusicListener_Descriptor()
+    : RunnableSwitchProgramDescriptor(
+        "PokemonLA:AlphaMusicListener",
+        STRING_POKEMON + " LA", "Alpha Music Listener",
+        "",
+        "Detect alpha music from audio stream.",
+        FeedbackType::REQUIRED, true,
+        PABotBaseLevel::PABOTBASE_12KB
+    )
+{}
+
+
+AlphaMusicListener::AlphaMusicListener(const AlphaMusicListener_Descriptor& descriptor)
+    : SingleSwitchProgramInstance(descriptor)
+    , STOP_ON_ALPHA_MUSIC("<b>Stop on Alpha Music</b><br>Stop program when alpha music is heard.", false)
+{
+    PA_ADD_OPTION(STOP_ON_ALPHA_MUSIC);
+}
+
+
+void searchAlphaRoarFromAudioDump();
+
+void AlphaMusicListener::program(SingleSwitchProgramEnvironment& env, BotBaseContext& context){
+    //  Connect the controller.
+    // pbf_move_right_joystick(context, 0, 255, 10, 0);
+
+    // searchAlphaRoarFromAudioDump();
+    // return;
+
+    std::cout << "Running audio test program." << std::endl;
+    
+    AlphaMusicDetector detector(env.console, [&](float error_coefficient) -> bool{
+        // This lambda function will be called when an alpha roar is detected.
+        // Its return will determine whether to stop the program:
+        return STOP_ON_ALPHA_MUSIC;
+    });
+
+    InferenceSession session(
+        context, env.console,
+        {{detector, std::chrono::milliseconds(20)}}
+    );
+    context.wait_until_cancel();
+
+
+    std::cout << "Audio test program finished." << std::endl;
+}
+
+
+
+}
+}
+}

--- a/SerialPrograms/Source/PokemonLA/Programs/TestPrograms/PokemonLA_AlphaMusicListener.h
+++ b/SerialPrograms/Source/PokemonLA/Programs/TestPrograms/PokemonLA_AlphaMusicListener.h
@@ -1,0 +1,41 @@
+/*  Alpha Music Listener
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonLA_AlphaMusicListener_H
+#define PokemonAutomation_PokemonLA_AlphaMusicListener_H
+
+#include "CommonFramework/Options/BooleanCheckBoxOption.h"
+#include "NintendoSwitch/Framework/NintendoSwitch_SingleSwitchProgram.h"
+#include "NintendoSwitch/Options/GoHomeWhenDoneOption.h"
+
+namespace PokemonAutomation{ 
+namespace NintendoSwitch{
+namespace PokemonLA{
+
+
+class AlphaMusicListener_Descriptor : public RunnableSwitchProgramDescriptor{
+public:
+    AlphaMusicListener_Descriptor();
+};
+
+
+class AlphaMusicListener : public SingleSwitchProgramInstance{
+public:
+    AlphaMusicListener(const AlphaMusicListener_Descriptor& descriptor);
+
+    virtual void program(SingleSwitchProgramEnvironment& env, BotBaseContext& context) override;
+
+private:
+    BooleanCheckBoxOption STOP_ON_ALPHA_MUSIC;
+};
+
+
+
+
+}
+}
+}
+#endif

--- a/SerialPrograms/Source/PokemonLA/Programs/TestPrograms/PokemonLA_AlphaRoarListener.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/TestPrograms/PokemonLA_AlphaRoarListener.cpp
@@ -58,7 +58,11 @@ void AlphaRoarListener::program(SingleSwitchProgramEnvironment& env, BotBaseCont
 
     std::cout << "Running audio test program." << std::endl;
     
-    AlphaRoarDetector detector(env.console, STOP_ON_ALPHA_ROAR);
+    AlphaRoarDetector detector(env.console, [&](float error_coefficient) -> bool{
+        // This lambda function will be called when an alpha roar is detected.
+        // Its return will determine whether to stop the program:
+        return STOP_ON_ALPHA_ROAR;
+    });
 
     InferenceSession session(
         context, env.console,
@@ -70,7 +74,7 @@ void AlphaRoarListener::program(SingleSwitchProgramEnvironment& env, BotBaseCont
     std::cout << "Audio test program finished." << std::endl;
 }
 
-// A function used to search for the shiny sound on LA audio dump.
+// A function used to search for the alpha roar on LA audio dump.
 // But we didn't find the shound sound :P
 void searchAlphaRoarFromAudioDump(){
 
@@ -121,7 +125,7 @@ void searchAlphaRoarFromAudioDump(){
         // match!
         float minScore = FLT_MAX;
         std::vector<AudioSpectrum> newSpectrums;
-        size_t numStreamWindows = std::max(matcher.numTemplateWindows(), audio.numWindows());
+        size_t numStreamWindows = std::max(matcher.numMatchedWindows(), audio.numWindows());
         for(size_t audioIdx = 0; audioIdx < numStreamWindows; audioIdx++){
             newSpectrums.clear();
             AlignedVector<float> freqVector(audio.numFrequencies());

--- a/SerialPrograms/Source/PokemonLA/Programs/TestPrograms/PokemonLA_AlphaRoarListener.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/TestPrograms/PokemonLA_AlphaRoarListener.cpp
@@ -15,6 +15,7 @@
 #include "CommonFramework/Tools/VideoOverlaySet.h"
 #include "CommonFramework/AudioPipeline/AudioTemplate.h"
 #include "CommonFramework/InferenceInfra/InferenceSession.h"
+#include "CommonFramework/Inference/AudioTemplateCache.h"
 #include "CommonFramework/Inference/SpectrogramMatcher.h"
 #include "NintendoSwitch/Commands/NintendoSwitch_Commands_PushButtons.h"
 #include "NintendoSwitch/NintendoSwitch_Settings.h"
@@ -75,9 +76,9 @@ void searchAlphaRoarFromAudioDump(){
 
     const size_t SAMPLE_RATE = 48000;
 
-    QString shinyFilename = "../Resources/PokemonLA/AlphaRoar-48000.wav";
     SpectrogramMatcher matcher(
-        shinyFilename, SpectrogramMatcher::Mode::NO_CONV, SAMPLE_RATE,
+        AudioTemplateCache::instance().get_throw("PokemonLA/AlphaRoar", SAMPLE_RATE),
+        SpectrogramMatcher::Mode::RAW, SAMPLE_RATE,
         100.0
     );
     

--- a/SerialPrograms/Source/PokemonLA/Programs/TestPrograms/PokemonLA_ShinySoundListener.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/TestPrograms/PokemonLA_ShinySoundListener.cpp
@@ -15,6 +15,7 @@
 #include "CommonFramework/Tools/VideoOverlaySet.h"
 #include "CommonFramework/AudioPipeline/AudioTemplate.h"
 #include "CommonFramework/InferenceInfra/InferenceSession.h"
+#include "CommonFramework/Inference/AudioTemplateCache.h"
 #include "CommonFramework/Inference/SpectrogramMatcher.h"
 #include "NintendoSwitch/Commands/NintendoSwitch_Commands_PushButtons.h"
 #include "NintendoSwitch/NintendoSwitch_Settings.h"
@@ -75,9 +76,9 @@ void searchShinySoundFromAudioDump(){
 
     const size_t SAMPLE_RATE = 48000;
 
-    QString shinyFilename = "./heracrossShinyTemplateCompact.wav";
     SpectrogramMatcher matcher(
-        shinyFilename, SpectrogramMatcher::Mode::SPIKE_CONV, SAMPLE_RATE,
+        AudioTemplateCache::instance().get_throw("PokemonLA/ShinySound", SAMPLE_RATE),
+        SpectrogramMatcher::Mode::SPIKE_CONV, SAMPLE_RATE,
         GameSettings::instance().SHINY_SHOUND_LOW_FREQUENCY
     );
     

--- a/SerialPrograms/Source/PokemonLA/Programs/TestPrograms/PokemonLA_ShinySoundListener.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/TestPrograms/PokemonLA_ShinySoundListener.cpp
@@ -58,7 +58,11 @@ void ShinySoundListener::program(SingleSwitchProgramEnvironment& env, BotBaseCon
     std::cout << "Running audio test program." << std::endl;
 
     
-    ShinySoundDetector detector(env.console, STOP_ON_SHINY_SOUND);
+    ShinySoundDetector detector(env.console, [&](float error_coefficient) -> bool{
+        // This lambda function will be called when a shiny is detected.
+        // Its return will determine whether to stop the program:
+        return STOP_ON_SHINY_SOUND;
+    });
 
     InferenceSession session(
         context, env.console,
@@ -121,7 +125,7 @@ void searchShinySoundFromAudioDump(){
         // match!
         float minScore = FLT_MAX;
         std::vector<AudioSpectrum> newSpectrums;
-        size_t numStreamWindows = std::max(matcher.numTemplateWindows(), audio.numWindows());
+        size_t numStreamWindows = std::max(matcher.numMatchedWindows(), audio.numWindows());
         for(size_t audioIdx = 0; audioIdx < numStreamWindows; audioIdx++){
             newSpectrums.clear();
             AlignedVector<float> freqVector(audio.numFrequencies());


### PR DESCRIPTION
- Change SpectrogramMatcher to prepare for more complex matching.
- Add an audio detection base class to remove similar code on each audio detector.
- Use the newer detector interface on all programs.
- Add alpha music detector