### PR TITLE
Tournament farmer

### DIFF
--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -1351,6 +1351,8 @@ file(GLOB MAIN_SOURCES
     Source/PokemonSV/Programs/General/PokemonSV_MassRelease.h
     Source/PokemonSV/Programs/General/PokemonSV_StatsReset.cpp
     Source/PokemonSV/Programs/General/PokemonSV_StatsReset.h
+    Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.cpp
+    Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.h
     Source/PokemonSV/Programs/Glitches/PokemonSV_CloneItems-1.0.1.cpp
     Source/PokemonSV/Programs/Glitches/PokemonSV_CloneItems-1.0.1.h
     Source/PokemonSV/Programs/Glitches/PokemonSV_RideCloner-1.0.1.cpp

--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -1284,6 +1284,8 @@ file(GLOB MAIN_SOURCES
     Source/PokemonSV/Inference/PokemonSV_PokemonSummaryReader.h
     Source/PokemonSV/Inference/PokemonSV_PokePortalDetector.cpp
     Source/PokemonSV/Inference/PokemonSV_PokePortalDetector.h
+    Source/PokemonSV/Inference/PokemonSV_TournamentPrizeNameReader.cpp
+    Source/PokemonSV/Inference/PokemonSV_TournamentPrizeNameReader.h
     Source/PokemonSV/Inference/PokemonSV_WhiteButtonDetector.cpp
     Source/PokemonSV/Inference/PokemonSV_WhiteButtonDetector.h
     Source/PokemonSV/Inference/Tera/PokemonSV_TeraCardDetector.cpp
@@ -1311,6 +1313,10 @@ file(GLOB MAIN_SOURCES
     Source/PokemonSV/Options/PokemonSV_TeraAIOption.h
     Source/PokemonSV/Options/PokemonSV_TeraMoveTable.cpp
     Source/PokemonSV/Options/PokemonSV_TeraMoveTable.h
+    Source/PokemonSV/Options/PokemonSV_TournamentPrizeSelectOption.cpp
+    Source/PokemonSV/Options/PokemonSV_TournamentPrizeSelectOption.h
+    Source/PokemonSV/Options/PokemonSV_TournamentPrizeTable.cpp
+    Source/PokemonSV/Options/PokemonSV_TournamentPrizeTable.h
     Source/PokemonSV/PokemonSV_Panels.cpp
     Source/PokemonSV/PokemonSV_Panels.h
     Source/PokemonSV/PokemonSV_Settings.cpp
@@ -1397,6 +1403,8 @@ file(GLOB MAIN_SOURCES
     Source/PokemonSV/Resources/PokemonSV_ItemSprites.h
     Source/PokemonSV/Resources/PokemonSV_PokemonSprites.cpp
     Source/PokemonSV/Resources/PokemonSV_PokemonSprites.h
+    Source/PokemonSV/Resources/PokemonSV_TournamentPrizeNames.cpp
+    Source/PokemonSV/Resources/PokemonSV_TournamentPrizeNames.h
     Source/PokemonSwSh/Commands/PokemonSwSh_Commands_AutoHosts.cpp
     Source/PokemonSwSh/Commands/PokemonSwSh_Commands_AutoHosts.h
     Source/PokemonSwSh/Commands/PokemonSwSh_Commands_DateSpam.cpp

--- a/SerialPrograms/Source/CommonFramework/OCR/OCR_Routines.cpp
+++ b/SerialPrograms/Source/CommonFramework/OCR/OCR_Routines.cpp
@@ -97,6 +97,14 @@ const std::vector<TextColorRange>& BLACK_OR_WHITE_TEXT_FILTERS(){
     };
     return filters;
 }
+const std::vector<TextColorRange>& BLUE_TEXT_FILTERS() {
+    static std::vector<TextColorRange> filters{
+        {0xFF3287A2, 0xFFA7F4FF},
+        {0xFF2283A2, 0xFF8EF1FF},
+        {0xFF428BA2, 0xFFC1F7FF},
+    };
+    return filters;
+}
 
 
 

--- a/SerialPrograms/Source/CommonFramework/OCR/OCR_Routines.h
+++ b/SerialPrograms/Source/CommonFramework/OCR/OCR_Routines.h
@@ -41,6 +41,7 @@ StringMatchResult multifiltered_OCR(
 const std::vector<TextColorRange>& BLACK_TEXT_FILTERS();
 const std::vector<TextColorRange>& WHITE_TEXT_FILTERS();
 const std::vector<TextColorRange>& BLACK_OR_WHITE_TEXT_FILTERS();
+const std::vector<TextColorRange>& BLUE_TEXT_FILTERS();
 
 
 

--- a/SerialPrograms/Source/PokemonSV/Inference/PokemonSV_TournamentPrizeNameReader.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/PokemonSV_TournamentPrizeNameReader.cpp
@@ -1,0 +1,39 @@
+/*  Tournament Prize Reader
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "CommonFramework/OCR/OCR_RawOCR.h"
+#include "PokemonSV_TournamentPrizeNameReader.h"
+
+namespace PokemonAutomation {
+namespace NintendoSwitch {
+namespace PokemonSV {
+
+TournamentPrizeNameReader& TournamentPrizeNameReader::instance() {
+    static TournamentPrizeNameReader reader;
+    return reader;
+}
+
+
+TournamentPrizeNameReader::TournamentPrizeNameReader()
+    : SmallDictionaryMatcher("PokemonSV/AAT/TournamentPrizeNameOCR.json")
+{}
+
+OCR::StringMatchResult TournamentPrizeNameReader::read_substring(
+    Logger& logger,
+    Language language,
+    const ImageViewRGB32& image,
+    const std::vector<OCR::TextColorRange>& text_color_ranges,
+    double min_text_ratio, double max_text_ratio
+) const {
+    return match_substring_from_image_multifiltered(
+        &logger, language, image, text_color_ranges,
+        MAX_LOG10P, MAX_LOG10P_SPREAD, min_text_ratio, max_text_ratio
+    );
+}
+
+}
+}
+}

--- a/SerialPrograms/Source/PokemonSV/Inference/PokemonSV_TournamentPrizeNameReader.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/PokemonSV_TournamentPrizeNameReader.cpp
@@ -1,4 +1,4 @@
-/*  Tournament Prize Reader
+/*  Tournament Prize Name Reader
  *
  *  From: https://github.com/PokemonAutomation/Arduino-Source
  *

--- a/SerialPrograms/Source/PokemonSV/Inference/PokemonSV_TournamentPrizeNameReader.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/PokemonSV_TournamentPrizeNameReader.h
@@ -1,11 +1,11 @@
-/*  Tournament Prize Reader
+/*  Tournament Prize Name Reader
  *
  *  From: https://github.com/PokemonAutomation/Arduino-Source
  *
  */
 
-#ifndef PokemonAutomation_PokemonSV_TournamentPrizeReader_H
-#define PokemonAutomation_PokemonSV_TournamentPrizeReader_H
+#ifndef PokemonAutomation_PokemonSV_TournamentPrizeNameReader_H
+#define PokemonAutomation_PokemonSV_TournamentPrizeNameReader_H
 
 #include "CommonFramework/OCR/OCR_SmallDictionaryMatcher.h"
 

--- a/SerialPrograms/Source/PokemonSV/Inference/PokemonSV_TournamentPrizeNameReader.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/PokemonSV_TournamentPrizeNameReader.h
@@ -1,0 +1,38 @@
+/*  Tournament Prize Reader
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonSV_TournamentPrizeReader_H
+#define PokemonAutomation_PokemonSV_TournamentPrizeReader_H
+
+#include "CommonFramework/OCR/OCR_SmallDictionaryMatcher.h"
+
+namespace PokemonAutomation {
+namespace NintendoSwitch {
+namespace PokemonSV {
+
+class TournamentPrizeNameReader : public OCR::SmallDictionaryMatcher {
+public:
+    static constexpr double MAX_LOG10P = -1.40;
+    static constexpr double MAX_LOG10P_SPREAD = 0.50;
+
+public:
+    TournamentPrizeNameReader();
+
+    static TournamentPrizeNameReader& instance();
+
+    OCR::StringMatchResult read_substring(
+        Logger& logger,
+        Language language,
+        const ImageViewRGB32& image,
+        const std::vector<OCR::TextColorRange>& text_color_ranges,
+        double min_text_ratio = 0.01, double max_text_ratio = 0.50
+    ) const;
+
+};
+}
+}
+}
+#endif

--- a/SerialPrograms/Source/PokemonSV/Options/PokemonSV_TournamentPrizeSelectOption.cpp
+++ b/SerialPrograms/Source/PokemonSV/Options/PokemonSV_TournamentPrizeSelectOption.cpp
@@ -1,4 +1,4 @@
-/*  Tournament Prize Select
+/*  Tournament Prize Select Option
  *
  *  From: https://github.com/PokemonAutomation/Arduino-Source
  *

--- a/SerialPrograms/Source/PokemonSV/Options/PokemonSV_TournamentPrizeSelectOption.cpp
+++ b/SerialPrograms/Source/PokemonSV/Options/PokemonSV_TournamentPrizeSelectOption.cpp
@@ -1,0 +1,52 @@
+/*  Tournament Prize Select
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "CommonFramework/Logging/Logger.h"
+#include "PokemonSV/Resources/PokemonSV_TournamentPrizeNames.h"
+#include "PokemonSV/Resources/PokemonSV_ItemSprites.h"
+#include "PokemonSV_TournamentPrizeSelectOption.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonSV{
+
+StringSelectDatabase make_tournament_prize_database(){
+    StringSelectDatabase ret;
+    for (const auto& slug : TOURNAMENT_PRIZE_SLUGS()){
+        const TournamentPrizeNames& data = get_tournament_prize_name(slug);
+        /*
+        const SpriteDatabase::Sprite* sprite = TOURNAMENT_PRIZE_SPRITES().get_nothrow(slug);
+        if (sprite == nullptr){
+            ret.add_entry(StringSelectEntry(slug, data.display_name()));
+            global_logger_tagged().log("Missing sprite for: " + slug, COLOR_RED);
+        }else{
+            ret.add_entry(StringSelectEntry(slug, data.display_name(), sprite->icon));
+        }
+        */
+        ret.add_entry(StringSelectEntry(slug, data.display_name()));
+    }
+    return ret;
+}
+const StringSelectDatabase& TOURNAMENT_PRIZE_SELECT_DATABASE(){
+    static StringSelectDatabase database = make_tournament_prize_database();
+    return database;
+}
+
+
+TournamentPrizeSelectCell::TournamentPrizeSelectCell(
+    const std::string& default_slug
+)
+    : StringSelectCell(
+        TOURNAMENT_PRIZE_SELECT_DATABASE(),
+        LockWhileRunning::LOCKED,
+        default_slug
+    )
+{}
+
+
+}
+}
+}

--- a/SerialPrograms/Source/PokemonSV/Options/PokemonSV_TournamentPrizeSelectOption.h
+++ b/SerialPrograms/Source/PokemonSV/Options/PokemonSV_TournamentPrizeSelectOption.h
@@ -1,4 +1,4 @@
-/*  Tournament Prize Select
+/*  Tournament Prize Select Option
  *
  *  From: https://github.com/PokemonAutomation/Arduino-Source
  *

--- a/SerialPrograms/Source/PokemonSV/Options/PokemonSV_TournamentPrizeSelectOption.h
+++ b/SerialPrograms/Source/PokemonSV/Options/PokemonSV_TournamentPrizeSelectOption.h
@@ -1,0 +1,24 @@
+/*  Tournament Prize Select
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonSV_TournamentPrizeSelectOption_H
+#define PokemonAutomation_PokemonSV_TournamentPrizeSelectOption_H
+
+#include "CommonFramework/Options/StringSelectOption.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonSV{
+
+class TournamentPrizeSelectCell : public StringSelectCell{
+public:
+    TournamentPrizeSelectCell(const std::string& default_slug);
+};
+
+}
+}
+}
+#endif

--- a/SerialPrograms/Source/PokemonSV/Options/PokemonSV_TournamentPrizeTable.cpp
+++ b/SerialPrograms/Source/PokemonSV/Options/PokemonSV_TournamentPrizeTable.cpp
@@ -1,4 +1,4 @@
-/*  Tournament prize table
+/*  Tournament Prize Table
  *
  *  From: https://github.com/PokemonAutomation/Arduino-Source
  *

--- a/SerialPrograms/Source/PokemonSV/Options/PokemonSV_TournamentPrizeTable.cpp
+++ b/SerialPrograms/Source/PokemonSV/Options/PokemonSV_TournamentPrizeTable.cpp
@@ -1,0 +1,72 @@
+/*  Tournament prize table
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "PokemonSV/Resources/PokemonSV_TournamentPrizeNames.h"
+#include "PokemonSV_TournamentPrizeTable.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonSV{
+
+TournamentPrizeSelectorRow::TournamentPrizeSelectorRow()
+    : item("beast-ball")
+{
+    PA_ADD_OPTION(item);
+}
+std::unique_ptr<EditableTableRow> TournamentPrizeSelectorRow::clone() const{
+    std::unique_ptr<TournamentPrizeSelectorRow> ret(new TournamentPrizeSelectorRow());
+    ret->item.set_by_index(item.index());
+    return ret;
+}
+
+TournamentPrizeTable::TournamentPrizeTable(std::string label)
+    : EditableTableOption_t<TournamentPrizeSelectorRow>(
+        std::move(label),
+        LockWhileRunning::LOCKED,
+        make_defaults()
+    )
+{}
+
+bool TournamentPrizeTable::find_item(const std::string& item_slug) const{
+    std::vector<std::unique_ptr<TournamentPrizeSelectorRow>> table = copy_snapshot();
+    for (const std::unique_ptr<TournamentPrizeSelectorRow>& row : table){
+        if (row->item.slug() == item_slug) {
+            return true;
+        }
+    }
+    return false;
+}
+
+std::vector<std::string> TournamentPrizeTable::selected_items() const{
+    std::vector<std::unique_ptr<TournamentPrizeSelectorRow>> table = copy_snapshot();
+    std::vector<std::string> slugs;
+    for (const std::unique_ptr<TournamentPrizeSelectorRow>& row : table){
+        slugs.emplace_back(row->item.slug());
+    }
+    return slugs;
+}
+
+
+std::vector<std::string> TournamentPrizeTable::make_header() const{
+    return std::vector<std::string>{
+        "Item",
+    };
+}
+
+std::vector<std::unique_ptr<EditableTableRow>> TournamentPrizeTable::make_defaults(){
+    std::vector<std::unique_ptr<EditableTableRow>> ret;
+    ret.emplace_back(std::make_unique<TournamentPrizeSelectorRow>());
+    return ret;
+}
+
+
+
+
+
+
+}
+}
+}

--- a/SerialPrograms/Source/PokemonSV/Options/PokemonSV_TournamentPrizeTable.h
+++ b/SerialPrograms/Source/PokemonSV/Options/PokemonSV_TournamentPrizeTable.h
@@ -34,7 +34,6 @@ public:
 
     // Whether item_slug is among the selected items.
     bool find_item(const std::string& item_slug) const;
-    // Return the auction item slugs that the user has selected via the auction item table UI.
     std::vector<std::string> selected_items() const;
 
     virtual std::vector<std::string> make_header() const override;

--- a/SerialPrograms/Source/PokemonSV/Options/PokemonSV_TournamentPrizeTable.h
+++ b/SerialPrograms/Source/PokemonSV/Options/PokemonSV_TournamentPrizeTable.h
@@ -1,11 +1,11 @@
-/* Tournament prize table
+/* Tournament Prize Table
  *
  *  From: https://github.com/PokemonAutomation/Arduino-Source
  *
  */
 
-#ifndef PokemonAutomation_PokemonSV_TournamentPrizeSelector_H
-#define PokemonAutomation_PokemonSV_TournamentPrizeSelector_H
+#ifndef PokemonAutomation_PokemonSV_TournamentPrizeTable_H
+#define PokemonAutomation_PokemonSV_TournamentPrizeTable_H
 
 #include "Common/Cpp/Options/EditableTableOption.h"
 #include "PokemonSV_TournamentPrizeSelectOption.h"

--- a/SerialPrograms/Source/PokemonSV/Options/PokemonSV_TournamentPrizeTable.h
+++ b/SerialPrograms/Source/PokemonSV/Options/PokemonSV_TournamentPrizeTable.h
@@ -1,0 +1,52 @@
+/* Tournament prize table
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonSV_TournamentPrizeSelector_H
+#define PokemonAutomation_PokemonSV_TournamentPrizeSelector_H
+
+#include "Common/Cpp/Options/EditableTableOption.h"
+#include "PokemonSV_TournamentPrizeSelectOption.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonSV{
+
+
+
+class TournamentPrizeSelectorRow : public EditableTableRow{
+public:
+    TournamentPrizeSelectorRow();
+    virtual std::unique_ptr<EditableTableRow> clone() const override;
+
+public:
+    TournamentPrizeSelectCell item;
+};
+
+
+
+class TournamentPrizeTable : public EditableTableOption_t<TournamentPrizeSelectorRow>{
+public:
+    TournamentPrizeTable(std::string label);
+
+
+    // Whether item_slug is among the selected items.
+    bool find_item(const std::string& item_slug) const;
+    // Return the auction item slugs that the user has selected via the auction item table UI.
+    std::vector<std::string> selected_items() const;
+
+    virtual std::vector<std::string> make_header() const override;
+
+    static std::vector<std::unique_ptr<EditableTableRow>> make_defaults();
+};
+
+
+
+
+
+}
+}
+}
+#endif

--- a/SerialPrograms/Source/PokemonSV/PokemonSV_Panels.cpp
+++ b/SerialPrograms/Source/PokemonSV/PokemonSV_Panels.cpp
@@ -75,7 +75,9 @@ std::vector<PanelEntry> PanelListFactory::make_panels() const{
     ret.emplace_back(make_single_switch_program<GimmighoulChestFarmer_Descriptor, GimmighoulChestFarmer>());
     ret.emplace_back(make_single_switch_program<AuctionFarmer_Descriptor, AuctionFarmer>());
     ret.emplace_back(make_single_switch_program<ESPTraining_Descriptor, ESPTraining>());
-    ret.emplace_back(make_single_switch_program<TournamentFarmer_Descriptor, TournamentFarmer>());
+    if (PreloadSettings::instance().DEVELOPER_MODE) {
+        ret.emplace_back(make_single_switch_program<TournamentFarmer_Descriptor, TournamentFarmer>());
+    }
 
     ret.emplace_back("---- Eggs ----");
     ret.emplace_back(make_single_switch_program<EggFetcher_Descriptor, EggFetcher>());

--- a/SerialPrograms/Source/PokemonSV/PokemonSV_Panels.cpp
+++ b/SerialPrograms/Source/PokemonSV/PokemonSV_Panels.cpp
@@ -21,6 +21,7 @@
 #include "Programs/General/PokemonSV_ESPTraining.h"
 #include "Programs/Trading/PokemonSV_SelfBoxTrade.h"
 #include "Programs/General/PokemonSV_StatsReset.h"
+#include "Programs/General/PokemonSV_TournamentFarmer.h"
 
 #include "Programs/Eggs/PokemonSV_EggFetcher.h"
 #include "Programs/Eggs/PokemonSV_EggHatcher.h"
@@ -74,6 +75,7 @@ std::vector<PanelEntry> PanelListFactory::make_panels() const{
     ret.emplace_back(make_single_switch_program<GimmighoulChestFarmer_Descriptor, GimmighoulChestFarmer>());
     ret.emplace_back(make_single_switch_program<AuctionFarmer_Descriptor, AuctionFarmer>());
     ret.emplace_back(make_single_switch_program<ESPTraining_Descriptor, ESPTraining>());
+    ret.emplace_back(make_single_switch_program<TournamentFarmer_Descriptor, TournamentFarmer>());
 
     ret.emplace_back("---- Eggs ----");
     ret.emplace_back(make_single_switch_program<EggFetcher_Descriptor, EggFetcher>());

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_GimmighoulChestFarmer.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_GimmighoulChestFarmer.cpp
@@ -32,7 +32,7 @@ using namespace Pokemon;
 
 GimmighoulChestFarmer_Descriptor::GimmighoulChestFarmer_Descriptor()
     : SingleSwitchProgramDescriptor(
-        "PokemonSV:GimmighoulChestFarerm",
+        "PokemonSV:GimmighoulChestFarmer",
         STRING_POKEMON + " SV", "Gimmighoul Chest Farmer",
         "ComputerControl/blob/master/Wiki/Programs/PokemonSV/GimmighoulChestFarmer.md",
         "Farm Chest Gimmighoul for coins.",

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.cpp
@@ -276,8 +276,14 @@ void TournamentFarmer::program(SingleSwitchProgramEnvironment& env, BotBaseConte
             for (const auto& r : result.results) {
                 env.console.log("Found prize: " + r.second.token);
                 if (TARGET_ITEMS.find_item(r.second.token)) {
-                    env.log("Prize on list");
-                    send_program_status_notification(env, NOTIFICATION_PRIZE_MATCH);  
+                    env.log("Prize matched");
+                    send_program_notification(
+                        env, NOTIFICATION_PRIZE_MATCH,
+                        COLOR_GREEN, "Prize matched",
+                        {
+                            { "Item:", r.second.token },
+                        }
+                    , "", screen);
                     break;
                 }
             }

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.cpp
@@ -40,7 +40,7 @@ TournamentFarmer_Descriptor::TournamentFarmer_Descriptor()
         "PokemonSV:TournamentFarmer",
         STRING_POKEMON + " SV", "Tournament Farmer",
         "ComputerControl/blob/master/Wiki/Programs/PokemonSV/TournamentFarmer.md",
-        "Farm the Ace Academy Tournament.",
+        "Farm the Ace Academy Tournament for money and prizes.",
         FeedbackType::REQUIRED,
         AllowCommandsWhenRunning::DISABLE_COMMANDS,
         PABotBaseLevel::PABOTBASE_12KB
@@ -120,6 +120,11 @@ void TournamentFarmer::program(SingleSwitchProgramEnvironment& env, BotBaseConte
     Sylveon only farming build - ideally with fairy tera
     stand in front of tournament entry man
     Ride legendary is not the solo pokemon (in case of loss)
+
+    Possible improvements to make:
+    money tracking? notifs tend to backlog.
+    find prize sprites - some code is there, just disabled
+    find translations for mints and tera shards
     */
 
     for(uint32_t c = 0; c < NUM_ROUNDS; c++) {

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.cpp
@@ -23,6 +23,8 @@
 #include "PokemonSV/Inference/Overworld/PokemonSV_OverworldDetector.h"
 #include "PokemonSV/Programs/PokemonSV_SaveGame.h"
 #include "PokemonSV/Programs/PokemonSV_Navigation.h"
+#include "PokemonSV/Inference/PokemonSV_TournamentPrizeNameReader.h"
+#include "PokemonSV/Resources/PokemonSV_TournamentPrizeNames.h"
 #include "PokemonSV_TournamentFarmer.h"
 
 namespace PokemonAutomation {
@@ -80,6 +82,7 @@ TournamentFarmer::TournamentFarmer()
         LockWhileRunning::UNLOCKED,
         0, 0
     )
+    , TARGET_ITEMS("<b>Items:</b>")
     , GO_HOME_WHEN_DONE(false)
     , NOTIFICATION_STATUS_UPDATE("Status Update", true, false, std::chrono::seconds(3600))
     , NOTIFICATIONS({
@@ -91,6 +94,7 @@ TournamentFarmer::TournamentFarmer()
     PA_ADD_OPTION(NUM_ROUNDS);
     PA_ADD_OPTION(TRY_TO_TERASTILLIZE);
     PA_ADD_OPTION(SAVE_NUM_ROUNDS);
+    PA_ADD_OPTION(TARGET_ITEMS);
     PA_ADD_OPTION(GO_HOME_WHEN_DONE);
     PA_ADD_OPTION(NOTIFICATIONS);
 }
@@ -110,7 +114,7 @@ void TournamentFarmer::program(SingleSwitchProgramEnvironment& env, BotBaseConte
         //Initiate dialog then mash until first battle starts
         AdvanceDialogWatcher advance_detector(COLOR_YELLOW);
         pbf_press_button(context, BUTTON_A, 10, 50);
-        int ret = wait_until(env.console, context, Milliseconds(4000), { advance_detector });
+        int ret = wait_until(env.console, context, Milliseconds(7000), { advance_detector });
         if (ret < 0) {
             env.log("Dialog detected.");
         }
@@ -269,7 +273,7 @@ void TournamentFarmer::program(SingleSwitchProgramEnvironment& env, BotBaseConte
             pbf_move_left_joystick(context, 0, 128, 8, 0);
             pbf_press_button(context, BUTTON_L, 50, 40);
             pbf_press_button(context, BUTTON_PLUS, 50, 40);
-            pbf_press_button(context, BUTTON_B, 50, 40); //Trying to glide over npc spawns
+            pbf_press_button(context, BUTTON_B, 50, 40); //Trying to jump/glide over npc spawns
             pbf_press_button(context, BUTTON_B, 50, 40);
             pbf_move_left_joystick(context, 128, 0, 500, 0);
             pbf_press_button(context, BUTTON_B, 50, 40);

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.cpp
@@ -1,0 +1,270 @@
+/*  Tournament Farmer
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "Common/Cpp/PrettyPrint.h"
+#include "CommonFramework/Exceptions/OperationFailedException.h"
+#include "CommonFramework/Notifications/ProgramNotifications.h"
+#include "CommonFramework/InferenceInfra/InferenceRoutines.h"
+#include "CommonFramework/Inference/BlackScreenDetector.h"
+#include "CommonFramework/Tools/StatsTracking.h"
+#include "CommonFramework/Tools/VideoResolutionCheck.h"
+#include "CommonFramework/OCR/OCR_NumberReader.h"
+#include "NintendoSwitch/NintendoSwitch_Settings.h"
+#include "NintendoSwitch/Commands/NintendoSwitch_Commands_PushButtons.h"
+#include "NintendoSwitch/Commands/NintendoSwitch_Commands_ScalarButtons.h"
+#include "NintendoSwitch/Programs/NintendoSwitch_GameEntry.h"
+#include "Pokemon/Pokemon_Strings.h"
+#include "PokemonSV/PokemonSV_Settings.h"
+#include "PokemonSV/Inference/Battles/PokemonSV_BattleMenuDetector.h"
+#include "PokemonSV/Inference/Dialogs/PokemonSV_DialogDetector.h"
+#include "PokemonSV/Inference/Overworld/PokemonSV_OverworldDetector.h"
+#include "PokemonSV/Programs/PokemonSV_SaveGame.h"
+#include "PokemonSV/Programs/PokemonSV_Navigation.h"
+#include "PokemonSV_TournamentFarmer.h"
+
+namespace PokemonAutomation {
+namespace NintendoSwitch {
+namespace PokemonSV {
+
+using namespace Pokemon;
+
+TournamentFarmer_Descriptor::TournamentFarmer_Descriptor()
+    : SingleSwitchProgramDescriptor(
+        "PokemonSV:TournamentFarmer",
+        STRING_POKEMON + " SV", "Tournament Farmer",
+        "ComputerControl/blob/master/Wiki/Programs/PokemonSV/TournamentFarmer.md",
+        "Farm the Ace Academy Tournament.",
+        FeedbackType::REQUIRED,
+        AllowCommandsWhenRunning::DISABLE_COMMANDS,
+        PABotBaseLevel::PABOTBASE_12KB
+    )
+{}
+
+struct TournamentFarmer_Descriptor::Stats : public StatsTracker {
+    Stats()
+        : tournaments(m_stats["Tournaments won"])
+        , battles(m_stats["Battles fought"])
+        , losses(m_stats["Losses"])
+        , errors(m_stats["Errors"])
+    {
+        m_display_order.emplace_back("Tournaments won");
+        m_display_order.emplace_back("Battles fought");
+        m_display_order.emplace_back("Losses");
+        m_display_order.emplace_back("Errors", true);
+    }
+    std::atomic<uint64_t>& tournaments;
+    std::atomic<uint64_t>& battles;
+    std::atomic<uint64_t>& losses;
+    std::atomic<uint64_t>& errors;
+};
+std::unique_ptr<StatsTracker> TournamentFarmer_Descriptor::make_stats() const {
+    return std::unique_ptr<StatsTracker>(new Stats());
+}
+
+TournamentFarmer::TournamentFarmer()
+    : NUM_ROUNDS(
+        "<b>Number of Tournaments to run:",
+        LockWhileRunning::UNLOCKED,
+        100, 0
+    )
+    , TRY_TO_TERASTILLIZE(
+        "<b>Use Terastillization:</b><br>Will take longer but may be worth the attack boost.",
+          LockWhileRunning::UNLOCKED,
+        false
+    )
+    , SAVE_NUM_ROUNDS(
+        "<b>Save every this many tournaments:</b><br>(zero disables saving)",
+        LockWhileRunning::UNLOCKED,
+        0, 0
+    )
+    , GO_HOME_WHEN_DONE(false)
+    , NOTIFICATION_STATUS_UPDATE("Status Update", true, false, std::chrono::seconds(3600))
+    , NOTIFICATIONS({
+        &NOTIFICATION_STATUS_UPDATE,
+        &NOTIFICATION_PROGRAM_FINISH,
+        &NOTIFICATION_ERROR_FATAL,
+        })
+{
+    PA_ADD_OPTION(NUM_ROUNDS);
+    PA_ADD_OPTION(TRY_TO_TERASTILLIZE);
+    PA_ADD_OPTION(SAVE_NUM_ROUNDS);
+    PA_ADD_OPTION(GO_HOME_WHEN_DONE);
+    PA_ADD_OPTION(NOTIFICATIONS);
+}
+
+void TournamentFarmer::program(SingleSwitchProgramEnvironment& env, BotBaseContext& context) {
+    assert_16_9_720p_min(env.logger(), env.console);
+    TournamentFarmer_Descriptor::Stats& stats = env.current_stats<TournamentFarmer_Descriptor::Stats>();
+    
+    /*
+    Preconditions:
+    Last Pokemon Center visited is Mesagzoa West
+    Sylveon only farming build - ideally with fairy tera
+    stand in front of tournament entry man
+    */
+
+    for(uint32_t c = 0; c < NUM_ROUNDS; c++) {
+        //Initiate dialog then mash until first battle starts
+        AdvanceDialogWatcher advance_detector(COLOR_YELLOW);
+        pbf_press_button(context, BUTTON_A, 10, 50);
+        int retD = wait_until(env.console, context, Milliseconds(4000), { advance_detector });
+        if (retD < 0) {
+            env.log("Dialog detected.");
+        }
+        pbf_mash_button(context, BUTTON_A, 300);
+        context.wait_for_all_requests();
+
+        NormalBattleMenuWatcher battle_menu(COLOR_YELLOW);
+        int ret = run_until(
+            env.console, context,
+            [](BotBaseContext& context) {
+                pbf_mash_button(context, BUTTON_B, 10000); //it takes a while to load and start
+            },
+            { battle_menu }
+            );
+        if (ret != 0) {
+            env.console.log("Failed to detect battle start!", COLOR_RED);
+        }
+        context.wait_for_all_requests();
+
+        bool battle_lost = false;
+        for (uint16_t battles = 0; !battle_lost && battles < 4; battles++) {
+            BlackScreenOverWatcher black_screen(COLOR_RED, { 0.2, 0.2, 0.6, 0.6 });
+            NormalBattleMenuWatcher battle_menu2(COLOR_YELLOW);
+            PromptDialogWatcher prompt_dialog(COLOR_CYAN); //pokemon center
+            int ret_black;
+
+            //Wait for battle - shorter than tournament start above
+            ret = run_until(
+                env.console, context,
+                [](BotBaseContext& context) {
+                    pbf_mash_button(context, BUTTON_B, 4000);
+                },
+                { battle_menu2, prompt_dialog }
+                );
+            context.wait_for_all_requests();
+            
+            switch (ret) {
+            case 0:
+                env.log("Detected battle menu.");
+
+                //Assuming the player has a charged orb
+                if (TRY_TO_TERASTILLIZE) {
+                    //Open move menu
+                    pbf_press_button(context, BUTTON_A, 10, 50);
+                    pbf_wait(context, 100);
+                    context.wait_for_all_requests();
+
+                    pbf_press_button(context, BUTTON_R, 20, 50);
+                }
+
+                //Mash A until battle finished
+                ret_black = run_until(
+                    env.console, context,
+                    [](BotBaseContext& context) {
+                        pbf_mash_button(context, BUTTON_A, 30000);
+                        pbf_mash_button(context, BUTTON_A, 7500); //5 minutes should be more than enough for one battle
+                    },
+                    { black_screen }
+                    );
+                if (ret_black == 0) {
+                    env.log("Battle finished.");
+                    stats.battles++;
+                    env.update_stats();
+                    send_program_status_notification(env, NOTIFICATION_STATUS_UPDATE);
+                }
+                else {
+                    env.log("Timed out during battle after 5 minutes.", COLOR_RED);
+                    stats.errors++;
+                    env.update_stats();
+                    send_program_status_notification(env, NOTIFICATION_STATUS_UPDATE);
+
+                    //RESET???
+                }
+                context.wait_for_all_requests();
+
+                break;
+            case 1:
+                env.log("Detected dialog prompt.");
+
+                //POKEMON CENTER???
+                //black screen then dialog
+
+                battle_lost = true;
+                break;
+            default:
+                env.log("Failed to detect battle menu or dialog prompt!");
+                stats.errors++;
+                env.update_stats();
+                send_program_status_notification(env, NOTIFICATION_STATUS_UPDATE);
+                break;
+            }
+        }
+        //One more black screen when done to load the academy
+        BlackScreenOverWatcher black_screen(COLOR_RED, { 0.2, 0.2, 0.6, 0.6 });
+        int ret_black = run_until(
+            env.console, context,
+            [](BotBaseContext& context) {
+                pbf_mash_button(context, BUTTON_A, 10000);
+            },
+            { black_screen }
+            );
+        if (ret_black == 0) {
+            env.log("Tournament complete, waiting for academy.");
+        }
+        context.wait_for_all_requests();
+
+        //Wait for congrats dialog - wait an extra bit since the dialog appears while still loading in
+        retD = wait_until(env.console, context, Milliseconds(1000), { advance_detector });
+        if (retD < 0) {
+            env.log("Dialog detected.");
+        }
+        pbf_wait(context, 300);
+        context.wait_for_all_requests();
+        
+        pbf_press_button(context, BUTTON_A, 10, 50);
+
+        //NOW DETECT ITEM HERE
+        //????? OCR ????
+
+
+
+        //Clear remaining dialog and check if we need to save
+        OverworldWatcher overworld(COLOR_CYAN);
+        ret = run_until(
+            env.console, context,
+            [](BotBaseContext& context) {
+                pbf_mash_button(context, BUTTON_B, 700);
+            },
+            { overworld }
+            );
+        if (ret != 0) {
+            env.console.log("Failed to detect overworld.", COLOR_RED);
+        }
+        context.wait_for_all_requests();
+
+        //Save the game if option checked, then loop again
+        if (SAVE_NUM_ROUNDS != 0) {
+            if (((c + 1) % SAVE_NUM_ROUNDS) == 0) {
+                env.log("Saving game.");
+                save_game_from_overworld(env.program_info(), env.console, context);
+            }
+        }
+
+        stats.tournaments++;
+        env.update_stats();
+        send_program_status_notification(env, NOTIFICATION_STATUS_UPDATE);
+        
+    }
+
+    send_program_finished_notification(env, NOTIFICATION_PROGRAM_FINISH);
+    GO_HOME_WHEN_DONE.run_end_of_program(context);
+}
+
+}
+}
+}
+

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.h
@@ -1,0 +1,48 @@
+/*  Tournament Farmer
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonSwSh_TournamentFarmer_H
+#define PokemonAutomation_PokemonSwSh_TournamentFarmer_H
+
+#include "Common/Cpp/Options/BooleanCheckBoxOption.h"
+#include "Common/Cpp/Options/SimpleIntegerOption.h"
+#include "Common/Cpp/Options/EnumDropdownOption.h"
+#include "CommonFramework/Notifications/EventNotificationsTable.h"
+#include "NintendoSwitch/NintendoSwitch_SingleSwitchProgram.h"
+#include "NintendoSwitch/Options/NintendoSwitch_GoHomeWhenDoneOption.h"
+
+namespace PokemonAutomation {
+namespace NintendoSwitch {
+namespace PokemonSV {
+
+class TournamentFarmer_Descriptor : public SingleSwitchProgramDescriptor {
+public:
+    TournamentFarmer_Descriptor();
+    struct Stats;
+    virtual std::unique_ptr<StatsTracker> make_stats() const override;
+};
+
+class TournamentFarmer : public SingleSwitchProgramInstance {
+public:
+    TournamentFarmer();
+    virtual void program(SingleSwitchProgramEnvironment& env, BotBaseContext& context) override;
+
+private:
+    SimpleIntegerOption<uint32_t> NUM_ROUNDS;
+    BooleanCheckBoxOption TRY_TO_TERASTILLIZE;
+    SimpleIntegerOption<uint16_t> SAVE_NUM_ROUNDS;
+    GoHomeWhenDoneOption GO_HOME_WHEN_DONE;
+    EventNotificationOption NOTIFICATION_STATUS_UPDATE;
+    EventNotificationsOption NOTIFICATIONS;
+};
+
+}
+}
+}
+#endif
+
+
+

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.h
@@ -41,6 +41,11 @@ private:
     EventNotificationOption NOTIFICATION_PRIZE_MATCH;
     EventNotificationOption NOTIFICATION_STATUS_UPDATE;
     EventNotificationsOption NOTIFICATIONS;
+
+    void run_battle(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
+    void check_prize(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
+    void handle_end_of_tournament(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
+    void return_to_academy_after_loss(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
 };
 
 }

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.h
@@ -9,10 +9,10 @@
 
 #include "Common/Cpp/Options/BooleanCheckBoxOption.h"
 #include "Common/Cpp/Options/SimpleIntegerOption.h"
-#include "Common/Cpp/Options/EnumDropdownOption.h"
 #include "CommonFramework/Notifications/EventNotificationsTable.h"
 #include "NintendoSwitch/NintendoSwitch_SingleSwitchProgram.h"
 #include "NintendoSwitch/Options/NintendoSwitch_GoHomeWhenDoneOption.h"
+#include "PokemonSV/Options/PokemonSV_TournamentPrizeTable.h"
 
 namespace PokemonAutomation {
 namespace NintendoSwitch {
@@ -34,6 +34,7 @@ private:
     SimpleIntegerOption<uint32_t> NUM_ROUNDS;
     BooleanCheckBoxOption TRY_TO_TERASTILLIZE;
     SimpleIntegerOption<uint16_t> SAVE_NUM_ROUNDS;
+    TournamentPrizeTable TARGET_ITEMS;
     GoHomeWhenDoneOption GO_HOME_WHEN_DONE;
     EventNotificationOption NOTIFICATION_STATUS_UPDATE;
     EventNotificationsOption NOTIFICATIONS;

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.h
@@ -32,14 +32,13 @@ public:
     virtual void program(SingleSwitchProgramEnvironment& env, BotBaseContext& context) override;
 
 private:
-    EventNotificationOption NOTIFICATION_PRIZE_MATCH;
-
     SimpleIntegerOption<uint32_t> NUM_ROUNDS;
     BooleanCheckBoxOption TRY_TO_TERASTILLIZE;
     SimpleIntegerOption<uint16_t> SAVE_NUM_ROUNDS;
     GoHomeWhenDoneOption GO_HOME_WHEN_DONE;
     OCR::LanguageOCROption LANGUAGE;
     TournamentPrizeTable TARGET_ITEMS;
+    EventNotificationOption NOTIFICATION_PRIZE_MATCH;
     EventNotificationOption NOTIFICATION_STATUS_UPDATE;
     EventNotificationsOption NOTIFICATIONS;
 };

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.h
@@ -12,6 +12,7 @@
 #include "CommonFramework/Notifications/EventNotificationsTable.h"
 #include "NintendoSwitch/NintendoSwitch_SingleSwitchProgram.h"
 #include "NintendoSwitch/Options/NintendoSwitch_GoHomeWhenDoneOption.h"
+#include "CommonFramework/Options/LanguageOCROption.h"
 #include "PokemonSV/Options/PokemonSV_TournamentPrizeTable.h"
 
 namespace PokemonAutomation {
@@ -31,11 +32,14 @@ public:
     virtual void program(SingleSwitchProgramEnvironment& env, BotBaseContext& context) override;
 
 private:
+    EventNotificationOption NOTIFICATION_PRIZE_MATCH;
+
     SimpleIntegerOption<uint32_t> NUM_ROUNDS;
     BooleanCheckBoxOption TRY_TO_TERASTILLIZE;
     SimpleIntegerOption<uint16_t> SAVE_NUM_ROUNDS;
-    TournamentPrizeTable TARGET_ITEMS;
     GoHomeWhenDoneOption GO_HOME_WHEN_DONE;
+    OCR::LanguageOCROption LANGUAGE;
+    TournamentPrizeTable TARGET_ITEMS;
     EventNotificationOption NOTIFICATION_STATUS_UPDATE;
     EventNotificationsOption NOTIFICATIONS;
 };

--- a/SerialPrograms/Source/PokemonSV/Resources/PokemonSV_ItemSprites.cpp
+++ b/SerialPrograms/Source/PokemonSV/Resources/PokemonSV_ItemSprites.cpp
@@ -16,7 +16,6 @@ const SpriteDatabase& AUCTION_ITEM_SPRITES(){
 }
 
 
-
 }
 }
 }

--- a/SerialPrograms/Source/PokemonSV/Resources/PokemonSV_ItemSprites.h
+++ b/SerialPrograms/Source/PokemonSV/Resources/PokemonSV_ItemSprites.h
@@ -16,7 +16,6 @@ namespace PokemonSV{
 
 const SpriteDatabase& AUCTION_ITEM_SPRITES();
 
-
 }
 }
 }

--- a/SerialPrograms/Source/PokemonSV/Resources/PokemonSV_TournamentPrizeNames.cpp
+++ b/SerialPrograms/Source/PokemonSV/Resources/PokemonSV_TournamentPrizeNames.cpp
@@ -1,0 +1,109 @@
+/*  Tournament Prize Names
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include <map>
+#include "Common/Cpp/Json/JsonValue.h"
+#include "Common/Cpp/Json/JsonArray.h"
+#include "Common/Cpp/Json/JsonObject.h"
+#include "CommonFramework/Globals.h"
+#include "PokemonSV_TournamentPrizeNames.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonSV{
+
+
+struct TournamentPrizeNameDatabase {
+    TournamentPrizeNameDatabase();
+
+    static const TournamentPrizeNameDatabase& instance() {
+        static TournamentPrizeNameDatabase database;
+        return database;
+    }
+
+    static const std::string NULL_SLUG;
+    std::vector<std::string> ordered_list;
+    std::map<std::string, TournamentPrizeNames> database;
+    std::map<std::string, std::string> reverse_lookup;
+};
+const std::string TournamentPrizeNameDatabase::NULL_SLUG;
+
+TournamentPrizeNameDatabase::TournamentPrizeNameDatabase()
+{
+    // Load a list of tournament prize slugs in the desired order:
+    // ["potion", "fresh-water", ... ]
+    std::string path_slugs = RESOURCE_PATH() + "PokemonSV/AAT/TournamentPrizeList.json";
+    JsonValue json_slugs = load_json_file(path_slugs);
+    JsonArray& slugs = json_slugs.get_array_throw(path_slugs);
+
+    // Load a map of tournament prize slugs to item names in all languages, e.g.:
+    // {
+    //      "potion": {
+    //          "eng": "Potion",
+    //          "deu": "Trank",
+    //          ...
+    //      },
+    //      ....
+    // }
+    std::string path_disp = RESOURCE_PATH() + "PokemonSV/AAT/TournamentPrizeNameDisplay.json";
+    JsonValue json_disp = load_json_file(path_disp);
+    JsonObject& item_disp = json_disp.get_object_throw(path_disp);
+
+    for (auto& item : slugs) {
+        std::string& slug = item.get_string_throw(path_slugs);
+
+        JsonObject& auction_item_name_dict = item_disp.get_object_throw(slug, path_disp);
+        std::string& display_name = auction_item_name_dict.get_string_throw("eng", path_disp);
+
+        ordered_list.push_back(slug);
+        database[std::move(slug)].m_display_name = std::move(display_name);
+    }
+
+    for (const auto& item : database) {
+        reverse_lookup[item.second.m_display_name] = item.first;
+    }
+}
+
+const TournamentPrizeNames& get_tournament_prize_name(const std::string& slug) {
+    const std::map<std::string, TournamentPrizeNames>& database = TournamentPrizeNameDatabase::instance().database;
+    auto iter = database.find(slug);
+    if (iter == database.end()) {
+        throw InternalProgramError(
+            nullptr, PA_CURRENT_FUNCTION,
+            "Tournament prize slug not found in database: " + slug
+        );
+    }
+    return iter->second;
+}
+const std::string& parse_tournament_prize_name(const std::string& display_name) {
+    const std::map<std::string, std::string>& database = TournamentPrizeNameDatabase::instance().reverse_lookup;
+    auto iter = database.find(display_name);
+    if (iter == database.end()) {
+        throw InternalProgramError(
+            nullptr, PA_CURRENT_FUNCTION,
+            "Tournament prize name not found in database: " + display_name
+        );
+    }
+    return iter->second;
+}
+const std::string& parse_tournament_prize_name_nothrow(const std::string& display_name) {
+    const std::map<std::string, std::string>& database = TournamentPrizeNameDatabase::instance().reverse_lookup;
+    auto iter = database.find(display_name);
+    if (iter == database.end()) {
+        return TournamentPrizeNameDatabase::NULL_SLUG;
+    }
+    return iter->second;
+}
+
+
+const std::vector<std::string>& TOURNAMENT_PRIZE_SLUGS() {
+    return TournamentPrizeNameDatabase::instance().ordered_list;
+}
+
+
+}
+}
+}

--- a/SerialPrograms/Source/PokemonSV/Resources/PokemonSV_TournamentPrizeNames.h
+++ b/SerialPrograms/Source/PokemonSV/Resources/PokemonSV_TournamentPrizeNames.h
@@ -1,0 +1,39 @@
+/*  Tournament Prize Names
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonSV_TournamentPrizeNames_H
+#define PokemonAutomation_PokemonSV_TournamentPrizeNames_H
+
+#include <string>
+#include <vector>
+
+namespace PokemonAutomation {
+namespace NintendoSwitch {
+namespace PokemonSV {
+
+
+class TournamentPrizeNames {
+public:
+    const std::string& display_name() const { return m_display_name; }
+
+private:
+    friend struct TournamentPrizeNameDatabase;
+
+    std::string m_display_name;
+};
+
+
+const TournamentPrizeNames& get_tournament_prize_name(const std::string& slug);
+const std::string& parse_tournament_prize_name(const std::string& display_name);
+const std::string& parse_tournament_prize_name_nothrow(const std::string& display_name);
+
+const std::vector<std::string>& TOURNAMENT_PRIZE_SLUGS();
+
+
+}
+}
+}
+#endif


### PR DESCRIPTION
Farms the academy tournament and notifies if the resulting prize matches filters. Supports tera at the start of each battle and saving every x number of tournaments. If tournament lost, it will attempt to return to the academy. Does not support counting prize money (yet). Turbo A actually runs faster than this if you have the right build, don't die, and don't care for knowing what the prizes were so I'll put that in the documentation when I get to writing it.

Prize reading will most likely have the same gold bottle cap issue in japanese as auction farmer. In english, "a bottle of PP Up" was mistaken as "bottle cap" so there's another line in the json file to account for it, unsure if a similar issue will happen in other languages. I couldn't find translations for "tera shard" so it only checks for the type.