### PR TITLE
Fix Windows Debug builds for QT Creator

### DIFF
--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -1,5 +1,5 @@
 #set the minimum cmake version required
-cmake_minimum_required(VERSION 3.16.0)
+cmake_minimum_required(VERSION 3.18.0)
 
 #set the name of the project
 project(SerialPrograms)
@@ -1802,6 +1802,13 @@ if (EXISTS "../../Internal/SerialPrograms/TelemetryURLs.h")
     target_sources(SerialPrograms PRIVATE ../../Internal/SerialPrograms/TelemetryURLs.h)
     target_sources(SerialPrograms PRIVATE ../../Internal/SerialPrograms/NintendoSwitch_TestPrograms.cpp)
     target_sources(SerialPrograms PRIVATE ../../Internal/SerialPrograms/NintendoSwitch_TestPrograms.h)
+endif()
+
+#extract opencv_world460d.dll from archive on Windows Debug builds
+if (MSVC)
+    if (CMAKE_BUILD_TYPE MATCHES "Debug")
+        file(ARCHIVE_EXTRACT INPUT ../3rdPartyBinaries/opencv_world460d.zip DESTINATION ../3rdPartyBinaries/)
+    endif()
 endif()
 
 #add include directory


### PR DESCRIPTION
https://github.com/PokemonAutomation/Arduino-Source/issues/215

Was told that going up to CMake 3.18 should be fine, no longer get an error when running Debug through QT. Can be moved around or done another way if needed.