### PR TITLE
extra and adjust A press for tournament start

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.cpp
@@ -363,11 +363,12 @@ void TournamentFarmer::program(SingleSwitchProgramEnvironment& env, BotBaseConte
         //Initiate dialog then mash until first battle starts
         AdvanceDialogWatcher advance_detector(COLOR_YELLOW);
         pbf_press_button(context, BUTTON_A, 10, 50);
+        pbf_press_button(context, BUTTON_A, 10, 50);
         int ret = wait_until(env.console, context, Milliseconds(7000), { advance_detector });
         if (ret < 0) {
             env.log("Dialog detected.");
         }
-        pbf_mash_button(context, BUTTON_A, 300);
+        pbf_mash_button(context, BUTTON_A, 400);
         context.wait_for_all_requests();
 
         NormalBattleMenuWatcher battle_menu(COLOR_YELLOW);


### PR DESCRIPTION
in case the input is missed, which leads the program to treat it as a loss in battle while the player is stuck at the entry desk