### PR TITLE
tournament money tracking and options

### DIFF
--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -429,6 +429,8 @@ file(GLOB MAIN_SOURCES
     Source/CommonFramework/OCR/OCR_DictionaryOCR.h
     Source/CommonFramework/OCR/OCR_LargeDictionaryMatcher.cpp
     Source/CommonFramework/OCR/OCR_LargeDictionaryMatcher.h
+    Source/CommonFramework/OCR/OCR_MoneyReader.cpp
+    Source/CommonFramework/OCR/OCR_MoneyReader.h
     Source/CommonFramework/OCR/OCR_NumberReader.cpp
     Source/CommonFramework/OCR/OCR_NumberReader.h
     Source/CommonFramework/OCR/OCR_RawOCR.cpp

--- a/SerialPrograms/Source/CommonFramework/OCR/OCR_MoneyReader.cpp
+++ b/SerialPrograms/Source/CommonFramework/OCR/OCR_MoneyReader.cpp
@@ -1,0 +1,68 @@
+/*  OCR Money Reader
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "CommonFramework/Language.h"
+#include "OCR_RawOCR.h"
+#include "OCR_MoneyReader.h"
+
+//#include <iostream>
+//using std::cout;
+//using std::endl;
+#include <regex>
+
+namespace PokemonAutomation{
+namespace OCR{
+
+
+
+int read_money(Logger& logger, const ImageViewRGB32& image){
+    std::string ocr_text = OCR::ocr_read(Language::English, image);
+    std::string normalized;
+
+    //Find pound sign and amount, we want to prevent cases like the following:
+    //OCR Text: "Al IRt 1N} . !You got 27,200 in prize money!" -> "4127200" -> 4127200
+    //OCR Text: "You got 26,400 in prize money!AR -" -> "264004" -> 264004
+    //OCR Text: "v N r 1 .You got 26,400 in prize money!" -> "126400" -> 126400
+    std::regex reg{ "\xA3[a-zA-Z0-9,.]+" };
+    std::smatch match;
+    std::regex_search(ocr_text, match, reg);
+    std::ssub_match sub_match = match[0];
+
+    bool has_digit = false;
+    for (char ch : sub_match.str()) {
+        //  4 is commonly misread as A.
+        if (ch == 'a' || ch == 'A') {
+            normalized += '4';
+            has_digit = true;
+        }
+        if ('0' <= ch && ch <= '9') {
+            normalized += ch;
+            has_digit = true;
+        }
+    }
+
+    if (!has_digit) {
+        return -1;
+    }
+
+    int number = std::atoi(normalized.c_str());
+
+    std::string str;
+    for (char ch : ocr_text){
+        if (ch != '\r' && ch != '\n'){
+            str += ch;
+        }
+    }
+
+    logger.log("OCR Text: \"" + str + "\" -> \"" + sub_match.str() + "\" -> " + normalized + "\" -> " + std::to_string(number));
+
+    return number;
+}
+
+
+
+}
+}

--- a/SerialPrograms/Source/CommonFramework/OCR/OCR_MoneyReader.h
+++ b/SerialPrograms/Source/CommonFramework/OCR/OCR_MoneyReader.h
@@ -1,0 +1,23 @@
+/*  OCR Money Reader
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_OCR_MoneyReader_H
+#define PokemonAutomation_OCR_MoneyReader_H
+
+#include "CommonFramework/Logging/Logger.h"
+
+namespace PokemonAutomation{
+    class ImageViewRGB32;
+namespace OCR{
+
+
+//  Returns -1 if no number is found.
+int read_money(Logger& logger, const ImageViewRGB32& image);
+
+
+}
+}
+#endif

--- a/SerialPrograms/Source/PokemonSV/Inference/Dialogs/PokemonSV_DialogDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Dialogs/PokemonSV_DialogDetector.cpp
@@ -59,7 +59,7 @@ bool DialogBoxDetector::detect(const ImageViewRGB32& screen) const{
 
     ImageStats stats_border_top = image_stats(extract_box_reference(screen, m_border_top));
 //    cout << stats_border_top.average << stats_border_top.stddev << endl;
-    if (stats_border_top.stddev.sum() < 80){
+    if (stats_border_top.stddev.sum() < 75){
         return !m_true_if_detected;
     }
 

--- a/SerialPrograms/Source/PokemonSV/Inference/Dialogs/PokemonSV_DialogDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Dialogs/PokemonSV_DialogDetector.cpp
@@ -59,7 +59,7 @@ bool DialogBoxDetector::detect(const ImageViewRGB32& screen) const{
 
     ImageStats stats_border_top = image_stats(extract_box_reference(screen, m_border_top));
 //    cout << stats_border_top.average << stats_border_top.stddev << endl;
-    if (stats_border_top.stddev.sum() < 85){
+    if (stats_border_top.stddev.sum() < 80){
         return !m_true_if_detected;
     }
 

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.cpp
@@ -449,8 +449,11 @@ void TournamentFarmer::program(SingleSwitchProgramEnvironment& env, BotBaseConte
         pbf_press_button(context, BUTTON_A, 10, 50);
         pbf_press_button(context, BUTTON_A, 10, 50);
         int ret = wait_until(env.console, context, Milliseconds(7000), { advance_detector });
-        if (ret < 0) {
+        if (ret == 0) {
             env.log("Dialog detected.");
+        }
+        else {
+            env.log("Dialog not detected.");
         }
         pbf_mash_button(context, BUTTON_A, 400);
         context.wait_for_all_requests();

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.cpp
@@ -87,6 +87,11 @@ TournamentFarmer::TournamentFarmer()
           LockWhileRunning::UNLOCKED,
           0, 0
           )
+    , MONEY_LIMIT(
+        "<b>Stop after earning this amount of money:</b><br>Zero disables this check. Does not count losses. Max is 999,999,999.",
+        LockWhileRunning::UNLOCKED,
+        999999999, 0, 999999999
+    )
     , GO_HOME_WHEN_DONE(false)
     , LANGUAGE(
           "<b>Game Language:</b><br>The language is needed to read the prizes.",
@@ -107,6 +112,7 @@ TournamentFarmer::TournamentFarmer()
     PA_ADD_OPTION(NUM_ROUNDS);
     PA_ADD_OPTION(TRY_TO_TERASTILLIZE);
     PA_ADD_OPTION(SAVE_NUM_ROUNDS);
+    PA_ADD_OPTION(MONEY_LIMIT);
     PA_ADD_OPTION(GO_HOME_WHEN_DONE);
     PA_ADD_OPTION(LANGUAGE);
     PA_ADD_OPTION(TARGET_ITEMS);
@@ -495,6 +501,13 @@ void TournamentFarmer::program(SingleSwitchProgramEnvironment& env, BotBaseConte
         if (num_rounds_temp != 0 && ((c + 1) % num_rounds_temp) == 0) {
             env.log("Saving game.");
             save_game_from_overworld(env.program_info(), env.console, context);
+        }
+
+        //Break loop and finish program if money limit is hit
+        uint32_t earnings_temp = MONEY_LIMIT;
+        if (earnings_temp != 0 && stats.money >= earnings_temp) {
+            env.log("Money limit hit. Ending program.");
+            break;
         }
     }
 

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.h
@@ -42,6 +42,7 @@ private:
     EventNotificationOption NOTIFICATION_STATUS_UPDATE;
     EventNotificationsOption NOTIFICATIONS;
 
+    void check_money(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
     void run_battle(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
     void check_prize(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
     void handle_end_of_tournament(SingleSwitchProgramEnvironment& env, BotBaseContext& context);

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.h
@@ -35,6 +35,7 @@ private:
     SimpleIntegerOption<uint32_t> NUM_ROUNDS;
     BooleanCheckBoxOption TRY_TO_TERASTILLIZE;
     SimpleIntegerOption<uint16_t> SAVE_NUM_ROUNDS;
+    SimpleIntegerOption<uint32_t> MONEY_LIMIT;
     GoHomeWhenDoneOption GO_HOME_WHEN_DONE;
     OCR::LanguageOCROption LANGUAGE;
     TournamentPrizeTable TARGET_ITEMS;


### PR DESCRIPTION
tournament farmer now reads and tracks money earned. new option added to stop after x amount of money made.

read_money is a modified read_number with some regex. depending on the lighting/time of day in game, additional digits would be added when trying to read the bottom notification. read_money stops that by only taking the amount after £