### PR TITLE
More trees for Burmy

### DIFF
--- a/SerialPrograms/Source/PokemonLA/Programs/ShinyHunting/PokemonLA_BurmyFinder.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/ShinyHunting/PokemonLA_BurmyFinder.cpp
@@ -10,6 +10,7 @@
 #include "CommonFramework/Tools/StatsTracking.h"
 #include "NintendoSwitch/NintendoSwitch_Settings.h"
 #include "PokemonLA/PokemonLA_Settings.h"
+#include "PokemonLA/Inference/Battles/PokemonLA_BattleMenuDetector.h"
 #include "PokemonLA/Inference/PokemonLA_OverworldDetector.h"
 #include "PokemonLA/Inference/PokemonLA_StatusInfoScreenDetector.h"
 #include "PokemonLA/Inference/Sounds/PokemonLA_ShinySoundDetector.h"
@@ -17,6 +18,8 @@
 #include "PokemonLA/Programs/PokemonLA_GameEntry.h"
 #include "PokemonLA/Programs/ShinyHunting/PokemonLA_BurmyFinder.h"
 #include "PokemonLA/Programs/PokemonLA_LeapPokemonActions.h"
+
+#include <sstream>
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
@@ -87,6 +90,7 @@ class BurmyFinder::Stats : public StatsTracker{
 public:
     Stats()
         : attempts(m_stats["Attempts"])
+        , trees(m_stats["Trees"])
         , errors(m_stats["Errors"])
         , found(m_stats["Found"])
         , enroute_shinies(m_stats["Enroute Shinies"])
@@ -94,6 +98,7 @@ public:
         , tree_shinies(m_stats["Tree Shinies"])
     {
         m_display_order.emplace_back("Attempts");
+        m_display_order.emplace_back("Trees");
         m_display_order.emplace_back("Errors", true);
         m_display_order.emplace_back("Found");
         m_display_order.emplace_back("Enroute Shinies");
@@ -104,6 +109,7 @@ public:
     }
 
     std::atomic<uint64_t>& attempts;
+    std::atomic<uint64_t>& trees;
     std::atomic<uint64_t>& errors;
     std::atomic<uint64_t>& found;
     std::atomic<uint64_t>& enroute_shinies;
@@ -118,96 +124,117 @@ std::unique_ptr<StatsTracker> BurmyFinder::make_stats() const{
 
 
 struct BurmyFinder::TreeCounter{
-    uint64_t tree0 = 0;
-    uint64_t tree1 = 0;
-    uint64_t tree2 = 0;
-    uint64_t tree3 = 0;
-    uint64_t tree4 = 0;
-    uint64_t tree5 = 0;
-
+    std::array<uint64_t, 10> tree = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    
     void log(Logger& logger) const{
-        std::string str;
-        str += "Tree0: " + tostr_u_commas(tree0);
-        str += " - Tree1: " + tostr_u_commas(tree1);
-        str += " - Tree2: " + tostr_u_commas(tree2);
-        str += " - Tree3: " + tostr_u_commas(tree3);
-        str += " - Tree4: " + tostr_u_commas(tree4);
-        str += " - Tree5: " + tostr_u_commas(tree5);
-        logger.log(str);
+        std::ostringstream oss;
+        for(size_t i = 0; i < 10; i++){
+            if (i != 0){
+                oss << " - ";
+            }
+            oss << "Tree" << i << ": " << tostr_u_commas(tree[i]);
+        }
+        logger.log(oss.str());
     }
 };
 
-
-bool BurmyFinder::check_tree(SingleSwitchProgramEnvironment& env, BotBaseContext& context){
+bool BurmyFinder::handle_battle(SingleSwitchProgramEnvironment& env, BotBaseContext& context){
     Stats& stats = env.stats<Stats>();
 
-    bool battle_found = check_tree_or_ore_for_battle(env.console, context);
+    PokemonDetails pokemon = get_pokemon_details(env.console, context, LANGUAGE);
+
+    pbf_press_button(context, BUTTON_B, 20, 225);
 
     context.wait_for_all_requests();
 
-    if (battle_found){
-
-        PokemonDetails pokemon = get_pokemon_details(env.console, context, LANGUAGE);
-
-        pbf_press_button(context, BUTTON_B, 20, 225);
-
-        context.wait_for_all_requests();
-
-        if (pokemon.name_candidates.find("burmy") == pokemon.name_candidates.end()){
-            env.console.log("Not a burmy. Leaving battle.");
-            exit_battle(env.console, context, EXIT_METHOD == 1);
-            return false;
-        }
-
-        stats.found++;
-        //  Match validation
-
-        if (pokemon.is_alpha && pokemon.is_shiny){
-            env.console.log("Found Shiny Alpha!");
-            stats.tree_shinies++;
-            stats.tree_alphas++;
-        }else if (pokemon.is_alpha){
-            env.console.log("Found Alpha!");
-            stats.tree_alphas++;
-        }else if (pokemon.is_shiny){
-            env.console.log("Found Shiny!");
-            stats.tree_shinies++;
-        }else{
-            env.console.log("Normie in the tree -_-");
-        }
-        env.update_stats();
-
-        bool is_match = false;
-        switch (STOP_ON){
-        case 0: //  Shiny
-            is_match = pokemon.is_shiny;
-            break;
-        case 1: //  Alpha
-            is_match = pokemon.is_alpha;
-            break;
-        case 2: //  Shiny and Alpha
-            is_match = pokemon.is_alpha && pokemon.is_shiny;
-            break;
-        case 3: //  Shiny or Alpha
-            is_match = pokemon.is_alpha || pokemon.is_shiny;
-            break;
-        }
-
-        if (pokemon.is_alpha || pokemon.is_shiny){
-            on_match_found(env, env.console, context, MATCH_DETECTED_OPTIONS, is_match);
-        }
-
+    if (pokemon.name_candidates.find("burmy") == pokemon.name_candidates.end()){
+        env.console.log("Not a burmy. Leaving battle.");
         exit_battle(env.console, context, EXIT_METHOD == 1);
-
-        return true;
+        return false;
     }
 
-    return false;
+    stats.found++;
+    //  Match validation
+
+    if (pokemon.is_alpha && pokemon.is_shiny){
+        env.console.log("Found Shiny Alpha!");
+        stats.tree_shinies++;
+        stats.tree_alphas++;
+    }else if (pokemon.is_alpha){
+        env.console.log("Found Alpha!");
+        stats.tree_alphas++;
+    }else if (pokemon.is_shiny){
+        env.console.log("Found Shiny!");
+        stats.tree_shinies++;
+    }else{
+        env.console.log("Normie in the tree -_-");
+    }
+    env.update_stats();
+
+    bool is_match = false;
+    switch (STOP_ON){
+    case 0: //  Shiny
+        is_match = pokemon.is_shiny;
+        break;
+    case 1: //  Alpha
+        is_match = pokemon.is_alpha;
+        break;
+    case 2: //  Shiny and Alpha
+        is_match = pokemon.is_alpha && pokemon.is_shiny;
+        break;
+    case 3: //  Shiny or Alpha
+        is_match = pokemon.is_alpha || pokemon.is_shiny;
+        break;
+    }
+
+    if (pokemon.is_alpha || pokemon.is_shiny){
+        on_match_found(env, env.console, context, MATCH_DETECTED_OPTIONS, is_match);
+    }
+
+    exit_battle(env.console, context, EXIT_METHOD == 1);
+
+    return true;
+}
+
+
+bool BurmyFinder::check_tree(SingleSwitchProgramEnvironment& env, BotBaseContext& context){
+    disable_shiny_sound(context);
+    bool battle_found = check_tree_or_ore_for_battle(env.console, context);
+    env.stats<Stats>().trees++;
+    env.update_stats();
+
+    context.wait_for_all_requests();
+
+    bool ret = false;
+    if (battle_found){
+        ret = handle_battle(env, context);
+    }
+
+    enable_shiny_sound(context);
+
+    return ret;
+}
+
+void BurmyFinder::check_tree_no_stop(SingleSwitchProgramEnvironment& env, BotBaseContext& context){
+    // Throw pokemon
+    pbf_press_button(context, BUTTON_ZR, (0.5 * TICKS_PER_SECOND), 1.5 * TICKS_PER_SECOND);
+    env.stats<Stats>().trees++;
+    env.update_stats();
+}
+
+void BurmyFinder::disable_shiny_sound(BotBaseContext& context){
+    context.wait_for_all_requests();
+    m_enable_shiny_sound.store(false, std::memory_order_release);
+}
+void BurmyFinder::enable_shiny_sound(BotBaseContext& context){
+    context.wait_for_all_requests();
+    m_enable_shiny_sound.store(true, std::memory_order_release);
 }
 
 void BurmyFinder::run_iteration(SingleSwitchProgramEnvironment& env, BotBaseContext& context, TreeCounter& tree_counter){
     Stats& stats = env.stats<Stats>();
     stats.attempts++;
+    env.update_stats();
     env.console.log("Starting route and shiny detection...");
 
     for (size_t c = 0; true; c++){
@@ -223,10 +250,10 @@ void BurmyFinder::run_iteration(SingleSwitchProgramEnvironment& env, BotBaseCont
     }
 
     float shiny_coefficient = 1.0;
-    std::atomic<bool> enable_shiny_sound(true);
+
     ShinySoundDetector shiny_detector(env.console.logger(), env.console, [&](float error_coefficient) -> bool{
         //  Warning: This callback will be run from a different thread than this function.
-        if (!enable_shiny_sound.load()){
+        if (!m_enable_shiny_sound.load()){
             return false;
         }
         stats.enroute_shinies++;
@@ -234,13 +261,14 @@ void BurmyFinder::run_iteration(SingleSwitchProgramEnvironment& env, BotBaseCont
         return on_shiny_callback(env, env.console, SHINY_DETECTED_ENROUTE, error_coefficient);
     });
 
+    goto_camp_from_jubilife(env, env.console, context, TravelLocations::instance().Fieldlands_Heights);
+
+    size_t cur_tree = 0;
     int ret = run_until(
         env.console, context,
         [&](BotBaseContext& context){
-
             //  Tree 0
             env.console.log("Heading to Tree 0");
-            goto_camp_from_jubilife(env, env.console, context, TravelLocations::instance().Fieldlands_Heights);
             pbf_move_left_joystick(context, 148, 255, 20, 20);
             change_mount(env.console, context, MountState::BRAVIARY_ON);
             pbf_press_button(context, BUTTON_B, (11.8 * TICKS_PER_SECOND), 20);
@@ -251,12 +279,9 @@ void BurmyFinder::run_iteration(SingleSwitchProgramEnvironment& env, BotBaseCont
             pbf_press_button(context, BUTTON_ZL, 20, (0.5 * TICKS_PER_SECOND));
             pbf_move_right_joystick(context, 127, 255, (0.2 * TICKS_PER_SECOND), (0.5 * TICKS_PER_SECOND));
 
-            context.wait_for_all_requests();
-            enable_shiny_sound.store(false, std::memory_order_release);
             if (check_tree(env, context)){
-                tree_counter.tree0++;
+                tree_counter.tree[0]++;
             }
-            enable_shiny_sound.store(true, std::memory_order_release);
 
             //Tree 1
             env.console.log("Heading to Tree 1");
@@ -269,12 +294,9 @@ void BurmyFinder::run_iteration(SingleSwitchProgramEnvironment& env, BotBaseCont
             pbf_press_button(context, BUTTON_PLUS, 20, (1.5 * TICKS_PER_SECOND));
             pbf_move_right_joystick(context, 127, 255, (0.2 * TICKS_PER_SECOND), (0.5 * TICKS_PER_SECOND));
 
-            context.wait_for_all_requests();
-            enable_shiny_sound.store(false, std::memory_order_release);
             if (check_tree(env, context)){
-                tree_counter.tree1++;
+                tree_counter.tree[1]++;
             }
-            enable_shiny_sound.store(true, std::memory_order_release);
 
 
             //Tree 2
@@ -287,12 +309,10 @@ void BurmyFinder::run_iteration(SingleSwitchProgramEnvironment& env, BotBaseCont
             pbf_move_left_joystick(context, 140, 255, 20, 20);
             pbf_press_button(context, BUTTON_ZL, 20, (0.5 * TICKS_PER_SECOND));
             pbf_move_right_joystick(context, 140, 255, (0.3 * TICKS_PER_SECOND), (0.5 * TICKS_PER_SECOND));
-            context.wait_for_all_requests();
-            enable_shiny_sound.store(false, std::memory_order_release);
+
             if (check_tree(env, context)){
-                tree_counter.tree2++;
+                tree_counter.tree[2]++;
             }
-            enable_shiny_sound.store(true, std::memory_order_release);
 
 
             //Tree 3
@@ -307,12 +327,10 @@ void BurmyFinder::run_iteration(SingleSwitchProgramEnvironment& env, BotBaseCont
             pbf_move_left_joystick(context, 255, 135, 30, (0.5 * TICKS_PER_SECOND));
             pbf_press_button(context, BUTTON_ZL, 20, (0.5 * TICKS_PER_SECOND));
             pbf_move_right_joystick(context, 127, 255, (0.2 * TICKS_PER_SECOND), (0.5 * TICKS_PER_SECOND));
-            context.wait_for_all_requests();
-            enable_shiny_sound.store(false, std::memory_order_release);
+
             if (check_tree(env, context)){
-                tree_counter.tree3++;
+                tree_counter.tree[3]++;
             }
-            enable_shiny_sound.store(true, std::memory_order_release);
 
             //Tree 4
             env.console.log("Heading to Tree 4");
@@ -327,12 +345,10 @@ void BurmyFinder::run_iteration(SingleSwitchProgramEnvironment& env, BotBaseCont
             pbf_move_left_joystick(context, 0, 0, 20, (0.5 * TICKS_PER_SECOND));
             pbf_press_button(context, BUTTON_ZL, 20, (0.5 * TICKS_PER_SECOND));
             pbf_move_right_joystick(context, 127, 255, (0.2 * TICKS_PER_SECOND), (0.5 * TICKS_PER_SECOND));
-            context.wait_for_all_requests();
-            enable_shiny_sound.store(false, std::memory_order_release);
+
             if (check_tree(env, context)){
-                tree_counter.tree4++;
+                tree_counter.tree[4]++;
             }
-            enable_shiny_sound.store(true, std::memory_order_release);
 
             //Tree 5
             env.console.log("Heading to Tree 5");
@@ -349,12 +365,110 @@ void BurmyFinder::run_iteration(SingleSwitchProgramEnvironment& env, BotBaseCont
             pbf_move_left_joystick(context, 255, 130, 20, (0.5 * TICKS_PER_SECOND));
             pbf_press_button(context, BUTTON_ZL, 20, (0.5 * TICKS_PER_SECOND));
             pbf_move_right_joystick(context, 127, 255, (0.15 * TICKS_PER_SECOND), (0.5 * TICKS_PER_SECOND));
-            context.wait_for_all_requests();
-            enable_shiny_sound.store(false, std::memory_order_release);
+            
             if (check_tree(env, context)){
-                tree_counter.tree5++;
+                tree_counter.tree[5]++;
             }
-            enable_shiny_sound.store(true, std::memory_order_release);
+
+            // Tree 6-9
+            env.console.log("Heading to Tree 6-9");
+            goto_any_camp_from_overworld(env, env.console, context, TravelLocations::instance().Fieldlands_Heights);
+            const bool stop_on_detected = true;
+            BattleMenuDetector battle_menu_detector(env.console, env.console, stop_on_detected);
+            int ret = run_until(
+                env.console, context,
+                [&](BotBaseContext& context){
+                    // === Fly to the first tree on trip ===
+                    cur_tree = 6;
+                    pbf_move_left_joystick(context, 255, 90, 20, (0.5 * TICKS_PER_SECOND));
+                    pbf_press_button(context, BUTTON_ZL, 20, (0.5 * TICKS_PER_SECOND));
+                    change_mount(env.console, context, MountState::BRAVIARY_ON);
+                    pbf_press_button(context, BUTTON_B, (5 * TICKS_PER_SECOND), 0);
+                    pbf_press_button(context, BUTTON_Y, (4.2 * TICKS_PER_SECOND), 0);
+                    pbf_press_button(context, BUTTON_PLUS, 20, (1 * TICKS_PER_SECOND));
+
+                    // Now on ground, move towards the tree
+                    // change_mount(env.console, context, MountState::WYRDEER_OFF);
+                    pbf_move_left_joystick(context, 0, 70, 20, (0.3 * TICKS_PER_SECOND));
+                    // Change camera to face what player character faces
+                    pbf_press_button(context, BUTTON_ZL, 20, (0.4 * TICKS_PER_SECOND));
+                    // Move camera down
+                    pbf_move_right_joystick(context, 128, 255, (0.2 * TICKS_PER_SECOND), (0.5 * TICKS_PER_SECOND));
+                    
+                    // Now we should be on ground
+                    disable_shiny_sound(context);
+                    check_tree_no_stop(env, context);
+
+                    // === Fly to the second tree on trip ===
+                    // Mount on Braviary
+                    pbf_press_button(context, BUTTON_PLUS, 20, 100);
+                    enable_shiny_sound(context);
+
+                    // Now face towards the next tree
+                    pbf_move_left_joystick(context, 255, 200, 1 * TICKS_PER_SECOND, 0);
+                    pbf_press_button(context, BUTTON_B, 60, 0);
+                    pbf_press_button(context, BUTTON_Y, (2.3 * TICKS_PER_SECOND), 0);
+                    // Get off Braviary
+                    pbf_press_button(context, BUTTON_PLUS, 20, (1 * TICKS_PER_SECOND));
+                    // Move camera down
+                    pbf_move_right_joystick(context, 128, 255, (0.1 * TICKS_PER_SECOND), (0.3 * TICKS_PER_SECOND));
+                    
+                    // Now we should be on ground
+                    disable_shiny_sound(context);
+                    check_tree_no_stop(env, context);
+                    cur_tree = 7;
+                    
+                    // === Fly to the third tree on trip ===
+                    // Mount on Braviary
+                    pbf_press_button(context, BUTTON_PLUS, 20, 100);
+                    enable_shiny_sound(context);
+
+                    // Now face towards the next tree
+                    pbf_move_left_joystick(context, 255, 130, 1 * TICKS_PER_SECOND, 0);
+                    pbf_press_button(context, BUTTON_B, 80, 0);
+                    pbf_press_button(context, BUTTON_Y, (2.2 * TICKS_PER_SECOND), 0);
+                    // Get off Braviary
+                    pbf_press_button(context, BUTTON_PLUS, 20, (1 * TICKS_PER_SECOND));
+                    // Move camera down
+                    pbf_move_right_joystick(context, 128, 255, (0.1 * TICKS_PER_SECOND), (0.3 * TICKS_PER_SECOND));
+
+                    // Now we should be on ground
+                    disable_shiny_sound(context);
+                    check_tree_no_stop(env, context);
+                    cur_tree = 8;
+
+                    // === Fly to the fifth tree ===
+                    // Mount on Braviary
+                    pbf_press_button(context, BUTTON_PLUS, 20, 100);
+                    enable_shiny_sound(context);
+
+                    // Now face towards the next tree
+                    pbf_move_left_joystick(context, 0, 60, 1 * TICKS_PER_SECOND, 0);
+                    pbf_press_button(context, BUTTON_B, 90, 0);
+                    pbf_press_button(context, BUTTON_Y, (2.3 * TICKS_PER_SECOND), 0);
+                    // Get off Braviary
+                    pbf_press_button(context, BUTTON_PLUS, 20, (1 * TICKS_PER_SECOND));
+                    // Move camera down
+                    pbf_move_right_joystick(context, 128, 255, (0.1 * TICKS_PER_SECOND), (0.3 * TICKS_PER_SECOND));
+                    // Now we should be on ground
+                },
+                {
+                    {battle_menu_detector},
+                }
+            );
+            
+            if (ret == 0){
+                env.log("Found battle during river-side traversal.");
+                if (handle_battle(env, context)){
+                    tree_counter.tree[cur_tree]++;
+                }
+                
+            } else{
+                // Check last tree
+                if (check_tree(env, context)){
+                    tree_counter.tree[9]++;
+                }
+            }
 
             //  End
             goto_camp_from_overworld(env, env.console, context);

--- a/SerialPrograms/Source/PokemonLA/Programs/ShinyHunting/PokemonLA_BurmyFinder.h
+++ b/SerialPrograms/Source/PokemonLA/Programs/ShinyHunting/PokemonLA_BurmyFinder.h
@@ -33,11 +33,32 @@ private:
     struct TreeCounter;
 
     void run_iteration(SingleSwitchProgramEnvironment& env, BotBaseContext& context, TreeCounter& tree_counter);
+    // Press X to throw pokemon, check whether there is pokemon in the tree. Wait for potential battle
+    // after pokemon is thrown.
+    // Return true if encountering a burmy in the tree. False otherwise.
+    // Also during pokemon throwing and battle, disable shiny sound detection. This is because a shiny burmy
+    // will play the shiny sound when it jumps out of the tree. To avoid this shiny sound be categorized as
+    // enroute shiny, we disable the sound detection when a burmy may jump out.
     bool check_tree(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
+    // Throw pokemon to check a tree.
+    // Does not wait for potential battle to start.
+    // Unlike `check_tree()`, shiny sound detection is not disabled. 
+    void check_tree_no_stop(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
+
+    // While during battle, press + button to check pokemon details.
+    // May throw ProgramFinishedException if a Burmy match is found.
+    // Finish battle by mashing A or escape. 
+    // Return true if a burmy is in the battle. False otherwise.
+    bool handle_battle(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
+
+    void disable_shiny_sound(BotBaseContext& context);
+    void enable_shiny_sound(BotBaseContext& context);
 
 private:
     class Stats;
     class RunRoute;
+
+    std::atomic<bool> m_enable_shiny_sound{true};
 
     OCR::LanguageOCR LANGUAGE;
     EnumDropdownOption STOP_ON;


### PR DESCRIPTION
- 4 more trees to check on a single trip. Now total 10 trees to check. Note the for the 4 new trees, once one of them has a burmy, the program will not check the remaining trees on the trip, since the 4 trees are far from the camp, traveling there again is not efficient.
- Clean Burmy Finder code.
- Add stat: trees to record how many trees visited.