### PR TITLE
Nature filters

### DIFF
--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -827,6 +827,8 @@ file(GLOB MAIN_SOURCES
     Source/Pokemon/Inference/Pokemon_IVCheckerReader.h
     Source/Pokemon/Inference/Pokemon_NameReader.cpp
     Source/Pokemon/Inference/Pokemon_NameReader.h
+    Source/Pokemon/Inference/Pokemon_NatureReader.cpp
+    Source/Pokemon/Inference/Pokemon_NatureReader.h
     Source/Pokemon/Inference/Pokemon_PokeballNameReader.cpp
     Source/Pokemon/Inference/Pokemon_PokeballNameReader.h
     Source/Pokemon/Inference/Pokemon_TrainIVCheckerOCR.cpp
@@ -849,6 +851,8 @@ file(GLOB MAIN_SOURCES
     Source/Pokemon/Pokemon_EncounterStats.h
     Source/Pokemon/Pokemon_IVChecker.cpp
     Source/Pokemon/Pokemon_IVChecker.h
+    Source/Pokemon/Pokemon_NatureChecker.cpp
+    Source/Pokemon/Pokemon_NatureChecker.h
     Source/Pokemon/Pokemon_Notification.cpp
     Source/Pokemon/Pokemon_Notification.h
     Source/Pokemon/Pokemon_ShinySparkleSet.cpp
@@ -1229,6 +1233,8 @@ file(GLOB MAIN_SOURCES
     Source/PokemonSV/Inference/Boxes/PokemonSV_BoxEggDetector.h
     Source/PokemonSV/Inference/Boxes/PokemonSV_BoxGenderDetector.cpp
     Source/PokemonSV/Inference/Boxes/PokemonSV_BoxGenderDetector.h
+    Source/PokemonSV/Inference/Boxes/PokemonSV_BoxNatureDetector.cpp
+    Source/PokemonSV/Inference/Boxes/PokemonSV_BoxNatureDetector.h
     Source/PokemonSV/Inference/Boxes/PokemonSV_BoxShinyDetector.cpp
     Source/PokemonSV/Inference/Boxes/PokemonSV_BoxShinyDetector.h
     Source/PokemonSV/Inference/Boxes/PokemonSV_IVCheckerReader.cpp

--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -885,6 +885,8 @@ file(GLOB MAIN_SOURCES
     Source/PokemonBDSP/Inference/BoxSystem/PokemonBDSP_BoxDetector.h
     Source/PokemonBDSP/Inference/BoxSystem/PokemonBDSP_BoxGenderDetector.cpp
     Source/PokemonBDSP/Inference/BoxSystem/PokemonBDSP_BoxGenderDetector.h
+    Source/PokemonBDSP/Inference/BoxSystem/PokemonBDSP_BoxNatureDetector.cpp
+    Source/PokemonBDSP/Inference/BoxSystem/PokemonBDSP_BoxNatureDetector.h
     Source/PokemonBDSP/Inference/BoxSystem/PokemonBDSP_BoxShinyDetector.cpp
     Source/PokemonBDSP/Inference/BoxSystem/PokemonBDSP_BoxShinyDetector.h
     Source/PokemonBDSP/Inference/BoxSystem/PokemonBDSP_IVCheckerReader.cpp

--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -1413,6 +1413,8 @@ file(GLOB MAIN_SOURCES
     Source/PokemonSwSh/Inference/Dens/PokemonSwSh_RaidLobbyReader.h
     Source/PokemonSwSh/Inference/PokemonSwSh_BoxGenderDetector.cpp
     Source/PokemonSwSh/Inference/PokemonSwSh_BoxGenderDetector.h
+    Source/PokemonSwSh/Inference/PokemonSwSh_BoxNatureDetector.cpp
+    Source/PokemonSwSh/Inference/PokemonSwSh_BoxNatureDetector.h
     Source/PokemonSwSh/Inference/PokemonSwSh_BoxShinySymbolDetector.cpp
     Source/PokemonSwSh/Inference/PokemonSwSh_BoxShinySymbolDetector.h
     Source/PokemonSwSh/Inference/PokemonSwSh_DialogBoxDetector.cpp

--- a/SerialPrograms/Source/Pokemon/Inference/Pokemon_NatureReader.cpp
+++ b/SerialPrograms/Source/Pokemon/Inference/Pokemon_NatureReader.cpp
@@ -1,0 +1,74 @@
+/*  Nature Reader
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "CommonFramework/OCR/OCR_Routines.h"
+#include "Pokemon_NatureReader.h"
+
+namespace PokemonAutomation{
+namespace Pokemon{
+
+namespace {
+
+std::string nature_checker_value_to_string(NatureCheckerValue value) {
+    const char* names[] = {
+        "UnableToDetect",
+        "Any",
+        "Adamant",
+        "Bashful",
+        "Bold",
+        "Brave",
+        "Calm",
+        "Careful",
+        "Docile",
+        "Gentle",
+        "Hardy",
+        "Hasty",
+        "Impish",
+        "Jolly",
+        "Lax",
+        "Lonely",
+        "Mild",
+        "Modest",
+        "Naive",
+        "Naughty",
+        "Quiet",
+        "Quirky",
+        "Rash",
+        "Relaxed",
+        "Sassy",
+        "Serious",
+        "Timid",
+    };
+
+    return names[int(value)];
+}
+}
+
+NatureReader::NatureReader(const std::string& json_path)
+: SmallDictionaryMatcher(json_path)
+{}
+
+OCR::StringMatchResult NatureReader::read_substring(
+    Logger& logger,
+    Language language,
+    const ImageViewRGB32& image,
+    const std::vector<OCR::TextColorRange>& text_color_ranges,
+    double min_text_ratio, double max_text_ratio
+    ) const {
+    return match_substring_from_image_multifiltered(
+        &logger, language, image, text_color_ranges,
+        MAX_LOG10P, MAX_LOG10P_SPREAD,
+        min_text_ratio, max_text_ratio
+    );
+}
+
+std::string NatureReader::Results::to_string() const {
+    return  "HP: " + nature_checker_value_to_string(nature);
+}
+
+
+}
+}

--- a/SerialPrograms/Source/Pokemon/Inference/Pokemon_NatureReader.cpp
+++ b/SerialPrograms/Source/Pokemon/Inference/Pokemon_NatureReader.cpp
@@ -41,6 +41,7 @@ std::string nature_checker_value_to_string(NatureCheckerValue value) {
         "Sassy",
         "Serious",
         "Timid",
+        "Last"
     };
 
     return names[int(value)];
@@ -66,7 +67,7 @@ OCR::StringMatchResult NatureReader::read_substring(
 }
 
 std::string NatureReader::Results::to_string() const {
-    return  "HP: " + nature_checker_value_to_string(nature);
+    return  "Nature: " + nature_checker_value_to_string(nature);
 }
 
 

--- a/SerialPrograms/Source/Pokemon/Inference/Pokemon_NatureReader.h
+++ b/SerialPrograms/Source/Pokemon/Inference/Pokemon_NatureReader.h
@@ -1,0 +1,42 @@
+/*  Nature Reader
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_Pokemon_NatureReader_H
+#define PokemonAutomation_Pokemon_NatureReader_H
+
+#include "CommonFramework/Logging/Logger.h"
+#include "CommonFramework/OCR/OCR_SmallDictionaryMatcher.h"
+#include "Pokemon/Pokemon_NatureChecker.h"
+
+namespace PokemonAutomation {
+namespace Pokemon {
+
+class NatureReader : public OCR::SmallDictionaryMatcher {
+public:
+    static constexpr double MAX_LOG10P = -1.40;
+    static constexpr double MAX_LOG10P_SPREAD = 0.50;
+
+public:
+    struct Results {
+        NatureCheckerValue nature = NatureCheckerValue::UnableToDetect;
+        std::string to_string() const;
+    };
+
+    NatureReader(const std::string& json_path);
+
+    OCR::StringMatchResult read_substring(
+        Logger& logger,
+        Language language,
+        const ImageViewRGB32& image,
+        const std::vector<OCR::TextColorRange>& text_color_ranges,
+        double min_text_ratio = 0.01, double max_text_ratio = 0.50
+    ) const;
+
+};
+
+}
+}
+#endif

--- a/SerialPrograms/Source/Pokemon/Options/Pokemon_EggHatchFilter.cpp
+++ b/SerialPrograms/Source/Pokemon/Options/Pokemon_EggHatchFilter.cpp
@@ -52,13 +52,11 @@ const EnumDatabase<EggHatchGenderFilter>& EggHatchGenderFilter_Database(){
     return database;
 }
 
-
-
-
 EggHatchFilterRow::EggHatchFilterRow()
     : action(EggHatchAction_Database(), LockWhileRunning::LOCKED, EggHatchAction::Keep)
     , shiny(EggHatchShinyFilter_Database(), LockWhileRunning::LOCKED, EggHatchShinyFilter::Anything)
     , gender(EggHatchGenderFilter_Database(), LockWhileRunning::LOCKED, EggHatchGenderFilter::Any)
+    , nature(NatureCheckerFilter_Database(), LockWhileRunning::LOCKED, NatureCheckerFilter::Any)
     , iv_hp(IVCheckerFilter::Anything)
     , iv_atk(IVCheckerFilter::Anything)
     , iv_def(IVCheckerFilter::Anything)
@@ -69,6 +67,7 @@ EggHatchFilterRow::EggHatchFilterRow()
     PA_ADD_OPTION(action);
     PA_ADD_OPTION(shiny);
     PA_ADD_OPTION(gender);
+    PA_ADD_OPTION(nature);
     PA_ADD_OPTION(iv_hp);
     PA_ADD_OPTION(iv_atk);
     PA_ADD_OPTION(iv_def);
@@ -86,6 +85,7 @@ std::unique_ptr<EditableTableRow> EggHatchFilterRow::clone() const{
     ret->action.set(action);
     ret->shiny.set(shiny);
     ret->gender.set(gender);
+    ret->nature.set(nature);
     ret->iv_hp.set(iv_hp);
     ret->iv_atk.set(iv_atk);
     ret->iv_def.set(iv_def);
@@ -115,6 +115,7 @@ std::vector<std::string> EggHatchFilterTable::make_header() const{
         "Action",
         "Shininess",
         "Gender",
+        "Nature",
         "HP",
         "Attack",
         "Defense",
@@ -129,8 +130,7 @@ std::vector<std::unique_ptr<EditableTableRow>> EggHatchFilterTable::make_default
     return ret;
 }
 
-
-EggHatchAction EggHatchFilterTable::get_action(bool shiny, const IVCheckerReader::Results& IVs, EggHatchGenderFilter gender) const{
+EggHatchAction EggHatchFilterTable::get_action(bool shiny, const IVCheckerReader::Results& IVs, EggHatchGenderFilter gender, NatureReader::Results nature) const{
     EggHatchAction action = EggHatchAction::Release;
     std::vector<std::unique_ptr<EggHatchFilterRow>> list = copy_snapshot();
     for (size_t c = 0; c < list.size(); c++){
@@ -164,6 +164,9 @@ EggHatchAction EggHatchFilterTable::get_action(bool shiny, const IVCheckerReader
         if(filter_gender != gender && filter_gender != EggHatchGenderFilter::Any){
             continue;
         }
+
+        if (!NatureChecker_filter_match(filter.nature, nature.nature)) continue;
+        
 
         EggHatchAction filter_action = filter.action;
 

--- a/SerialPrograms/Source/Pokemon/Options/Pokemon_EggHatchFilter.h
+++ b/SerialPrograms/Source/Pokemon/Options/Pokemon_EggHatchFilter.h
@@ -10,8 +10,10 @@
 #include "Common/Cpp/Options/EnumDropdownOption.h"
 #include "Common/Cpp/Options/EditableTableOption.h"
 //#include "Pokemon/Pokemon_IVChecker.h"
+#include "Pokemon/Pokemon_NatureChecker.h"
 #include "Pokemon/Options/Pokemon_IVCheckerOption.h"
 #include "Pokemon/Inference/Pokemon_IVCheckerReader.h"
+#include "Pokemon/Inference/Pokemon_NatureReader.h"
 
 namespace PokemonAutomation{
 namespace Pokemon{
@@ -78,7 +80,7 @@ public:
     EnumDropdownCell<EggHatchAction> action;
     EnumDropdownCell<EggHatchShinyFilter> shiny;
     EnumDropdownCell<EggHatchGenderFilter> gender;
-    EnumDropdownCell<EggHatchNatureFilter> nature;
+    EnumDropdownCell<NatureCheckerFilter> nature;
     IVCheckerFilterCell iv_hp;
     IVCheckerFilterCell iv_atk;
     IVCheckerFilterCell iv_def;
@@ -93,7 +95,7 @@ public:
     virtual std::vector<std::string> make_header() const override;
     static std::vector<std::unique_ptr<EditableTableRow>> make_defaults();
 
-    EggHatchAction get_action(bool shiny, const IVCheckerReader::Results& IVs, EggHatchGenderFilter gender, EggHatchNatureFilter nature) const;
+    EggHatchAction get_action(bool shiny, const IVCheckerReader::Results& IVs, EggHatchGenderFilter gender, NatureReader::Results nature) const;
 };
 
 

--- a/SerialPrograms/Source/Pokemon/Options/Pokemon_EggHatchFilter.h
+++ b/SerialPrograms/Source/Pokemon/Options/Pokemon_EggHatchFilter.h
@@ -36,9 +36,36 @@ enum class EggHatchGenderFilter{
     Genderless
 };
 
+enum class EggHatchNatureFilter {
+    Any,
+    Adamant,
+    Bashful,
+    Bold,
+    Brave,
+    Calm,
+    Careful,
+    Docile,
+    Gentle,
+    Hardy,
+    Hasty,
+    Impish,
+    Jolly,
+    Lax,
+    Lonely,
+    Mild,
+    Modest,
+    Naive,
+    Naughty,
+    Quiet,
+    Quirky,
+    Rash,
+    Relaxed,
+    Sassy,
+    Serious,
+    Timid
+};
+
 std::string gender_to_string(EggHatchGenderFilter gender);
-
-
 
 
 class EggHatchFilterRow : public EditableTableRow{
@@ -51,6 +78,7 @@ public:
     EnumDropdownCell<EggHatchAction> action;
     EnumDropdownCell<EggHatchShinyFilter> shiny;
     EnumDropdownCell<EggHatchGenderFilter> gender;
+    EnumDropdownCell<EggHatchNatureFilter> nature;
     IVCheckerFilterCell iv_hp;
     IVCheckerFilterCell iv_atk;
     IVCheckerFilterCell iv_def;
@@ -65,7 +93,7 @@ public:
     virtual std::vector<std::string> make_header() const override;
     static std::vector<std::unique_ptr<EditableTableRow>> make_defaults();
 
-    EggHatchAction get_action(bool shiny, const IVCheckerReader::Results& IVs, EggHatchGenderFilter gender) const;
+    EggHatchAction get_action(bool shiny, const IVCheckerReader::Results& IVs, EggHatchGenderFilter gender, EggHatchNatureFilter nature) const;
 };
 
 

--- a/SerialPrograms/Source/Pokemon/Pokemon_NatureChecker.cpp
+++ b/SerialPrograms/Source/Pokemon/Pokemon_NatureChecker.cpp
@@ -11,7 +11,6 @@
 namespace PokemonAutomation{
 namespace Pokemon{
 
-
 const std::map<std::string, NatureCheckerValue> NatureCheckerValue_TOKEN_TO_ENUM{
     {"Adamant",     NatureCheckerValue::Adamant},
     {"Bashful",     NatureCheckerValue::Bashful},
@@ -26,6 +25,7 @@ const std::map<std::string, NatureCheckerValue> NatureCheckerValue_TOKEN_TO_ENUM
     {"Impish",      NatureCheckerValue::Impish},
     {"Jolly",       NatureCheckerValue::Jolly},
     {"Lax",         NatureCheckerValue::Lax},
+    {"Lonely",      NatureCheckerValue::Lonely},
     {"Mild",        NatureCheckerValue::Mild},
     {"Modest",      NatureCheckerValue::Modest},
     {"Naive",       NatureCheckerValue::Naive},
@@ -52,6 +52,7 @@ const std::map<NatureCheckerValue, std::string> NatureCheckerValue_ENUM_TO_TOKEN
     {NatureCheckerValue::Impish,            "Impish"},
     {NatureCheckerValue::Jolly,             "Jolly"},
     {NatureCheckerValue::Lax,               "Lax"},
+    {NatureCheckerValue::Lonely,            "Lonely"},
     {NatureCheckerValue::Mild,              "Mild"},
     {NatureCheckerValue::Modest,            "Modest"},
     {NatureCheckerValue::Naive,             "Naive"},
@@ -64,6 +65,31 @@ const std::map<NatureCheckerValue, std::string> NatureCheckerValue_ENUM_TO_TOKEN
     {NatureCheckerValue::Serious,           "Serious"},
     {NatureCheckerValue::Timid,             "Timid"},
 };
+
+const std::map<std::pair<int, int>, NatureCheckerValue> NatureCheckerValue_HELPHINDER_TO_ENUM{
+    {{ 0, 2 },      NatureCheckerValue::Adamant},
+    {{ -1, -1 },    NatureCheckerValue::Bashful}, //Bashful, Docile, Hardy, Quirky, Serious
+    {{ 1, 0 },      NatureCheckerValue::Bold},
+    {{ 0, 4 },      NatureCheckerValue::Brave},
+    {{ 3, 0 },      NatureCheckerValue::Calm},
+    {{ 3, 2 },      NatureCheckerValue::Careful},
+    {{ 3, 1 },      NatureCheckerValue::Gentle},
+    {{ 4, 1 },      NatureCheckerValue::Hasty},
+    {{ 1, 2 },      NatureCheckerValue::Impish},
+    {{ 4, 2 },      NatureCheckerValue::Jolly},
+    {{ 1, 3 },      NatureCheckerValue::Lax},
+    {{ 0, 1 },      NatureCheckerValue::Lonely},
+    {{ 2, 1 },      NatureCheckerValue::Mild},
+    {{ 2, 0 },      NatureCheckerValue::Modest},
+    {{ 4, 3 },      NatureCheckerValue::Naive},
+    {{ 0, 3 },      NatureCheckerValue::Naughty},
+    {{ 2, 4 },      NatureCheckerValue::Quiet},
+    {{ 2, 3 },      NatureCheckerValue::Rash},
+    {{ 1, 4 },      NatureCheckerValue::Relaxed},
+    {{ 3, 4 },      NatureCheckerValue::Sassy},
+    {{ 4, 0 },      NatureCheckerValue::Timid},
+};
+
 NatureCheckerValue NatureCheckerValue_string_to_enum(const std::string& token){
     auto iter = NatureCheckerValue_TOKEN_TO_ENUM.find(token);
     if (iter == NatureCheckerValue_TOKEN_TO_ENUM.end()){
@@ -72,6 +98,13 @@ NatureCheckerValue NatureCheckerValue_string_to_enum(const std::string& token){
     return iter->second;
 }
 
+NatureCheckerValue NatureCheckerValue_helphinder_to_enum(const std::pair<int,int>& token) {
+    auto iter = NatureCheckerValue_HELPHINDER_TO_ENUM.find(token);
+    if (iter == NatureCheckerValue_HELPHINDER_TO_ENUM.end()) {
+        return NatureCheckerValue::UnableToDetect;
+    }
+    return iter->second;
+}
 
 const EnumDatabase<NatureCheckerValue>& NatureCheckerValue_Database(){
     static EnumDatabase<NatureCheckerValue> database({

--- a/SerialPrograms/Source/Pokemon/Pokemon_NatureChecker.cpp
+++ b/SerialPrograms/Source/Pokemon/Pokemon_NatureChecker.cpp
@@ -1,0 +1,203 @@
+/*  Pokemon Nature Checker
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include <map>
+#include "Common/Cpp/Exceptions.h"
+#include "Pokemon_NatureChecker.h"
+
+namespace PokemonAutomation{
+namespace Pokemon{
+
+
+const std::map<std::string, NatureCheckerValue> NatureCheckerValue_TOKEN_TO_ENUM{
+    {"Adamant",     NatureCheckerValue::Adamant},
+    {"Bashful",     NatureCheckerValue::Bashful},
+    {"Bold",        NatureCheckerValue::Bold},
+    {"Brave",       NatureCheckerValue::Brave},
+    {"Calm",        NatureCheckerValue::Calm},
+    {"Careful",     NatureCheckerValue::Careful},
+    {"Docile",      NatureCheckerValue::Docile},
+    {"Gentle",      NatureCheckerValue::Gentle},
+    {"Hardy",       NatureCheckerValue::Hardy},
+    {"Hasty",       NatureCheckerValue::Hasty},
+    {"Impish",      NatureCheckerValue::Impish},
+    {"Jolly",       NatureCheckerValue::Jolly},
+    {"Lax",         NatureCheckerValue::Lax},
+    {"Mild",        NatureCheckerValue::Mild},
+    {"Modest",      NatureCheckerValue::Modest},
+    {"Naive",       NatureCheckerValue::Naive},
+    {"Naughty",     NatureCheckerValue::Naughty},
+    {"Quiet",       NatureCheckerValue::Quiet},
+    {"Quirky",      NatureCheckerValue::Quirky},
+    {"Rash",        NatureCheckerValue::Rash},
+    {"Relaxed",     NatureCheckerValue::Relaxed},
+    {"Sassy",       NatureCheckerValue::Sassy},
+    {"Serious",     NatureCheckerValue::Serious},
+    {"Timid",       NatureCheckerValue::Timid},
+};
+const std::map<NatureCheckerValue, std::string> NatureCheckerValue_ENUM_TO_TOKEN{
+    {NatureCheckerValue::UnableToDetect,    "Unable to Detect"},
+    {NatureCheckerValue::Adamant,           "Adamant"},
+    {NatureCheckerValue::Bashful,           "Bashful"},
+    {NatureCheckerValue::Bold,              "Bold"},
+    {NatureCheckerValue::Brave,             "Brave"},
+    {NatureCheckerValue::Calm,              "Calm"},
+    {NatureCheckerValue::Careful,           "Careful"},
+    {NatureCheckerValue::Gentle,            "Gentle"},
+    {NatureCheckerValue::Hardy,             "Hardy"},
+    {NatureCheckerValue::Hasty,             "Hasty"},
+    {NatureCheckerValue::Impish,            "Impish"},
+    {NatureCheckerValue::Jolly,             "Jolly"},
+    {NatureCheckerValue::Lax,               "Lax"},
+    {NatureCheckerValue::Mild,              "Mild"},
+    {NatureCheckerValue::Modest,            "Modest"},
+    {NatureCheckerValue::Naive,             "Naive"},
+    {NatureCheckerValue::Naughty,           "Naughty"},
+    {NatureCheckerValue::Quiet,             "Quiet"},
+    {NatureCheckerValue::Quirky,            "Quirky"},
+    {NatureCheckerValue::Rash,              "Rash"},
+    {NatureCheckerValue::Relaxed,           "Relaxed"},
+    {NatureCheckerValue::Sassy,             "Sassy"},
+    {NatureCheckerValue::Serious,           "Serious"},
+    {NatureCheckerValue::Timid,             "Timid"},
+};
+NatureCheckerValue NatureCheckerValue_string_to_enum(const std::string& token){
+    auto iter = NatureCheckerValue_TOKEN_TO_ENUM.find(token);
+    if (iter == NatureCheckerValue_TOKEN_TO_ENUM.end()){
+        return NatureCheckerValue::UnableToDetect;
+    }
+    return iter->second;
+}
+
+
+const EnumDatabase<NatureCheckerValue>& NatureCheckerValue_Database(){
+    static EnumDatabase<NatureCheckerValue> database({
+        {NatureCheckerValue::Adamant,     "adamant",      "Adamant"},
+        {NatureCheckerValue::Bashful,     "bashful",      "Bashful"},
+        {NatureCheckerValue::Bold,        "bold",         "Bold"},
+        {NatureCheckerValue::Brave,       "brave",        "Brave"},
+        {NatureCheckerValue::Calm,        "calm",         "Calm"},
+        {NatureCheckerValue::Careful,     "careful",      "Careful"},
+        {NatureCheckerValue::Docile,      "docile",       "Docile"},
+        {NatureCheckerValue::Gentle,      "gentle",       "Gentle"},
+        {NatureCheckerValue::Hardy,       "hardy",        "Hardy"},
+        {NatureCheckerValue::Hasty,       "hasty",        "Hasty"},
+        {NatureCheckerValue::Impish,      "impish",       "Impish"},
+        {NatureCheckerValue::Jolly,       "jolly",        "Jolly"},
+        {NatureCheckerValue::Lax,         "lax",          "Lax"},
+        {NatureCheckerValue::Lonely,      "lonely",       "Lonely"},
+        {NatureCheckerValue::Mild,        "mild",         "Mild"},
+        {NatureCheckerValue::Modest,      "modest",       "Modest"},
+        {NatureCheckerValue::Naive,       "naive",        "Naive"},
+        {NatureCheckerValue::Naughty,     "naughty",      "Naughty"},
+        {NatureCheckerValue::Quiet,       "quiet",        "Quiet"},
+        {NatureCheckerValue::Quirky,      "quirky",       "Quirky"},
+        {NatureCheckerValue::Rash,        "rash",         "Rash"},
+        {NatureCheckerValue::Relaxed,     "relaxed",      "Relaxed"},
+        {NatureCheckerValue::Sassy,       "sassy",        "Sassy"},
+        {NatureCheckerValue::Serious,     "serious",      "Serious"},
+        {NatureCheckerValue::Timid,       "timid",        "Timid"},
+    });
+    return database;
+}
+
+const EnumDatabase<NatureCheckerFilter>& NatureCheckerFilter_Database(){
+    static EnumDatabase<NatureCheckerFilter> database({
+        {NatureCheckerFilter::Any,         "any",          "Any"},
+        {NatureCheckerFilter::Adamant,     "adamant",      "Adamant"},
+        {NatureCheckerFilter::Bashful,     "bashful",      "Bashful"},
+        {NatureCheckerFilter::Bold,        "bold",         "Bold"},
+        {NatureCheckerFilter::Brave,       "brave",        "Brave"},
+        {NatureCheckerFilter::Calm,        "calm",         "Calm"},
+        {NatureCheckerFilter::Careful,     "careful",      "Careful"},
+        {NatureCheckerFilter::Docile,      "docile",       "Docile"},
+        {NatureCheckerFilter::Gentle,      "gentle",       "Gentle"},
+        {NatureCheckerFilter::Hardy,       "hardy",        "Hardy"},
+        {NatureCheckerFilter::Hasty,       "hasty",        "Hasty"},
+        {NatureCheckerFilter::Impish,      "impish",       "Impish"},
+        {NatureCheckerFilter::Jolly,       "jolly",        "Jolly"},
+        {NatureCheckerFilter::Lax,         "lax",          "Lax"},
+        {NatureCheckerFilter::Lonely,      "lonely",       "Lonely"},
+        {NatureCheckerFilter::Mild,        "mild",         "Mild"},
+        {NatureCheckerFilter::Modest,      "modest",       "Modest"},
+        {NatureCheckerFilter::Naive,       "naive",        "Naive"},
+        {NatureCheckerFilter::Naughty,     "naughty",      "Naughty"},
+        {NatureCheckerFilter::Quiet,       "quiet",        "Quiet"},
+        {NatureCheckerFilter::Quirky,      "quirky",       "Quirky"},
+        {NatureCheckerFilter::Rash,        "rash",         "Rash"},
+        {NatureCheckerFilter::Relaxed,     "relaxed",      "Relaxed"},
+        {NatureCheckerFilter::Sassy,       "sassy",        "Sassy"},
+        {NatureCheckerFilter::Serious,     "serious",      "Serious"},
+        {NatureCheckerFilter::Timid,       "timid",        "Timid"},
+    });
+    return database;
+}
+
+
+
+bool NatureChecker_filter_match(NatureCheckerFilter filter, NatureCheckerValue value){
+    switch (filter){
+    case NatureCheckerFilter::Any:
+        return true;
+    case NatureCheckerFilter::Adamant:
+        return value == NatureCheckerValue::Adamant;
+    case NatureCheckerFilter::Bashful:
+        return value == NatureCheckerValue::Bashful;
+    case NatureCheckerFilter::Bold:
+        return value == NatureCheckerValue::Bold;
+    case NatureCheckerFilter::Brave:
+        return value == NatureCheckerValue::Brave;
+    case NatureCheckerFilter::Calm:
+        return value == NatureCheckerValue::Calm;
+    case NatureCheckerFilter::Careful:
+        return value == NatureCheckerValue::Careful;
+    case NatureCheckerFilter::Docile:
+        return value == NatureCheckerValue::Docile;
+    case NatureCheckerFilter::Gentle:
+        return value == NatureCheckerValue::Gentle;
+    case NatureCheckerFilter::Hardy:
+        return value == NatureCheckerValue::Hardy;
+    case NatureCheckerFilter::Hasty:
+        return value == NatureCheckerValue::Hasty;
+    case NatureCheckerFilter::Impish:
+        return value == NatureCheckerValue::Impish;
+    case NatureCheckerFilter::Jolly:
+        return value == NatureCheckerValue::Jolly;
+    case NatureCheckerFilter::Lax:
+        return value == NatureCheckerValue::Lax;
+    case NatureCheckerFilter::Lonely:
+        return value == NatureCheckerValue::Lonely;
+    case NatureCheckerFilter::Mild:
+        return value == NatureCheckerValue::Mild;
+    case NatureCheckerFilter::Modest:
+        return value == NatureCheckerValue::Modest;
+    case NatureCheckerFilter::Naive:
+        return value == NatureCheckerValue::Naive;
+    case NatureCheckerFilter::Naughty:
+        return value == NatureCheckerValue::Naughty;
+    case NatureCheckerFilter::Quiet:
+        return value == NatureCheckerValue::Quiet;
+    case NatureCheckerFilter::Quirky:
+        return value == NatureCheckerValue::Quirky;
+    case NatureCheckerFilter::Rash:
+        return value == NatureCheckerValue::Rash;
+    case NatureCheckerFilter::Relaxed:
+        return value == NatureCheckerValue::Relaxed;
+    case NatureCheckerFilter::Sassy:
+        return value == NatureCheckerValue::Sassy;
+    case NatureCheckerFilter::Serious:
+        return value == NatureCheckerValue::Serious;
+    case NatureCheckerFilter::Timid:
+        return value == NatureCheckerValue::Timid;
+    }
+    return false;
+}
+
+
+
+
+}
+}

--- a/SerialPrograms/Source/Pokemon/Pokemon_NatureChecker.cpp
+++ b/SerialPrograms/Source/Pokemon/Pokemon_NatureChecker.cpp
@@ -40,6 +40,7 @@ const std::map<std::string, NatureCheckerValue> NatureCheckerValue_TOKEN_TO_ENUM
 };
 const std::map<NatureCheckerValue, std::string> NatureCheckerValue_ENUM_TO_TOKEN{
     {NatureCheckerValue::UnableToDetect,    "Unable to Detect"},
+    {NatureCheckerValue::Neutral,           "Neutral"},
     {NatureCheckerValue::Adamant,           "Adamant"},
     {NatureCheckerValue::Bashful,           "Bashful"},
     {NatureCheckerValue::Bold,              "Bold"},
@@ -68,7 +69,7 @@ const std::map<NatureCheckerValue, std::string> NatureCheckerValue_ENUM_TO_TOKEN
 
 const std::map<std::pair<int, int>, NatureCheckerValue> NatureCheckerValue_HELPHINDER_TO_ENUM{
     {{ 0, 2 },      NatureCheckerValue::Adamant},
-    {{ -1, -1 },    NatureCheckerValue::Bashful}, //Bashful, Docile, Hardy, Quirky, Serious
+    {{ -1, -1 },    NatureCheckerValue::Neutral}, //Bashful, Docile, Hardy, Quirky, Serious
     {{ 1, 0 },      NatureCheckerValue::Bold},
     {{ 0, 4 },      NatureCheckerValue::Brave},
     {{ 3, 0 },      NatureCheckerValue::Calm},
@@ -178,6 +179,9 @@ bool NatureChecker_filter_match(NatureCheckerFilter filter, NatureCheckerValue v
     case NatureCheckerFilter::Adamant:
         return value == NatureCheckerValue::Adamant;
     case NatureCheckerFilter::Bashful:
+        if (value == NatureCheckerValue::Neutral) {
+            return true;
+        }
         return value == NatureCheckerValue::Bashful;
     case NatureCheckerFilter::Bold:
         return value == NatureCheckerValue::Bold;
@@ -188,10 +192,16 @@ bool NatureChecker_filter_match(NatureCheckerFilter filter, NatureCheckerValue v
     case NatureCheckerFilter::Careful:
         return value == NatureCheckerValue::Careful;
     case NatureCheckerFilter::Docile:
+        if (value == NatureCheckerValue::Neutral) {
+            return true;
+        }
         return value == NatureCheckerValue::Docile;
     case NatureCheckerFilter::Gentle:
         return value == NatureCheckerValue::Gentle;
     case NatureCheckerFilter::Hardy:
+        if (value == NatureCheckerValue::Neutral) {
+            return true;
+        }
         return value == NatureCheckerValue::Hardy;
     case NatureCheckerFilter::Hasty:
         return value == NatureCheckerValue::Hasty;
@@ -214,6 +224,9 @@ bool NatureChecker_filter_match(NatureCheckerFilter filter, NatureCheckerValue v
     case NatureCheckerFilter::Quiet:
         return value == NatureCheckerValue::Quiet;
     case NatureCheckerFilter::Quirky:
+        if (value == NatureCheckerValue::Neutral) {
+            return true;
+        }
         return value == NatureCheckerValue::Quirky;
     case NatureCheckerFilter::Rash:
         return value == NatureCheckerValue::Rash;
@@ -222,6 +235,9 @@ bool NatureChecker_filter_match(NatureCheckerFilter filter, NatureCheckerValue v
     case NatureCheckerFilter::Sassy:
         return value == NatureCheckerValue::Sassy;
     case NatureCheckerFilter::Serious:
+        if (value == NatureCheckerValue::Neutral) {
+            return true;
+        }
         return value == NatureCheckerValue::Serious;
     case NatureCheckerFilter::Timid:
         return value == NatureCheckerValue::Timid;

--- a/SerialPrograms/Source/Pokemon/Pokemon_NatureChecker.h
+++ b/SerialPrograms/Source/Pokemon/Pokemon_NatureChecker.h
@@ -16,6 +16,7 @@ namespace Pokemon{
 
 enum class NatureCheckerValue{
     UnableToDetect,
+    Neutral,
     Any,
     Adamant,
     Bashful,

--- a/SerialPrograms/Source/Pokemon/Pokemon_NatureChecker.h
+++ b/SerialPrograms/Source/Pokemon/Pokemon_NatureChecker.h
@@ -45,6 +45,8 @@ enum class NatureCheckerValue{
 };
 const EnumDatabase<NatureCheckerValue>& NatureCheckerValue_Database();
 NatureCheckerValue NatureCheckerValue_string_to_enum(const std::string& token);
+NatureCheckerValue NatureCheckerValue_helphinder_to_enum(const std::pair<int,int>& token);
+
 
 enum class NatureCheckerFilter {
     Any,

--- a/SerialPrograms/Source/Pokemon/Pokemon_NatureChecker.h
+++ b/SerialPrograms/Source/Pokemon/Pokemon_NatureChecker.h
@@ -1,0 +1,83 @@
+/*  Pokemon Nature Checker
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_Pokemon_NatureChecker_H
+#define PokemonAutomation_Pokemon_NatureChecker_H
+
+#include <string>
+#include <vector>
+#include "Common/Cpp/EnumDatabase.h"
+
+namespace PokemonAutomation{
+namespace Pokemon{
+
+enum class NatureCheckerValue{
+    UnableToDetect,
+    Any,
+    Adamant,
+    Bashful,
+    Bold,
+    Brave,
+    Calm,
+    Careful,
+    Docile,
+    Gentle,
+    Hardy,
+    Hasty,
+    Impish,
+    Jolly,
+    Lax,
+    Lonely,
+    Mild,
+    Modest,
+    Naive,
+    Naughty,
+    Quiet,
+    Quirky,
+    Rash,
+    Relaxed,
+    Sassy,
+    Serious,
+    Timid
+};
+const EnumDatabase<NatureCheckerValue>& NatureCheckerValue_Database();
+NatureCheckerValue NatureCheckerValue_string_to_enum(const std::string& token);
+
+enum class NatureCheckerFilter {
+    Any,
+    Adamant,
+    Bashful,
+    Bold,
+    Brave,
+    Calm,
+    Careful,
+    Docile,
+    Gentle,
+    Hardy,
+    Hasty,
+    Impish,
+    Jolly,
+    Lax,
+    Lonely,
+    Mild,
+    Modest,
+    Naive,
+    Naughty,
+    Quiet,
+    Quirky,
+    Rash,
+    Relaxed,
+    Sassy,
+    Serious,
+    Timid
+};
+
+const EnumDatabase<NatureCheckerFilter>& NatureCheckerFilter_Database();
+bool NatureChecker_filter_match(NatureCheckerFilter filter, NatureCheckerValue value);
+
+}
+}
+#endif

--- a/SerialPrograms/Source/PokemonBDSP/Inference/BoxSystem/PokemonBDSP_BoxNatureDetector.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Inference/BoxSystem/PokemonBDSP_BoxNatureDetector.cpp
@@ -1,11 +1,10 @@
-/*  IV Checker Reader
+/*  Box Nature Detector
  *
  *  From: https://github.com/PokemonAutomation/Arduino-Source
  *
  */
 
 #include "CommonFramework/ImageTypes/ImageViewRGB32.h"
-#include "PokemonSwSh/Inference/PokemonSwSh_IVCheckerReader.h"
 #include "PokemonBDSP_BoxNatureDetector.h"
 
 namespace PokemonAutomation{

--- a/SerialPrograms/Source/PokemonBDSP/Inference/BoxSystem/PokemonBDSP_BoxNatureDetector.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Inference/BoxSystem/PokemonBDSP_BoxNatureDetector.cpp
@@ -1,31 +1,32 @@
-/*  Box Nature Detector
+/*  IV Checker Reader
  *
  *  From: https://github.com/PokemonAutomation/Arduino-Source
  *
  */
 
 #include "CommonFramework/ImageTypes/ImageViewRGB32.h"
-#include "PokemonSV_BoxNatureDetector.h"
+#include "PokemonSwSh/Inference/PokemonSwSh_IVCheckerReader.h"
+#include "PokemonBDSP_BoxNatureDetector.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
-namespace PokemonSV{
+namespace PokemonBDSP{
 
-const NatureReader& NATURE_READER(){
-    const static Pokemon::NatureReader reader("PokemonSV/NatureCheckerOCR.json");
+const NatureReader& NATURE_READER() {
+    const static Pokemon::NatureReader reader("Pokemon/NatureCheckerOCR.json");
     return reader;
 }
 
 BoxNatureDetector::BoxNatureDetector(VideoOverlay& overlay, Language language)
     : m_language(language)
-    , m_box_nature(overlay, {0.757, 0.529, 0.141, 0.050})
+    , m_nature(overlay, {0.785, 0.196 + 6 * 0.0529, 0.2, 0.0515})
 {}
 
 NatureCheckerValue BoxNatureDetector::read(Logger& logger, const ImageViewRGB32& frame, const OverlayBoxScope& box){
     ImageViewRGB32 image = extract_box_reference(frame, box);
     OCR::StringMatchResult result = NATURE_READER().read_substring(
         logger, m_language, image,
-        OCR::WHITE_TEXT_FILTERS()
+        OCR::BLACK_TEXT_FILTERS()
     );
     result.clear_beyond_log10p(NatureReader::MAX_LOG10P);
     if (result.results.size() != 1){
@@ -36,13 +37,12 @@ NatureCheckerValue BoxNatureDetector::read(Logger& logger, const ImageViewRGB32&
 NatureReader::Results BoxNatureDetector::read(Logger& logger, const ImageViewRGB32& frame){
     NatureReader::Results results;
     if (m_language != Language::None){
-        results.nature = read(logger, frame, m_box_nature);
+        results.nature      = read(logger, frame, m_nature);
     }
     return results;
 }
 
+}
+}
+}
 
-
-}
-}
-}

--- a/SerialPrograms/Source/PokemonBDSP/Inference/BoxSystem/PokemonBDSP_BoxNatureDetector.h
+++ b/SerialPrograms/Source/PokemonBDSP/Inference/BoxSystem/PokemonBDSP_BoxNatureDetector.h
@@ -1,4 +1,4 @@
-/*  IV Checker Reader
+/*  Box Nature Detector
  *
  *  From: https://github.com/PokemonAutomation/Arduino-Source
  *

--- a/SerialPrograms/Source/PokemonBDSP/Inference/BoxSystem/PokemonBDSP_BoxNatureDetector.h
+++ b/SerialPrograms/Source/PokemonBDSP/Inference/BoxSystem/PokemonBDSP_BoxNatureDetector.h
@@ -1,0 +1,39 @@
+/*  IV Checker Reader
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonBDSP_BoxNatureDetector_H
+#define PokemonAutomation_PokemonBDSP_BoxNatureDetector_H
+
+#include "CommonFramework/VideoPipeline/VideoOverlayScopes.h"
+#include "Pokemon/Inference/Pokemon_NatureReader.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonBDSP{
+using namespace Pokemon;
+
+const NatureReader& NATURE_READER();
+
+class BoxNatureDetector {
+public:
+    BoxNatureDetector(VideoOverlay& overlay, Language language);
+
+    NatureReader::Results read(Logger& logger, const ImageViewRGB32& frame);
+
+private:
+    NatureCheckerValue read(Logger& logger, const ImageViewRGB32& frame, const OverlayBoxScope& box);
+
+private:
+    Language m_language;
+    OverlayBoxScope m_nature;
+};
+
+
+
+}
+}
+}
+#endif

--- a/SerialPrograms/Source/PokemonBDSP/Programs/Eggs/PokemonBDSP_EggAutonomousState.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/Eggs/PokemonBDSP_EggAutonomousState.cpp
@@ -21,6 +21,7 @@
 #include "PokemonBDSP/Inference/PokemonBDSP_DialogDetector.h"
 #include "PokemonBDSP/Inference/PokemonBDSP_SelectionArrow.h"
 #include "PokemonBDSP/Inference/BoxSystem/PokemonBDSP_BoxGenderDetector.h"
+#include "PokemonBDSP/Inference/BoxSystem/PokemonBDSP_BoxNatureDetector.h"
 #include "PokemonBDSP/Inference/BoxSystem/PokemonBDSP_BoxShinyDetector.h"
 #include "PokemonBDSP/Inference/BoxSystem/PokemonBDSP_IVCheckerReader.h"
 #include "PokemonBDSP/Programs/PokemonBDSP_GameNavigation.h"
@@ -189,6 +190,7 @@ bool EggAutonomousState::process_party(){
 
     BoxShinyDetector shiny_reader;
     IVCheckerReaderScope iv_reader(m_console, m_language);
+    BoxNatureDetector nature_detector(m_console.overlay(), m_language);
 
     VideoOverlaySet set(m_console);
     shiny_reader.make_overlays(set);
@@ -224,7 +226,7 @@ bool EggAutonomousState::process_party(){
         }
         IVCheckerReader::Results IVs = iv_reader.read(m_console, screen);
         EggHatchGenderFilter gender = read_gender_from_box(m_console, m_console, screen);
-        NatureReader::Results nature;
+        NatureReader::Results nature = nature_detector.read(m_console.logger(), screen);
 
         EggHatchAction action = m_filters.get_action(shiny, IVs, gender, nature);
 

--- a/SerialPrograms/Source/PokemonBDSP/Programs/Eggs/PokemonBDSP_EggAutonomousState.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/Eggs/PokemonBDSP_EggAutonomousState.cpp
@@ -224,8 +224,9 @@ bool EggAutonomousState::process_party(){
         }
         IVCheckerReader::Results IVs = iv_reader.read(m_console, screen);
         EggHatchGenderFilter gender = read_gender_from_box(m_console, m_console, screen);
+        NatureReader::Results nature;
 
-        EggHatchAction action = m_filters.get_action(shiny, IVs, gender);
+        EggHatchAction action = m_filters.get_action(shiny, IVs, gender, nature);
 
         switch (action){
         case EggHatchAction::StopProgram:

--- a/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxNatureDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxNatureDetector.cpp
@@ -1,0 +1,48 @@
+/*  Box Nature Detector
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "CommonFramework/ImageTypes/ImageViewRGB32.h"
+#include "PokemonSV_BoxNatureDetector.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonSV{
+
+const NatureReader& NATURE_READER(){
+    const static Pokemon::NatureReader reader("PokemonSV/NatureCheckerOCR.json");
+    return reader;
+}
+
+BoxNatureDetector::BoxNatureDetector(VideoOverlay& overlay, Language language)
+    : m_language(language)
+    , m_box_nature(overlay, {0.757, 0.529, 0.141, 0.050})
+{}
+
+NatureCheckerValue BoxNatureDetector::read(Logger& logger, const ImageViewRGB32& frame, const OverlayBoxScope& box){
+    ImageViewRGB32 image = extract_box_reference(frame, box);
+    OCR::StringMatchResult result = NATURE_READER().read_substring(
+        logger, m_language, image,
+        OCR::WHITE_TEXT_FILTERS()
+    );
+    result.clear_beyond_log10p(-1.40);
+    if (result.results.size() != 1){
+        return NatureCheckerValue::UnableToDetect;
+    }
+    return NatureCheckerValue_string_to_enum(result.results.begin()->second.token);
+}
+NatureReader::Results BoxNatureDetector::read(Logger& logger, const ImageViewRGB32& frame){
+    NatureReader::Results results;
+    if (m_language != Language::None){
+        results.nature = read(logger, frame, m_box_nature);
+    }
+    return results;
+}
+
+
+
+}
+}
+}

--- a/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxNatureDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxNatureDetector.cpp
@@ -12,7 +12,7 @@ namespace NintendoSwitch{
 namespace PokemonSV{
 
 const NatureReader& NATURE_READER(){
-    const static Pokemon::NatureReader reader("PokemonSV/NatureCheckerOCR.json");
+    const static Pokemon::NatureReader reader("Pokemon/NatureCheckerOCR.json");
     return reader;
 }
 

--- a/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxNatureDetector.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxNatureDetector.h
@@ -1,0 +1,39 @@
+/*  Box Nature Detector
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonSV_BoxNatureDetector_H
+#define PokemonAutomation_PokemonSV_BoxNatureDetector_H
+
+#include "CommonFramework/VideoPipeline/VideoOverlayScopes.h"
+#include "Pokemon/Inference/Pokemon_NatureReader.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonSV{
+using namespace Pokemon;
+
+const NatureReader& NATURE_READER();
+
+class BoxNatureDetector {
+public:
+    BoxNatureDetector(VideoOverlay& overlay, Language language);
+
+    NatureReader::Results read(Logger& logger, const ImageViewRGB32& frame);
+
+private:
+    NatureCheckerValue read(Logger& logger, const ImageViewRGB32& frame, const OverlayBoxScope& box);
+
+private:
+    Language m_language;
+    OverlayBoxScope m_box_nature;
+};
+
+
+
+}
+}
+}
+#endif

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.cpp
@@ -19,6 +19,7 @@
 #include "PokemonSV/Inference/Boxes/PokemonSV_BoxGenderDetector.h"
 #include "PokemonSV/Inference/Boxes/PokemonSV_BoxShinyDetector.h"
 #include "PokemonSV/Inference/Boxes/PokemonSV_IVCheckerReader.h"
+#include "PokemonSV/Inference/Boxes/PokemonSV_BoxNatureDetector.h"
 #include "PokemonSV/Inference/Dialogs/PokemonSV_DialogDetector.h"
 #include "PokemonSV/Inference/Dialogs/PokemonSV_GradientArrowDetector.h"
 #include "PokemonSV/Inference/PokemonSV_OverworldDetector.h"
@@ -611,6 +612,7 @@ bool check_baby_info(
     IVCheckerReaderScope iv_reader_scope(console.overlay(), LANGUAGE);
     BoxGenderDetector gender_detector;
     gender_detector.make_overlays(overlay_set);
+    BoxNatureDetector nature_detector(console.overlay(), LANGUAGE);
 
     const int shiny_ret = wait_until(console, context, std::chrono::milliseconds(200), {shiny_detector});
     const bool shiny = (shiny_ret == 0);
@@ -618,11 +620,12 @@ bool check_baby_info(
 
     IVCheckerReader::Results IVs = iv_reader_scope.read(console.logger(), screen);
     EggHatchGenderFilter gender = gender_detector.detect(screen);
+    NatureReader::Results nature = nature_detector.read(console.logger(), screen);
 
     console.log(IVs.to_string(), COLOR_GREEN);
     console.log("Gender: " + gender_to_string(gender), COLOR_GREEN);
 
-    action = FILTERS.get_action(shiny, IVs, gender);
+    action = FILTERS.get_action(shiny, IVs, gender, nature);
 
     return shiny;
 }

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.cpp
@@ -624,6 +624,7 @@ bool check_baby_info(
 
     console.log(IVs.to_string(), COLOR_GREEN);
     console.log("Gender: " + gender_to_string(gender), COLOR_GREEN);
+    console.log("Nature: " + nature.to_string(), COLOR_GREEN);
 
     action = FILTERS.get_action(shiny, IVs, gender, nature);
 

--- a/SerialPrograms/Source/PokemonSwSh/Inference/PokemonSwSh_BoxNatureDetector.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Inference/PokemonSwSh_BoxNatureDetector.cpp
@@ -31,7 +31,6 @@ BoxNatureDetector::BoxNatureDetector(VideoOverlay& overlay)
 {}
 
 NaturePlusMinus BoxNatureDetector::read(Logger& logger, const ImageViewRGB32& frame, const ImageFloatBox& box){
-    const auto region = extract_box_reference(frame, box);
     const bool replace_color_within_range = true;
 
     //Filter out background - white/gray

--- a/SerialPrograms/Source/PokemonSwSh/Inference/PokemonSwSh_BoxNatureDetector.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Inference/PokemonSwSh_BoxNatureDetector.cpp
@@ -23,48 +23,25 @@ namespace NintendoSwitch{
 namespace PokemonSwSh{
 
 BoxNatureDetector::BoxNatureDetector(VideoOverlay& overlay)
-    : m_box_atk(overlay, { 0.689, 0.198 + 1 * 0.0515, 0.84, 0.047})
-    , m_box_def(overlay, { 0.689, 0.198 + 2 * 0.0515, 0.84, 0.047})
-    , m_box_spatk(overlay, { 0.689, 0.198 + 3 * 0.0515, 0.84, 0.047})
-    , m_box_spdef(overlay, { 0.689, 0.198 + 4 * 0.0515, 0.84, 0.047})
-    , m_box_spd(overlay, { 0.689, 0.198 + 5 * 0.0515, 0.84, 0.047})
+    : m_box_atk(overlay, { 0.689, 0.198 + 1 * 0.0515, 0.084, 0.047})
+    , m_box_def(overlay, { 0.689, 0.198 + 2 * 0.0515, 0.084, 0.047})
+    , m_box_spatk(overlay, { 0.689, 0.198 + 3 * 0.0515, 0.084, 0.047})
+    , m_box_spdef(overlay, { 0.689, 0.198 + 4 * 0.0515, 0.084, 0.047})
+    , m_box_spd(overlay, { 0.689, 0.198 + 5 * 0.0515, 0.084, 0.047})
 {}
 
-NaturePlusMinus BoxNatureDetector::read(Logger& logger, const ImageViewRGB32& frame, const OverlayBoxScope& box){
+NaturePlusMinus BoxNatureDetector::read(Logger& logger, const ImageViewRGB32& frame, const ImageFloatBox& box){
+    const ImageStats region = image_stats(extract_box_reference(frame, box));
 
-    const auto region = extract_box_reference(frame, box);
-
-    // Retain only red pixels from region
-    const bool replace_color_within_range = false;
-    const ImageRGB32 red_region = filter_rgb32_range(
-        region,
-        combine_rgb(150, 0, 0), combine_rgb(255, 100, 100), Color(0), replace_color_within_range
-    );
-    const size_t num_red_pixels = image_stats(red_region).count;
-
-    // Retain only blue pixels from region
-    const ImageRGB32 blue_region = filter_rgb32_range(
-        region,
-        combine_rgb(0, 0, 180), combine_rgb(130, 130, 255), Color(0), replace_color_within_range
-    );
-    const size_t num_blue_pixels = image_stats(blue_region).count;
-
-    const double threshold = region.width() * region.height() * m_area_ratio_threshold;
-
-    if (PreloadSettings::debug().COLOR_CHECK) {
-        cout << "num_red_pixels: " << num_red_pixels << ", num_blue_pixels: " << num_blue_pixels
-            << ", region " << region.width() << " x " << region.height() << " threshold " << threshold << endl;
-
-        cout << "Save images to ./red_only.png and ./blue_only.png" << endl;
-        red_region.save("./red_only.png");
-        blue_region.save("./blue_only.png");
-    }
-
-    if (num_red_pixels > threshold) {
-        return NaturePlusMinus::PLUS;
-    }
-    else if (num_blue_pixels > threshold) {
+    //cout << region.average.r << endl;
+    //cout << region.average.g << endl;
+    //cout << region.average.b << endl;
+    
+    if (region.average.b > region.average.r + 3) {
         return NaturePlusMinus::MINUS;
+    }
+    else if (region.average.r > region.average.b) {
+        return NaturePlusMinus::PLUS;
     }
     return NaturePlusMinus::NEUTRAL;
 

--- a/SerialPrograms/Source/PokemonSwSh/Inference/PokemonSwSh_BoxNatureDetector.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Inference/PokemonSwSh_BoxNatureDetector.cpp
@@ -1,0 +1,101 @@
+/*  IV Checker Reader
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "Common/Cpp/Color.h"
+#include "CommonFramework/GlobalSettingsPanel.h"
+#include "CommonFramework/ImageTools/ImageBoxes.h"
+#include "CommonFramework/ImageTools/ImageFilter.h"
+#include "CommonFramework/ImageTypes/ImageRGB32.h"
+#include "CommonFramework/ImageTools/ImageStats.h"
+#include "CommonFramework/ImageTypes/ImageViewRGB32.h"
+#include "CommonFramework/VideoPipeline/VideoOverlayScopes.h"
+#include "PokemonSwSh_BoxNatureDetector.h"
+
+#include <iostream>
+using std::cout;
+using std::endl;
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonSwSh{
+
+BoxNatureDetector::BoxNatureDetector(VideoOverlay& overlay)
+    : m_box_atk(overlay, { 0.689, 0.198 + 1 * 0.0515, 0.84, 0.047})
+    , m_box_def(overlay, { 0.689, 0.198 + 2 * 0.0515, 0.84, 0.047})
+    , m_box_spatk(overlay, { 0.689, 0.198 + 3 * 0.0515, 0.84, 0.047})
+    , m_box_spdef(overlay, { 0.689, 0.198 + 4 * 0.0515, 0.84, 0.047})
+    , m_box_spd(overlay, { 0.689, 0.198 + 5 * 0.0515, 0.84, 0.047})
+{}
+
+NaturePlusMinus BoxNatureDetector::read(Logger& logger, const ImageViewRGB32& frame, const OverlayBoxScope& box){
+
+    const auto region = extract_box_reference(frame, box);
+
+    // Retain only red pixels from region
+    const bool replace_color_within_range = false;
+    const ImageRGB32 red_region = filter_rgb32_range(
+        region,
+        combine_rgb(150, 0, 0), combine_rgb(255, 100, 100), Color(0), replace_color_within_range
+    );
+    const size_t num_red_pixels = image_stats(red_region).count;
+
+    // Retain only blue pixels from region
+    const ImageRGB32 blue_region = filter_rgb32_range(
+        region,
+        combine_rgb(0, 0, 180), combine_rgb(130, 130, 255), Color(0), replace_color_within_range
+    );
+    const size_t num_blue_pixels = image_stats(blue_region).count;
+
+    const double threshold = region.width() * region.height() * m_area_ratio_threshold;
+
+    if (PreloadSettings::debug().COLOR_CHECK) {
+        cout << "num_red_pixels: " << num_red_pixels << ", num_blue_pixels: " << num_blue_pixels
+            << ", region " << region.width() << " x " << region.height() << " threshold " << threshold << endl;
+
+        cout << "Save images to ./red_only.png and ./blue_only.png" << endl;
+        red_region.save("./red_only.png");
+        blue_region.save("./blue_only.png");
+    }
+
+    if (num_red_pixels > threshold) {
+        return NaturePlusMinus::PLUS;
+    }
+    else if (num_blue_pixels > threshold) {
+        return NaturePlusMinus::MINUS;
+    }
+    return NaturePlusMinus::NEUTRAL;
+
+}
+NatureReader::Results BoxNatureDetector::read(Logger& logger, const ImageViewRGB32& frame){
+    NatureReader::Results results;
+    NaturePlusMinus stats[5];
+    int statPlus = -1;
+    int statMinus = -1;
+
+    stats[0] = read(logger, frame, m_box_atk);
+    stats[1] = read(logger, frame, m_box_def);
+    stats[2] = read(logger, frame, m_box_spatk);
+    stats[3] = read(logger, frame, m_box_spdef);
+    stats[4] = read(logger, frame, m_box_spd);
+
+    for (int i = 0; i < 5; i++) {
+        if (stats[i] == NaturePlusMinus::PLUS) {
+            statPlus = i;
+        }
+        else if (stats[i] == NaturePlusMinus::MINUS) {
+            statMinus = i;
+        }
+    }
+
+    results.nature = NatureCheckerValue_helphinder_to_enum(std::make_pair(statPlus, statMinus));
+    return results;
+}
+
+
+}
+}
+}
+

--- a/SerialPrograms/Source/PokemonSwSh/Inference/PokemonSwSh_BoxNatureDetector.h
+++ b/SerialPrograms/Source/PokemonSwSh/Inference/PokemonSwSh_BoxNatureDetector.h
@@ -28,7 +28,7 @@ public:
     NatureReader::Results read(Logger& logger, const ImageViewRGB32& frame);
 
 private:
-    NaturePlusMinus read(Logger& logger, const ImageViewRGB32& frame, const OverlayBoxScope& box);
+    NaturePlusMinus read(Logger& logger, const ImageViewRGB32& frame, const ImageFloatBox& box);
 
 private:
     OverlayBoxScope m_box_atk;
@@ -36,8 +36,6 @@ private:
     OverlayBoxScope m_box_spatk;
     OverlayBoxScope m_box_spdef;
     OverlayBoxScope m_box_spd;
-    double m_area_ratio_threshold;
-    Color m_color;
 };
 
 

--- a/SerialPrograms/Source/PokemonSwSh/Inference/PokemonSwSh_BoxNatureDetector.h
+++ b/SerialPrograms/Source/PokemonSwSh/Inference/PokemonSwSh_BoxNatureDetector.h
@@ -1,0 +1,48 @@
+/*  IV Checker Reader
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonSwSh_BoxNatureDetector_H
+#define PokemonAutomation_PokemonSwSh_BoxNatureDetector_H
+
+#include "CommonFramework/VideoPipeline/VideoOverlayScopes.h"
+#include "Pokemon/Inference/Pokemon_NatureReader.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonSwSh{
+using namespace Pokemon;
+
+enum class NaturePlusMinus{
+    NEUTRAL = 0,
+    PLUS,
+    MINUS,
+};
+
+class BoxNatureDetector {
+public:
+    BoxNatureDetector(VideoOverlay& overlay);
+
+    NatureReader::Results read(Logger& logger, const ImageViewRGB32& frame);
+
+private:
+    NaturePlusMinus read(Logger& logger, const ImageViewRGB32& frame, const OverlayBoxScope& box);
+
+private:
+    OverlayBoxScope m_box_atk;
+    OverlayBoxScope m_box_def;
+    OverlayBoxScope m_box_spatk;
+    OverlayBoxScope m_box_spdef;
+    OverlayBoxScope m_box_spd;
+    double m_area_ratio_threshold;
+    Color m_color;
+};
+
+
+
+}
+}
+}
+#endif

--- a/SerialPrograms/Source/PokemonSwSh/Programs/EggPrograms/PokemonSwSh_EggAutonomous.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/EggPrograms/PokemonSwSh_EggAutonomous.cpp
@@ -601,8 +601,9 @@ bool EggAutonomous::process_hatched_pokemon(SingleSwitchProgramEnvironment& env,
             EggHatchGenderFilter gender = gender_detector.detect(screen);
             env.log(IVs.to_string(), COLOR_GREEN);
             env.log("Gender: " + gender_to_string(gender), COLOR_GREEN);
+            NatureReader::Results nature;
 
-            EggHatchAction action = FILTERS.get_action(shiny, IVs, gender);
+            EggHatchAction action = FILTERS.get_action(shiny, IVs, gender, nature);
 
             auto send_keep_notification = [&](){
                 if (!shiny){

--- a/SerialPrograms/Source/PokemonSwSh/Programs/EggPrograms/PokemonSwSh_EggAutonomous.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/EggPrograms/PokemonSwSh_EggAutonomous.cpp
@@ -21,6 +21,7 @@
 #include "PokemonSwSh/Inference/PokemonSwSh_BoxShinySymbolDetector.h"
 #include "PokemonSwSh/Inference/PokemonSwSh_DialogBoxDetector.h"
 #include "PokemonSwSh/Inference/PokemonSwSh_IVCheckerReader.h"
+#include "PokemonSwSh/Inference/PokemonSwSh_BoxNatureDetector.h"
 #include "PokemonSwSh/Inference/PokemonSwSh_SelectionArrowFinder.h"
 #include "PokemonSwSh/Inference/PokemonSwSh_YCommDetector.h"
 #include "PokemonSwSh/Programs/PokemonSwSh_GameEntry.h"
@@ -571,6 +572,7 @@ bool EggAutonomous::process_hatched_pokemon(SingleSwitchProgramEnvironment& env,
         BoxGenderDetector gender_detector;
         gender_detector.make_overlays(overlay_set);
         IVCheckerReaderScope iv_reader(env.console.overlay(), LANGUAGE);
+        BoxNatureDetector nature_detector(env.console.overlay());
 
         for (size_t i_hatched = 0; i_hatched < 5; i_hatched++){
             pbf_wait(context, 50); // wait for a while to make sure the pokemon stats are loaded.
@@ -601,7 +603,7 @@ bool EggAutonomous::process_hatched_pokemon(SingleSwitchProgramEnvironment& env,
             EggHatchGenderFilter gender = gender_detector.detect(screen);
             env.log(IVs.to_string(), COLOR_GREEN);
             env.log("Gender: " + gender_to_string(gender), COLOR_GREEN);
-            NatureReader::Results nature;
+            NatureReader::Results nature = nature_detector.read(env.console.logger(), screen);
 
             EggHatchAction action = FILTERS.get_action(shiny, IVs, gender, nature);
 


### PR DESCRIPTION
Nature filter for SwSh, BDSP, and SV egg auto.

Most of the filter code is the IV checker, but with natures.
BDSP and SV read the text, PR in the Packages repo for the json file has also been opened.
SwSh gets the color of the stat names and uses the red/blue color to determine nature. All neutral natures are treated the same because of this.

Tested in english only, other languages were all copied from a bulbapedia table.