### PR TITLE
Remove unused count variable that causes build issues on Linux

### DIFF
--- a/SerialPrograms/Source/Tests/PokemonLA_Tests.cpp
+++ b/SerialPrograms/Source/Tests/PokemonLA_Tests.cpp
@@ -576,7 +576,7 @@ int test_pokemonLA_MMOSpriteMatcher(const std::string& filepath){
         return 1;
     }
 
-    static int count = 0;
+    // static int count = 0;
     ImageRGB32 output_sprite = sprite_image.copy();
     ImageRGB32 output_quest = question_mark_image.copy();
     std::vector<ImagePixelBox> new_boxes;
@@ -624,7 +624,7 @@ int test_pokemonLA_MMOSpriteMatcher(const std::string& filepath){
         cout << "FAILURE: " << target_sprites.size() - success_count << "/" << target_sprites.size() << endl;
         return 1;
     }
-    count++;
+    // count++;
     
     return 0;
 }


### PR DESCRIPTION
In [PokemonLA_Tests.cpp](https://github.com/PokemonAutomation/Arduino-Source/commit/4e3c783dda9b634d0a302ee79ef6222bfff1e2c0#diff-c6418efa5fefc78f76bdb7ddb283866d12353769e38c630cf5f5eb412be48b60) there's an unused variable that prevents building on linux for some reason.

Just commented it out