### PR TITLE
money reading fix for other languages

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Inference/PokemonSV_MoneyReader.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/PokemonSV_MoneyReader.cpp
@@ -23,6 +23,10 @@ int read_money(Logger& logger, const ImageViewRGB32& image){
     std::string ocr_text = OCR::ocr_read(Language::English, image);
     std::string normalized;
 
+    //Clean up the string because regex search does not like accented characters
+    std::regex regg("[^a-zA-Z0-9\xA3, .]+");
+    ocr_text = std::regex_replace(ocr_text, regg, "");
+
     //Find pound sign and amount, we want to prevent cases like the following:
     //OCR Text: "Al IRt 1N} . !You got 27,200 in prize money!" -> "4127200" -> 4127200
     //OCR Text: "You got 26,400 in prize money!AR -" -> "264004" -> 264004


### PR DESCRIPTION
regex_search results are inconsistent with different languages. using the language option and changing the language to match the game language works in some cases (it worked in french but not spanish) but was also inconsistent. using regex_replace to clean the string up ended up working the best.