### PR TITLE
lower stats_border_top.stddev.sum() in DialogDetector

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Inference/Dialogs/PokemonSV_DialogDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Dialogs/PokemonSV_DialogDetector.cpp
@@ -59,7 +59,7 @@ bool DialogBoxDetector::detect(const ImageViewRGB32& screen) const{
 
     ImageStats stats_border_top = image_stats(extract_box_reference(screen, m_border_top));
 //    cout << stats_border_top.average << stats_border_top.stddev << endl;
-    if (stats_border_top.stddev.sum() < 100){
+    if (stats_border_top.stddev.sum() < 85){
         return !m_true_if_detected;
     }
 

--- a/SerialPrograms/Source/Tests/PokemonSV_Tests.cpp
+++ b/SerialPrograms/Source/Tests/PokemonSV_Tests.cpp
@@ -23,6 +23,7 @@
 #include "PokemonSV/Inference/Picnics/PokemonSV_SandwichHandDetector.h"
 #include "PokemonSV/Inference/Picnics/PokemonSV_SandwichIngredientDetector.h"
 #include "PokemonSV/Inference/Overworld/PokemonSV_OverworldDetector.h"
+#include "PokemonSV/Inference/Dialogs/PokemonSV_DialogDetector.h"
 
 #include <iostream>
 using std::cout;
@@ -425,6 +426,13 @@ int test_pokemonSV_SandwichIngredientReader(const ImageViewRGB32& image, const s
         }
     }
 
+    return 0;
+}
+
+int test_pokemonSV_AdvanceDialogDetector(const ImageViewRGB32& image, bool target) {
+    AdvanceDialogDetector detector(COLOR_RED);
+    bool result = detector.detect(image);
+    TEST_RESULT_EQUAL(result, target);
     return 0;
 }
 

--- a/SerialPrograms/Source/Tests/PokemonSV_Tests.h
+++ b/SerialPrograms/Source/Tests/PokemonSV_Tests.h
@@ -48,6 +48,8 @@ int test_pokemonSV_SandwichIngredientsDetector(const ImageViewRGB32& image, cons
 
 int test_pokemonSV_SandwichIngredientReader(const ImageViewRGB32& image, const std::vector<std::string>& words);
 
+int test_pokemonSV_AdvanceDialogDetector(const ImageViewRGB32& image, bool target);
+
 }
 
 #endif

--- a/SerialPrograms/Source/Tests/TestMap.cpp
+++ b/SerialPrograms/Source/Tests/TestMap.cpp
@@ -271,6 +271,7 @@ const std::map<std::string, TestFunction> TEST_MAP = {
     {"PokemonSV_BoxBottomButtonDetector", std::bind(image_words_detector_helper, test_pokemonSV_BoxBottomButtonDetector, _1)},
     {"PokemonSV_SandwichIngredientsDetector", std::bind(image_words_detector_helper, test_pokemonSV_SandwichIngredientsDetector, _1)},
     {"PokemonSV_SandwichIngredientReader", std::bind(image_words_detector_helper, test_pokemonSV_SandwichIngredientReader, _1)},
+    {"PokemonSV_AdvanceDialogDetector", std::bind(image_bool_detector_helper, test_pokemonSV_AdvanceDialogDetector, _1)},
 };
 
 TestFunction find_test_function(const std::string& test_space, const std::string& test_name){


### PR DESCRIPTION
Advance dialog detector fails on the image below.

stats_border_top.stddev.sum() = 90.3619
![AdvanceDialogDetector_True](https://user-images.githubusercontent.com/3212217/219894515-278448eb-54b2-4c47-8f9e-1fd5909a556c.png)