### PR TITLE
Implemented screenshots sub folder

### DIFF
--- a/SerialPrograms/Source/CommonFramework/Globals.cpp
+++ b/SerialPrograms/Source/CommonFramework/Globals.cpp
@@ -69,6 +69,7 @@ std::string get_training_path(){
 
 
 const std::string SETTINGS_PATH = "UserSettings/";
+const std::string SCREENSHOTS_PATH = "Screenshots/";
 const std::string& RESOURCE_PATH(){
     static std::string path = get_resource_path();
     return path;

--- a/SerialPrograms/Source/CommonFramework/Globals.h
+++ b/SerialPrograms/Source/CommonFramework/Globals.h
@@ -31,6 +31,7 @@ extern const std::string PROJECT_SOURCE_URL;
 const auto SERIAL_REFRESH_RATE = std::chrono::milliseconds(1000);
 
 extern const std::string SETTINGS_PATH;
+extern const std::string SCREENSHOTS_PATH;
 const std::string& RESOURCE_PATH();
 const std::string& TRAINING_PATH();
 

--- a/SerialPrograms/Source/CommonFramework/Main.cpp
+++ b/SerialPrograms/Source/CommonFramework/Main.cpp
@@ -63,6 +63,9 @@ int main(int argc, char *argv[]){
     //  Make settings directory.
     QDir().mkpath(QString::fromStdString(SETTINGS_PATH));
 
+    // Make screenshots directory.
+    QDir().mkpath(QString::fromStdString(SCREENSHOTS_PATH));
+
     if (GlobalSettings::instance().COMMAND_LINE_TEST_MODE){
         return run_command_line_tests();
     }

--- a/SerialPrograms/Source/CommonFramework/Notifications/MessageAttachment.cpp
+++ b/SerialPrograms/Source/CommonFramework/Notifications/MessageAttachment.cpp
@@ -7,6 +7,7 @@
 #include <QDir>
 #include <QFile>
 #include "Common/Cpp/PrettyPrint.h"
+#include "CommonFramework/Globals.h"
 #include "MessageAttachment.h"
 
 namespace PokemonAutomation{
@@ -85,7 +86,7 @@ PendingFileSend::PendingFileSend(Logger& logger, const ImageAttachment& image)
     m_filename = now_to_filestring() + format;
 
     if (image.keep_file){
-        m_filepath = m_filename;
+        m_filepath = SCREENSHOTS_PATH + m_filename;
     }else{
         QDir().mkdir("TempFiles");
 //        m_filename = "temp-" + m_filename;

--- a/SerialPrograms/Source/NintendoSwitch/Framework/UI/NintendoSwitch_SwitchSystemWidget.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/Framework/UI/NintendoSwitch_SwitchSystemWidget.cpp
@@ -17,6 +17,7 @@
 #include "CommonFramework/ControllerDevices/SerialPortWidget.h"
 #include "CommonFramework/VideoPipeline/UI/CameraSelectorWidget.h"
 #include "CommonFramework/VideoPipeline/UI/VideoDisplayWidget.h"
+#include "CommonFramework/Globals.h"
 #include "NintendoSwitch_CommandRow.h"
 #include "NintendoSwitch_SwitchSystemWidget.h"
 
@@ -140,7 +141,7 @@ SwitchSystemWidget::SwitchSystemWidget(
                 if (!image){
                     return;
                 }
-                std::string filename = "screenshot-" + now_to_filestring() + ".png";
+                std::string filename = SCREENSHOTS_PATH + "screenshot-" + now_to_filestring() + ".png";
                 m_session.logger().log("Saving screenshot to: " + filename, COLOR_PURPLE);
                 image->save(filename);
             });


### PR DESCRIPTION
https://github.com/PokemonAutomation/ComputerControl/issues/103

I believe I got the screenshot sub folder working. I tested with manual and programs creating notifications for Discord and the images came through appropriately and stored in the created folder.

Looked around for other places this could be implemented and this seemed like the place to do it. If I missed a spot, I can update the code.