### PR TITLE
Fixes

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Inference/Battles/PokemonSV_NormalBattleMenus.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Battles/PokemonSV_NormalBattleMenus.h
@@ -95,6 +95,10 @@ public:
     virtual void make_overlays(VideoOverlaySet& items) const override;
     virtual bool detect(const ImageViewRGB32& screen) const override;
 
+    //  Returns -1 if not found.
+    int8_t detect_slot(const ImageViewRGB32& screen) const;
+    bool move_to_slot(ConsoleHandle& console, BotBaseContext& context, uint8_t slot) const;
+
 private:
     GradientArrowDetector m_arrow;
 };

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_StatsReset.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_StatsReset.cpp
@@ -214,7 +214,7 @@ void StatsReset::program(SingleSwitchProgramEnvironment& env, BotBaseContext& co
         }
         if (battle_ended){
             //Close all the dex entry and caught menus
-            pbf_mash_button(context, BUTTON_B, 100);
+            pbf_mash_button(context, BUTTON_B, 170);
             context.wait_for_all_requests();
 
             //Open box and navigate to last party slot

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.cpp
@@ -597,7 +597,7 @@ void TournamentFarmer::program(SingleSwitchProgramEnvironment& env, BotBaseConte
             int ret_battle2 = run_until(
                 env.console, context,
                 [](BotBaseContext& context) {
-                    pbf_mash_button(context, BUTTON_B, 4500);
+                    pbf_mash_button(context, BUTTON_B, 5000);
                 },
                 { battle_menu2, overworld }
                 );
@@ -620,6 +620,11 @@ void TournamentFarmer::program(SingleSwitchProgramEnvironment& env, BotBaseConte
                 stats.errors++;
                 env.update_stats();
                 send_program_status_notification(env, NOTIFICATION_STATUS_UPDATE);
+                throw OperationFailedException(
+                    ErrorReport::SEND_ERROR_REPORT, env.console,
+                    "Failed to detect battle menu or dialog prompt!",
+                    true
+                );
                 break;
             }
 

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_TournamentFarmer.cpp
@@ -204,6 +204,7 @@ void TournamentFarmer::run_battle(SingleSwitchProgramEnvironment& env, BotBaseCo
 
         //If not already dead, use memento and die
         NormalBattleMenuWatcher memento(COLOR_RED);
+        MoveSelectDetector move_select(COLOR_BLUE);
         SwapMenuWatcher fainted(COLOR_YELLOW);
         int retZ = wait_until(
             env.console, context,
@@ -212,6 +213,8 @@ void TournamentFarmer::run_battle(SingleSwitchProgramEnvironment& env, BotBaseCo
         );
         if (retZ == 0) {
             env.log("Using Memento to faint.");
+            pbf_press_button(context, BUTTON_A, 10, 50);
+            move_select.move_to_slot(env.console, context, 1);
             pbf_press_button(context, BUTTON_A, 10, 50);
             pbf_wait(context, 100);
             context.wait_for_all_requests();
@@ -271,7 +274,7 @@ void TournamentFarmer::run_battle(SingleSwitchProgramEnvironment& env, BotBaseCo
         }
 
         //Select 2nd pokemon from swap menu and send it out
-        pbf_press_dpad(context, DPAD_DOWN, 10, 50);
+        fainted.move_to_slot(env.console, context, 1);
         pbf_mash_button(context, BUTTON_A, 300);
         context.wait_for_all_requests();
 


### PR DESCRIPTION
B mash increase for Stats Reset.
Implement and use move_to_slot in Zoroark Tournament Farmer. Swap menu detector values adjusted as it matches the left side of main menu.