### PR TITLE
- Add a unified command handler to make use of both slash and prefix

### DIFF
--- a/SerialPrograms/Source/Integrations/DiscordIntegrationSettings.cpp
+++ b/SerialPrograms/Source/Integrations/DiscordIntegrationSettings.cpp
@@ -44,6 +44,15 @@ DiscordIntegrationSettingsOption::DiscordIntegrationSettingsOption()
         LockWhileRunning::LOCKED,
         Library::SleepyDiscord
     )
+    , command_type(
+        "<b>Discord Integration Command Type:</b><br>Restart the program for this to take effect.",
+        {
+            {CommandType::SlashCommands, "slash", "Slash commands"},
+            {CommandType::MessageCommands, "message", "Message (prefix) commands"},
+        },
+        LockWhileRunning::LOCKED,
+        CommandType::SlashCommands
+    )
     , token(
         true,
         "<b>Discord token:</b><br>Enter your Discord bot's token. Keep it safe and don't share it with anyone.",
@@ -52,7 +61,7 @@ DiscordIntegrationSettingsOption::DiscordIntegrationSettingsOption()
     )
     , command_prefix(
         false,
-        "<b>Discord command prefix (Sleepy):</b><br>Enter a command prefix for your bot.",
+        "<b>Discord command prefix:</b><br>Enter a command prefix for your bot.",
         LockWhileRunning::LOCKED,
         "^", "^"
     )
@@ -89,6 +98,7 @@ DiscordIntegrationSettingsOption::DiscordIntegrationSettingsOption()
     PA_ADD_OPTION(run_on_start);
     if (IS_BETA_VERSION){
         PA_ADD_OPTION(library);
+        PA_ADD_OPTION(command_type);
     }
     PA_ADD_OPTION(token);
     PA_ADD_OPTION(command_prefix);
@@ -115,6 +125,7 @@ void DiscordIntegrationSettingsOption::value_changed(){
         ConfigOptionState state = options_enabled ? ConfigOptionState::ENABLED : ConfigOptionState::DISABLED;
 
         library.set_visibility(state);
+        command_type.set_visibility(ConfigOptionState::HIDDEN);
         token.set_visibility(state);
         game_status.set_visibility(state);
         hello_message.set_visibility(state);
@@ -132,11 +143,12 @@ void DiscordIntegrationSettingsOption::value_changed(){
         ConfigOptionState state = options_enabled ? ConfigOptionState::ENABLED : ConfigOptionState::DISABLED;
 
         library.set_visibility(state);
+        command_type.set_visibility(state);
         token.set_visibility(state);
         game_status.set_visibility(state);
         hello_message.set_visibility(state);
 
-        command_prefix.set_visibility(ConfigOptionState::HIDDEN);
+        command_prefix.set_visibility(state);
         use_suffix.set_visibility(ConfigOptionState::HIDDEN);
         sudo.set_visibility(ConfigOptionState::HIDDEN);
         owner.set_visibility(ConfigOptionState::HIDDEN);

--- a/SerialPrograms/Source/Integrations/DiscordIntegrationSettings.h
+++ b/SerialPrograms/Source/Integrations/DiscordIntegrationSettings.h
@@ -35,6 +35,12 @@ public:
     };
     EnumDropdownOption<Library> library;
 
+    enum class CommandType {
+        SlashCommands,
+        MessageCommands,
+    };
+    EnumDropdownOption<CommandType> command_type;
+
     StringOption token;
     StringOption command_prefix;
     BooleanCheckBoxOption use_suffix;

--- a/SerialPrograms/Source/Integrations/DppIntegration/DppClient.h
+++ b/SerialPrograms/Source/Integrations/DppIntegration/DppClient.h
@@ -38,9 +38,9 @@ private:
 
 private:
     std::unique_ptr<dpp::cluster> m_bot = nullptr;
+    std::unique_ptr<dpp::commandhandler> m_handler = nullptr;
     std::atomic<bool> m_is_connected;
     std::mutex m_client_lock;
-//    std::thread m_thread;
 };
 
 

--- a/SerialPrograms/Source/Integrations/DppIntegration/DppCommandHandler.h
+++ b/SerialPrograms/Source/Integrations/DppIntegration/DppCommandHandler.h
@@ -28,12 +28,11 @@ private:
     AsyncDispatcher m_dispatcher = AsyncDispatcher(nullptr, 1);
     ScheduledTaskRunner m_queue = ScheduledTaskRunner(m_dispatcher);
     std::mutex m_count_lock;
-    static std::map<std::string, SlashCommand> command_map;
     static dpp::user owner;
     static Color color;
 
 protected:
-    void initialize(dpp::cluster& bot);
+    void initialize(dpp::cluster& bot, dpp::commandhandler& handler);
     bool check_if_empty(const DiscordSettingsOption& settings);
     void log_dpp(const std::string& message, const std::string& identity, const dpp::loglevel& ll);
     void send_message(
@@ -46,9 +45,9 @@ protected:
     );
 
 private:
-    void create_commands(dpp::cluster& bot);
+    void create_unified_commands(dpp::commandhandler& handler);
     void update_response(
-        const dpp::slashcommand_t& event,
+        const dpp::command_source& src,
         dpp::embed& embed,
         const std::string& msg,
         std::shared_ptr<PendingFileSend> file

--- a/SerialPrograms/Source/Integrations/DppIntegration/DppUtility.cpp
+++ b/SerialPrograms/Source/Integrations/DppIntegration/DppUtility.cpp
@@ -58,6 +58,27 @@ uint16_t Utility::get_button(const uint16_t& bt) {
     return 1 << bt;
 }
 
+int64_t Utility::get_value_from_input(const commandhandler& handler, const std::string& command_name, const std::string& input, std::string& out) {
+    auto cmd = handler.commands.find(command_name);
+    auto& choices = cmd->second.parameters[1].second.choices;
+    for (auto& choice : choices) {
+        std::string val = std::get<std::string>(choice.first);
+        if (val == input || choice.second == input) {
+            out = choice.second;
+            return std::stoi(val);
+        }
+    }
+    return -1;
+}
+
+int64_t Utility::sanitize_integer_input(const parameter_list_t& params, const uint8_t& index) {
+    int64_t val = std::get<int64_t>(params[index].second);
+    if (val < 0) {
+        return 0;
+    }
+    return val;
+}
+
 
 
 }

--- a/SerialPrograms/Source/Integrations/DppIntegration/DppUtility.h
+++ b/SerialPrograms/Source/Integrations/DppIntegration/DppUtility.h
@@ -20,7 +20,9 @@ protected:
 protected:
     void log(const std::string& message, const std::string& identity, const dpp::loglevel& ll);
     void get_user_counts(dpp::cluster& bot, const dpp::guild_create_t& event);
-    static uint16_t get_button(const uint16_t& bt);
+    int64_t get_value_from_input(const dpp::commandhandler& handler, const std::string& cmd, const std::string& input, std::string& out);
+    int64_t sanitize_integer_input(const dpp::parameter_list_t& params, const uint8_t& index);
+    uint16_t get_button(const uint16_t& bt);
 
 private:
     Logger& dpp_logger();


### PR DESCRIPTION
…commands.

- Add option to use either slash commands or prefix commands.
- Replace `std::format()` for cross-compatibility.