### PR TITLE
Fix Mass Release message

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Programs/PokemonSV_MassRelease.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/PokemonSV_MassRelease.cpp
@@ -30,7 +30,7 @@ MassRelease_Descriptor::MassRelease_Descriptor()
         "PokemonSV:MassRelease",
         STRING_POKEMON + " SV", "Mass Release",
         "ComputerControl/blob/master/Wiki/Programs/PokemonSV/MassRelease.md",
-        "Farm items from Tera raids.",
+        "Mass release boxes of Pokémon.",
         FeedbackType::REQUIRED, false,
         PABotBaseLevel::PABOTBASE_12KB
     )


### PR DESCRIPTION
Looks like the Descriptor was copied over from the Tera Farmer and this was missed.