### PR TITLE
Home sorter nav improvements, sort options table and json output

### DIFF
--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -961,6 +961,8 @@ file(GLOB MAIN_SOURCES
     Source/PokemonBDSP/Resources/PokemonBDSP_NameDatabase.h
     Source/PokemonHome/Inference/PokemonHome_BallReader.cpp
     Source/PokemonHome/Inference/PokemonHome_BallReader.h
+    Source/PokemonHome/Options/PokemonHome_BoxSortingTable.cpp
+    Source/PokemonHome/Options/PokemonHome_BoxSortingTable.h
     Source/PokemonHome/PokemonHome_Panels.cpp
     Source/PokemonHome/PokemonHome_Panels.h
     Source/PokemonHome/PokemonHome_Settings.cpp

--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -961,6 +961,8 @@ file(GLOB MAIN_SOURCES
     Source/PokemonBDSP/Resources/PokemonBDSP_NameDatabase.h
     Source/PokemonHome/Inference/PokemonHome_BallReader.cpp
     Source/PokemonHome/Inference/PokemonHome_BallReader.h
+    Source/PokemonHome/Inference/PokemonHome_BoxGenderDetector.cpp
+    Source/PokemonHome/Inference/PokemonHome_BoxGenderDetector.h
     Source/PokemonHome/Options/PokemonHome_BoxSortingTable.cpp
     Source/PokemonHome/Options/PokemonHome_BoxSortingTable.h
     Source/PokemonHome/PokemonHome_Panels.cpp

--- a/SerialPrograms/Scripts/check_detector_regions.py
+++ b/SerialPrograms/Scripts/check_detector_regions.py
@@ -34,7 +34,7 @@ raw_image = image.copy()
 
 # ==================================================================
 # LA map weather symbol
-add_infer_box_to_image(raw_image, 0.028, 0.069, 0.025, 0.044, image)
+# add_infer_box_to_image(raw_image, 0.028, 0.069, 0.025, 0.044, image)
 
 # ==================================================================
 # LA mult-pokemon battle sprite arrow
@@ -221,6 +221,26 @@ add_infer_box_to_image(raw_image, 0.028, 0.069, 0.025, 0.044, image)
 # add_infer_box_to_image(raw_image, 0.500, 0.760, 0.200, 0.020, image)
 # add_infer_box_to_image(raw_image, 0.400, 0.900, 0.200, 0.020, image)
 # add_infer_box_to_image(raw_image, 0.720, 0.855, 0.030, 0.060, image)
+
+# ==================================================================
+# Pokemon Home Box Sorting
+
+# , m_box_sprite(console, {0.228, 0.095, 0.030, 0.049}) // ball
+# ImageFloatBox GENDER_BOX{0.417, 0.097, 0.031, 0.046}; // gender
+
+add_infer_box_to_image(raw_image, 0.495, 0.0045, 0.01, 0.005, image) # square color to check which mode is active
+add_infer_box_to_image(raw_image, 0.447, 0.250, 0.037, 0.034, image) # pokemon national dex number pos
+add_infer_box_to_image(raw_image, 0.702, 0.09, 0.04, 0.06, image) # shiny symbol pos
+add_infer_box_to_image(raw_image, 0.463, 0.09, 0.04, 0.06, image) # gmax symbol pos
+add_infer_box_to_image(raw_image, 0.623, 0.095, 0.033, 0.05, image) # origin symbol pos
+add_infer_box_to_image(raw_image, 0.69, 0.18, 0.28, 0.46, image) # pokemon render pos
+add_infer_box_to_image(raw_image, 0.228, 0.095, 0.030, 0.049, image) # ball type pos
+add_infer_box_to_image(raw_image, 0.417, 0.097, 0.031, 0.046, image) # gender pos
+add_infer_box_to_image(raw_image, 0.546, 0.099, 0.044, 0.041, image) # Level box
+add_infer_box_to_image(raw_image, 0.782, 0.719, 0.193, 0.046, image) # OT ID box
+add_infer_box_to_image(raw_image, 0.492, 0.719, 0.165, 0.049, image) # OT box
+add_infer_box_to_image(raw_image, 0.157, 0.783, 0.212, 0.042, image) # Nature box
+add_infer_box_to_image(raw_image, 0.158, 0.838, 0.213, 0.042, image) # Ability box
 
 viewer = ImageViewer(image)
 viewer.run()

--- a/SerialPrograms/Scripts/check_detector_regions.py
+++ b/SerialPrograms/Scripts/check_detector_regions.py
@@ -228,19 +228,19 @@ raw_image = image.copy()
 # , m_box_sprite(console, {0.228, 0.095, 0.030, 0.049}) // ball
 # ImageFloatBox GENDER_BOX{0.417, 0.097, 0.031, 0.046}; // gender
 
-add_infer_box_to_image(raw_image, 0.495, 0.0045, 0.01, 0.005, image) # square color to check which mode is active
-add_infer_box_to_image(raw_image, 0.447, 0.250, 0.037, 0.034, image) # pokemon national dex number pos
-add_infer_box_to_image(raw_image, 0.702, 0.09, 0.04, 0.06, image) # shiny symbol pos
-add_infer_box_to_image(raw_image, 0.463, 0.09, 0.04, 0.06, image) # gmax symbol pos
-add_infer_box_to_image(raw_image, 0.623, 0.095, 0.033, 0.05, image) # origin symbol pos
-add_infer_box_to_image(raw_image, 0.69, 0.18, 0.28, 0.46, image) # pokemon render pos
-add_infer_box_to_image(raw_image, 0.228, 0.095, 0.030, 0.049, image) # ball type pos
-add_infer_box_to_image(raw_image, 0.417, 0.097, 0.031, 0.046, image) # gender pos
-add_infer_box_to_image(raw_image, 0.546, 0.099, 0.044, 0.041, image) # Level box
-add_infer_box_to_image(raw_image, 0.782, 0.719, 0.193, 0.046, image) # OT ID box
-add_infer_box_to_image(raw_image, 0.492, 0.719, 0.165, 0.049, image) # OT box
-add_infer_box_to_image(raw_image, 0.157, 0.783, 0.212, 0.042, image) # Nature box
-add_infer_box_to_image(raw_image, 0.158, 0.838, 0.213, 0.042, image) # Ability box
+# add_infer_box_to_image(raw_image, 0.495, 0.0045, 0.01, 0.005, image) # square color to check which mode is active
+# add_infer_box_to_image(raw_image, 0.447, 0.250, 0.037, 0.034, image) # pokemon national dex number pos
+# add_infer_box_to_image(raw_image, 0.702, 0.09, 0.04, 0.06, image) # shiny symbol pos
+# add_infer_box_to_image(raw_image, 0.463, 0.09, 0.04, 0.06, image) # gmax symbol pos
+# add_infer_box_to_image(raw_image, 0.623, 0.095, 0.033, 0.05, image) # origin symbol pos
+# add_infer_box_to_image(raw_image, 0.69, 0.18, 0.28, 0.46, image) # pokemon render pos
+# add_infer_box_to_image(raw_image, 0.228, 0.095, 0.030, 0.049, image) # ball type pos
+# add_infer_box_to_image(raw_image, 0.417, 0.097, 0.031, 0.046, image) # gender pos
+# add_infer_box_to_image(raw_image, 0.546, 0.099, 0.044, 0.041, image) # Level box
+# add_infer_box_to_image(raw_image, 0.782, 0.719, 0.193, 0.046, image) # OT ID box
+# add_infer_box_to_image(raw_image, 0.492, 0.719, 0.165, 0.049, image) # OT box
+# add_infer_box_to_image(raw_image, 0.157, 0.783, 0.212, 0.042, image) # Nature box
+# add_infer_box_to_image(raw_image, 0.158, 0.838, 0.213, 0.042, image) # Ability box
 
 viewer = ImageViewer(image)
 viewer.run()

--- a/SerialPrograms/SerialPrograms.pro
+++ b/SerialPrograms/SerialPrograms.pro
@@ -477,6 +477,7 @@ SOURCES += \
     Source/PokemonBDSP/Programs/Trading/PokemonBDSP_TradeRoutines.cpp \
     Source/PokemonBDSP/Resources/PokemonBDSP_NameDatabase.cpp \
     Source/PokemonHome/Inference/PokemonHome_BallReader.cpp \
+    Source/PokemonHome/Options/PokemonHome_BoxSortingTable.cpp \
     Source/PokemonHome/PokemonHome_Panels.cpp \
     Source/PokemonHome/PokemonHome_Settings.cpp \
     Source/PokemonHome/Programs/PokemonHome_BoxSorting.cpp \
@@ -1291,6 +1292,7 @@ HEADERS += \
     Source/PokemonBDSP/Programs/Trading/PokemonBDSP_TradeRoutines.h \
     Source/PokemonBDSP/Resources/PokemonBDSP_NameDatabase.h \
     Source/PokemonHome/Inference/PokemonHome_BallReader.h \
+    Source/PokemonHome/Options/PokemonHome_BoxSortingTable.h \
     Source/PokemonHome/PokemonHome_Panels.h \
     Source/PokemonHome/PokemonHome_Settings.h \
     Source/PokemonHome/Programs/PokemonHome_BoxSorting.h \

--- a/SerialPrograms/SerialPrograms.pro
+++ b/SerialPrograms/SerialPrograms.pro
@@ -477,6 +477,7 @@ SOURCES += \
     Source/PokemonBDSP/Programs/Trading/PokemonBDSP_TradeRoutines.cpp \
     Source/PokemonBDSP/Resources/PokemonBDSP_NameDatabase.cpp \
     Source/PokemonHome/Inference/PokemonHome_BallReader.cpp \
+    Source/PokemonHome/Inference/PokemonHome_BoxGenderDetector.cpp \
     Source/PokemonHome/Options/PokemonHome_BoxSortingTable.cpp \
     Source/PokemonHome/PokemonHome_Panels.cpp \
     Source/PokemonHome/PokemonHome_Settings.cpp \
@@ -1292,6 +1293,7 @@ HEADERS += \
     Source/PokemonBDSP/Programs/Trading/PokemonBDSP_TradeRoutines.h \
     Source/PokemonBDSP/Resources/PokemonBDSP_NameDatabase.h \
     Source/PokemonHome/Inference/PokemonHome_BallReader.h \
+    Source/PokemonHome/Inference/PokemonHome_BoxGenderDetector.h \
     Source/PokemonHome/Options/PokemonHome_BoxSortingTable.h \
     Source/PokemonHome/PokemonHome_Panels.h \
     Source/PokemonHome/PokemonHome_Settings.h \

--- a/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.cpp
+++ b/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.cpp
@@ -25,6 +25,7 @@ const std::set<std::string> TOKENS{
     "6643d9fe87b3e54dc75dfac8ac22f0cc8bd17f6a8a786debf5fc4c517ee65469",
     "8e48e38e49bffc8462ada9d2d9d850d5b3b5c9529d20978c09bc548bc9a614a4",
     "7694adee4419d62c6a923c4efc9e7b41def7b96bb84ea882701b0bf2e8c13bee",
+    "e8d168bc482e96553ea9f9ecaea5a817474dbccc2a6a228a6bde67f2b2aa2889",
 };
 
 

--- a/SerialPrograms/Source/PokemonHome/Inference/PokemonHome_BoxGenderDetector.cpp
+++ b/SerialPrograms/Source/PokemonHome/Inference/PokemonHome_BoxGenderDetector.cpp
@@ -1,0 +1,72 @@
+/*  Box Gender Detector
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "Common/Cpp/Color.h"
+#include "CommonFramework/GlobalSettingsPanel.h"
+#include "CommonFramework/ImageTools/ImageBoxes.h"
+#include "CommonFramework/ImageTools/ImageFilter.h"
+#include "CommonFramework/ImageTypes/ImageRGB32.h"
+#include "CommonFramework/ImageTools/ImageStats.h"
+#include "CommonFramework/ImageTypes/ImageViewRGB32.h"
+#include "CommonFramework/VideoPipeline/VideoOverlayScopes.h"
+#include "PokemonHome_BoxGenderDetector.h"
+
+#include <iostream>
+using std::cout;
+using std::endl;
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonHome{
+
+namespace {
+    ImageFloatBox GENDER_BOX{0.417, 0.097, 0.031, 0.046};
+}
+
+void BoxGenderDetector::make_overlays(VideoOverlaySet& items){
+    items.add(COLOR_RED, GENDER_BOX);
+}
+
+Pokemon::EggHatchGenderFilter BoxGenderDetector::detect(const ImageViewRGB32& screen){
+    const auto region = extract_box_reference(screen, GENDER_BOX);
+
+    // Retain only red pixels from region
+    const bool replace_color_within_range = false;
+    const ImageRGB32 red_region = filter_rgb32_range(
+        region,
+        combine_rgb(150, 0, 0), combine_rgb(255, 100, 100), Color(0), replace_color_within_range
+    );
+    const size_t num_red_pixels = image_stats(red_region).count;
+
+    // Retain only blue pixels from region
+    const ImageRGB32 blue_region = filter_rgb32_range(
+        region,
+        combine_rgb(0, 0, 150), combine_rgb(100, 100, 255), Color(0), replace_color_within_range
+    );
+    const size_t num_blue_pixels = image_stats(blue_region).count;
+
+    if (PreloadSettings::debug().COLOR_CHECK){
+        cout << "num_red_pixels: " << num_red_pixels << ", num_blue_pixels: " << num_blue_pixels
+             << ", region " << region.width() << " x " << region.height() << endl;
+
+        cout << "Save images to ./red_only.png and ./blue_only.png" << endl;
+        red_region.save("./red_only.png");
+        blue_region.save("./blue_only.png");
+    }
+
+    const size_t threshold = region.width() * region.height() / 100;
+
+    if (num_red_pixels > threshold){
+        return Pokemon::EggHatchGenderFilter::Female;
+    } else if (num_blue_pixels > threshold){
+        return Pokemon::EggHatchGenderFilter::Male;
+    }
+    return Pokemon::EggHatchGenderFilter::Genderless;
+}
+
+}
+}
+}

--- a/SerialPrograms/Source/PokemonHome/Inference/PokemonHome_BoxGenderDetector.h
+++ b/SerialPrograms/Source/PokemonHome/Inference/PokemonHome_BoxGenderDetector.h
@@ -1,0 +1,34 @@
+/*  Box Gender Detector
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonHome_BoxGenderDetector_H
+#define PokemonAutomation_PokemonHome_BoxGenderDetector_H
+
+#include "Pokemon/Options/Pokemon_EggHatchFilter.h"
+
+namespace PokemonAutomation{
+
+class ImageViewRGB32;
+class VideoOverlaySet;
+
+namespace NintendoSwitch{
+namespace PokemonHome{
+
+// Detect gender symbol inside the pokemon storage box
+class BoxGenderDetector{
+public:
+    static void make_overlays(VideoOverlaySet& items);
+
+    static Pokemon::EggHatchGenderFilter detect(const ImageViewRGB32& screen);
+};
+
+
+
+}
+}
+}
+
+#endif

--- a/SerialPrograms/Source/PokemonHome/Options/PokemonHome_BoxSortingTable.cpp
+++ b/SerialPrograms/Source/PokemonHome/Options/PokemonHome_BoxSortingTable.cpp
@@ -17,6 +17,7 @@ const EnumDatabase<BoxSortingSortType>& BallType_Database() {
         {BoxSortingSortType::Shiny,    "shiny",    "Shiny"},
         {BoxSortingSortType::Gigantamax,    "gigantamax",    "Gigantamax"},
         {BoxSortingSortType::Ball_Slug,    "ball_slug",    "Ball Type"},
+        {BoxSortingSortType::Gender,    "gender",    "Gender (Male, Female, Genderless)"},
     });
     return database;
 }
@@ -64,7 +65,7 @@ std::vector<BoxSortingSelection> BoxSortingTable::preferences() const{
 
 std::vector<std::string> BoxSortingTable::make_header() const{
     return std::vector<std::string>{
-        "Criteria", "Only Bonus", "Priority",
+        "Criteria", "Reverse",
     };
 }
 

--- a/SerialPrograms/Source/PokemonHome/Options/PokemonHome_BoxSortingTable.cpp
+++ b/SerialPrograms/Source/PokemonHome/Options/PokemonHome_BoxSortingTable.cpp
@@ -1,0 +1,95 @@
+/*  Box Sorter Table
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "PokemonHome_BoxSortingTable.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonHome{
+
+
+const EnumDatabase<BoxSortingSortType>& BallType_Database() {
+    static const EnumDatabase<BoxSortingSortType> database({
+        {BoxSortingSortType::NationalDexNo,     "dex",     "National Dex Number"},
+        {BoxSortingSortType::Shiny,    "shiny",    "Shiny"},
+        {BoxSortingSortType::Gigantamax,    "gigantamax",    "Gigantamax"},
+        {BoxSortingSortType::Ball_Slug,    "ball_slug",    "Ball Type"},
+    });
+    return database;
+}
+
+
+
+BoxSortingRow::BoxSortingRow()
+    : sort_type(BallType_Database(), LockWhileRunning::LOCKED, BoxSortingSortType::NationalDexNo)
+    , reverse(LockWhileRunning::LOCKED, false)
+{
+    PA_ADD_OPTION(sort_type);
+    PA_ADD_OPTION(reverse);
+}
+std::unique_ptr<EditableTableRow> BoxSortingRow::clone() const{
+    std::unique_ptr<BoxSortingRow> ret(new BoxSortingRow());
+    ret->sort_type.set_value(sort_type.current_value());
+    ret->reverse = reverse.current_value();
+    return ret;
+}
+
+
+BoxSortingTable::BoxSortingTable(std::string label)
+    : EditableTableOption_t<BoxSortingRow>(
+        std::move(label),
+        make_defaults()
+    )
+{}
+
+
+std::vector<BoxSortingSelection> BoxSortingTable::preferences() const{
+    std::vector<std::unique_ptr<BoxSortingRow>> table = copy_snapshot();
+    std::vector<BoxSortingSelection> selections;
+    for (const std::unique_ptr<BoxSortingRow>& row : table){
+        BoxSortingSelection selection;
+        selection.sort_type = BoxSortingSortType(row->sort_type.current_value());
+        selection.reverse = row->reverse.current_value();
+
+        selections.emplace_back(selection);
+    }
+    return selections;
+}
+
+
+
+
+std::vector<std::string> BoxSortingTable::make_header() const{
+    return std::vector<std::string>{
+        "Criteria", "Only Bonus", "Priority",
+    };
+}
+
+std::vector<std::unique_ptr<EditableTableRow>> BoxSortingTable::make_defaults(){
+    std::vector<std::unique_ptr<EditableTableRow>> ret;
+    ret.emplace_back(std::make_unique<BoxSortingRow>());
+    return ret;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+}
+}
+}

--- a/SerialPrograms/Source/PokemonHome/Options/PokemonHome_BoxSortingTable.h
+++ b/SerialPrograms/Source/PokemonHome/Options/PokemonHome_BoxSortingTable.h
@@ -1,0 +1,63 @@
+/*  Cram-o-matic Table
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonHome_BoxSortingTable_H
+#define PokemonAutomation_PokemonHome_BoxSortingTable_H
+
+#include "Common/Cpp/Options/EditableTableOption.h"
+#include "Common/Cpp/Options/SimpleIntegerOption.h"
+#include "Common/Cpp/Options/BooleanCheckBoxOption.h"
+#include "Common/Cpp/Options/EnumDropdownOption.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonHome{
+
+enum class BoxSortingSortType
+{
+    NationalDexNo,
+    Shiny,
+    Gigantamax,
+    Ball_Slug,
+};
+
+struct BoxSortingSelection
+{
+    BoxSortingSortType sort_type;
+    bool reverse;
+};
+
+class BoxSortingRow : public EditableTableRow{
+public:
+    BoxSortingRow();
+    virtual std::unique_ptr<EditableTableRow> clone() const;
+
+public:
+    EnumDropdownCell<BoxSortingSortType> sort_type;
+    BooleanCheckBoxCell reverse;
+};
+
+
+
+class BoxSortingTable : public EditableTableOption_t<BoxSortingRow>{
+public:
+    BoxSortingTable(std::string label);
+
+    std::vector<BoxSortingSelection> preferences() const;
+
+    virtual std::vector<std::string> make_header() const;
+
+    static std::vector<std::unique_ptr<EditableTableRow>> make_defaults();
+};
+
+
+
+
+
+}
+}
+}
+#endif

--- a/SerialPrograms/Source/PokemonHome/Options/PokemonHome_BoxSortingTable.h
+++ b/SerialPrograms/Source/PokemonHome/Options/PokemonHome_BoxSortingTable.h
@@ -22,6 +22,7 @@ enum class BoxSortingSortType
     Shiny,
     Gigantamax,
     Ball_Slug,
+    Gender,
 };
 
 struct BoxSortingSelection

--- a/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxSorting.cpp
+++ b/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxSorting.cpp
@@ -113,8 +113,8 @@ BoxSorting::BoxSorting()
           false,
           LockWhileRunning::LOCKED,
           "<b>Output File:</b><br>JSON file for output of storage boxes.",
-          "box_order.json",
-          "box_order.json"
+          "box_order",
+          "box_order"
       )
     , DRY_RUN(
           "<b>Dry Run:</b><br>Catalogue and make sort plan without executing. (Will output to OUTPUT_FILE and OUTPUT_FILE.sortplan)",
@@ -393,7 +393,7 @@ void output_boxes_data_json(const std::vector<std::optional<Pokemon>>& boxes_dat
         }
         pokemon_data.push_back(std::move(pokemon));
     }
-    pokemon_data.dump(json_path);
+    pokemon_data.dump(json_path + ".json");
 }
 
 void do_sort(
@@ -707,7 +707,7 @@ void BoxSorting::program(SingleSwitchProgramEnvironment& env, BotBaseContext& co
 
     env.console.log("Sorted boxes data :");
     print_boxes_data(boxes_sorted, env);
-    const std::string sorted_path = json_path + ".sorted";
+    const std::string sorted_path = json_path + "-sorted";
     output_boxes_data_json(boxes_sorted, sorted_path);
 
     if (!DRY_RUN) {

--- a/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxSorting.cpp
+++ b/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxSorting.cpp
@@ -462,7 +462,7 @@ void BoxSorting::program(SingleSwitchProgramEnvironment& env, BotBaseContext& co
     BoxSorting_Descriptor::Stats& stats = env.current_stats< BoxSorting_Descriptor::Stats>();
 
     ImageFloatBox select_check(0.495, 0.0045, 0.01, 0.005); // square color to check which mode is active
-    ImageFloatBox national_dex_number_box(0.447, 0.250, 0.037, 0.034); //pokemon national dex number pos
+    ImageFloatBox national_dex_number_box(0.44, 0.245, 0.04, 0.04); //pokemon national dex number pos
     ImageFloatBox shiny_symbol_box(0.702, 0.09, 0.04, 0.06); // shiny symbol pos
     ImageFloatBox gmax_symbol_box(0.463, 0.09, 0.04, 0.06); // gmax symbol pos
     ImageFloatBox origin_symbol_box(0.623, 0.095, 0.033, 0.05); // origin symbol pos

--- a/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxSorting.cpp
+++ b/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxSorting.cpp
@@ -408,7 +408,12 @@ void BoxSorting::program(SingleSwitchProgramEnvironment& env, BotBaseContext& co
     ImageFloatBox shiny_symbol_box(0.702, 0.09, 0.04, 0.06); // shiny symbol pos
     ImageFloatBox gmax_symbol_box(0.463, 0.09, 0.04, 0.06); // gmax symbol pos
     ImageFloatBox origin_symbol_box(0.623, 0.095, 0.033, 0.05); // origin symbol pos
-    ImageFloatBox pokemon_box(0.69, 0.18, 0.28, 0.46); // origin symbol pos
+    ImageFloatBox pokemon_box(0.69, 0.18, 0.28, 0.46); // pokemon render pos
+    ImageFloatBox level_box(0.546, 0.099, 0.044, 0.041); // Level box
+    ImageFloatBox ot_id_box(0.782, 0.719, 0.193, 0.046); // OT ID box
+    ImageFloatBox ot_box(0.492, 0.719, 0.165, 0.049); // OT box
+    ImageFloatBox nature_box(0.157, 0.783, 0.212, 0.042); // Nature box
+    ImageFloatBox ability_box(0.158, 0.838, 0.213, 0.042); // Ability box
 
 
     // vector that will store data for each slot
@@ -542,6 +547,11 @@ void BoxSorting::program(SingleSwitchProgramEnvironment& env, BotBaseContext& co
         box_render.add(COLOR_GREEN, gmax_symbol_box);
         box_render.add(COLOR_DARKGREEN, origin_symbol_box);
         box_render.add(COLOR_DARK_BLUE, pokemon_box);
+        box_render.add(COLOR_RED, level_box);
+        box_render.add(COLOR_RED, ot_id_box);
+        box_render.add(COLOR_RED, ot_box);
+        box_render.add(COLOR_RED, nature_box);
+        box_render.add(COLOR_RED, ability_box);
 
         //cycle through each summary of the current box and fill pokemon information
         for (size_t row = 0; row < MAX_ROWS; row++){

--- a/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxSorting.cpp
+++ b/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxSorting.cpp
@@ -16,7 +16,6 @@ nature
 type
 original game
 OT
-ID OT
 moves
 stats
 level

--- a/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxSorting.cpp
+++ b/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxSorting.cpp
@@ -176,6 +176,7 @@ struct Pokemon{
     bool gmax = false;
     std::string ball_slug = "";
     EggHatchGenderFilter gender = EggHatchGenderFilter::Genderless;
+    uint16_t ot_id = 0;
 };
 
 bool operator==(const Pokemon& lhs, const Pokemon& rhs){
@@ -245,7 +246,8 @@ std::ostream& operator<<(std::ostream& os, const std::optional<Pokemon>& pokemon
         os << "shiny:" << (pokemon->shiny ? "true" : "false") << " ";
         os << "gmax:" << (pokemon->gmax ? "true" : "false") << " ";
         os << "ball_slug:" << pokemon->ball_slug << " ";
-        os << "gender:" << gender_to_string(pokemon->gender);
+        os << "gender:" << gender_to_string(pokemon->gender) << " ";
+        os << "ot_id:" << pokemon->ot_id << " ";
         os << ")";
     }
     else{
@@ -388,6 +390,7 @@ void output_boxes_data_json(const std::vector<std::optional<Pokemon>>& boxes_dat
             pokemon["gmax"] =  boxes_data[poke_nb]->gmax;
             pokemon["ball_slug"] =  boxes_data[poke_nb]->ball_slug;
             pokemon["gender"] = gender_to_string(boxes_data[poke_nb]->gender);
+            pokemon["ot_id"] = boxes_data[poke_nb]->ot_id;
         }
         pokemon_data.push_back(std::move(pokemon));
     }
@@ -588,7 +591,23 @@ void BoxSorting::program(SingleSwitchProgramEnvironment& env, BotBaseContext& co
                     env.console.log("Gender: " + gender_to_string(gender), COLOR_GREEN);
                     boxes_data[get_index(box_nb, row, column)]->gender = gender;
 
+                    image = to_blackwhite_rgb32_range(
+                        extract_box_reference(*screen, ot_id_box),
+                        0xff808080, 0xffffffff, true
+                    );
+
+                    int ot_id = OCR::read_number(env.console, image);
+                    if (ot_id == -1){
+                        dump_image(env.console, ProgramInfo(), "ReadSummary", *screen);
+                    }
+                    boxes_data[get_index(box_nb, row, column)]->ot_id = ot_id;
+
                     // NOTE edit when adding new struct members (detections go here likely)
+
+                    // level_box
+                    // ot_box
+                    // nature_box
+                    // ability_box
 
                     pbf_press_button(context, BUTTON_R, 10, VIDEO_DELAY+15);
                     context.wait_for_all_requests();

--- a/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxSorting.cpp
+++ b/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxSorting.cpp
@@ -413,7 +413,9 @@ void BoxSorting::program(SingleSwitchProgramEnvironment& env, BotBaseContext& co
     ImageFloatBox national_dex_number_box(0.447, 0.250, 0.037, 0.034); //pokemon national dex number pos
     ImageFloatBox shiny_symbol_box(0.702, 0.09, 0.04, 0.06); // shiny symbol pos
     ImageFloatBox gmax_symbol_box(0.463, 0.09, 0.04, 0.06); // gmax symbol pos
-    ImageFloatBox origin_symbol_box(0.623, 0.095, 0.033, 0.048); // origin symbol pos
+    ImageFloatBox origin_symbol_box(0.623, 0.095, 0.033, 0.05); // origin symbol pos
+    ImageFloatBox pokemon_box(0.69, 0.18, 0.28, 0.46); // origin symbol pos
+
 
     // vector that will store data for each slot
     std::vector<std::optional<Pokemon>> boxes_data;
@@ -544,7 +546,8 @@ void BoxSorting::program(SingleSwitchProgramEnvironment& env, BotBaseContext& co
         box_render.add(COLOR_RED, national_dex_number_box);
         box_render.add(COLOR_BLUE, shiny_symbol_box);
         box_render.add(COLOR_GREEN, gmax_symbol_box);
-        box_render.add(COLOR_YELLOW, origin_symbol_box);
+        box_render.add(COLOR_DARKGREEN, origin_symbol_box);
+        box_render.add(COLOR_DARK_BLUE, pokemon_box);
 
         //cycle through each summary of the current box and fill pokemon information
         for (size_t row = 0; row < MAX_ROWS; row++){

--- a/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxSorting.cpp
+++ b/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxSorting.cpp
@@ -258,7 +258,7 @@ bool go_to_first_slot(SingleSwitchProgramEnvironment& env, BotBaseContext& conte
     ss << "Moving cursor from " << cur_cursor << " to " << dest_cursor;
     env.console.log(ss.str());
 
-    // TODO: shortest path movement though pages, boxes, rows, cols
+    // TODO: shortest path movement though pages, boxes
     for (size_t i = cur_cursor.box; i < dest_cursor.box; ++i){
         pbf_press_button(context, BUTTON_R, 10, GAME_DELAY+30);
     }
@@ -266,18 +266,46 @@ bool go_to_first_slot(SingleSwitchProgramEnvironment& env, BotBaseContext& conte
         pbf_press_button(context, BUTTON_L, 10, GAME_DELAY+30);
     }
 
-    for (size_t i = cur_cursor.row; i < dest_cursor.row; ++i){
-        pbf_press_dpad(context, DPAD_DOWN, 1, GAME_DELAY);
-    }
-    for (size_t i = dest_cursor.row; i < cur_cursor.row; ++i){
-        pbf_press_dpad(context, DPAD_UP, 1, GAME_DELAY);
+
+    // direct nav up or down through rows
+    if (!(cur_cursor.row == 0 && dest_cursor.row == 4) && !(dest_cursor.row == 0 && cur_cursor.row == 4)) {
+        for (size_t i = cur_cursor.row; i < dest_cursor.row; ++i){
+            pbf_press_dpad(context, DPAD_DOWN, 1, GAME_DELAY);
+        }
+        for (size_t i = dest_cursor.row; i < cur_cursor.row; ++i){
+            pbf_press_dpad(context, DPAD_UP, 1, GAME_DELAY);
+        }
+    } else { // wrap around is faster to move between first or last row
+        if (cur_cursor.row == 0 && dest_cursor.row == 4) {
+            for (size_t i = 0; i <= 2; ++i){
+                pbf_press_dpad(context, DPAD_UP, 1, GAME_DELAY);
+            }
+        } else {
+            for (size_t i = 0; i <= 2; ++i){
+                pbf_press_dpad(context, DPAD_DOWN, 1, GAME_DELAY);
+            }
+        }
     }
 
-    for (size_t i = cur_cursor.column; i < dest_cursor.column; ++i){
-        pbf_press_dpad(context, DPAD_RIGHT, 1, GAME_DELAY);
-    }
-    for (size_t i = dest_cursor.column; i < cur_cursor.column; ++i){
-        pbf_press_dpad(context, DPAD_LEFT, 1, GAME_DELAY);
+    // direct nav forward or backward through columns
+    if ((dest_cursor.column > cur_cursor.column && dest_cursor.column - cur_cursor.column <= 3) || (cur_cursor.column > dest_cursor.column && cur_cursor.column - dest_cursor.column <= 3)) {
+        for (size_t i = cur_cursor.column; i < dest_cursor.column; ++i){
+            pbf_press_dpad(context, DPAD_RIGHT, 1, GAME_DELAY);
+        }
+        for (size_t i = dest_cursor.column; i < cur_cursor.column; ++i){
+            pbf_press_dpad(context, DPAD_LEFT, 1, GAME_DELAY);
+        }
+    } else { // wrap around is faster if direct movement is more than 3 away
+        if (dest_cursor.column > cur_cursor.column) {
+            for (size_t i = 0; i < MAX_COLUMNS - (dest_cursor.column - cur_cursor.column); ++i){
+                pbf_press_dpad(context, DPAD_LEFT, 1, GAME_DELAY);
+            }
+        }
+        if (cur_cursor.column > dest_cursor.column) {
+            for (size_t i = 0; i < MAX_COLUMNS - (cur_cursor.column - dest_cursor.column); ++i){
+                pbf_press_dpad(context, DPAD_RIGHT, 1, GAME_DELAY);
+            }
+        }
     }
 
     context.wait_for_all_requests();

--- a/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxSorting.h
+++ b/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxSorting.h
@@ -9,9 +9,12 @@
 
 #include "Common/Cpp/Options/BooleanCheckBoxOption.h"
 #include "Common/Cpp/Options/SimpleIntegerOption.h"
+#include "Common/Cpp/Options/StringOption.h"
 #include "CommonFramework/Notifications/EventNotificationsTable.h"
 #include "NintendoSwitch/NintendoSwitch_SingleSwitchProgram.h"
 #include "NintendoSwitch/Options/NintendoSwitch_StartInGripMenuOption.h"
+#include "PokemonHome/Options/PokemonHome_BoxSortingTable.h"
+
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
@@ -35,6 +38,9 @@ private:
     SimpleIntegerOption<uint16_t> BOX_NUMBER;
     SimpleIntegerOption<uint16_t> VIDEO_DELAY;
     SimpleIntegerOption<uint16_t> GAME_DELAY;
+    BoxSortingTable SORT_TABLE;
+    StringOption OUTPUT_FILE;
+    BooleanCheckBoxOption DRY_RUN;
     EventNotificationsOption NOTIFICATIONS;
 
 };


### PR DESCRIPTION
This PR adds the following:

1.  Row and Column nav now use shortest path with wrap around when it makes sense to do so.
2. A table for options related to sort order (need to handle the "reverse" checkbox)
3. JSON file output of current state and sorted state.
4. "Dry run" option for just collecting current state (and outputting file showing sorted state if it were to be applied with current settings.)