### PR TITLE
option to loop macro, add L3 R3 buttons, table description

### DIFF
--- a/SerialPrograms/Source/NintendoSwitch/Options/TurboMacroTable.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/Options/TurboMacroTable.cpp
@@ -32,6 +32,8 @@ const EnumDatabase<TurboMacroAction>& TurboMacroAction_Database(){
         {TurboMacroAction::NO_ACTION,         "no-action",        "No Action"},
         {TurboMacroAction::LEFT_JOYSTICK,     "left-joystick",    "Left Joystick"},
         {TurboMacroAction::RIGHT_JOYSTICK,    "right-joystick",   "Right Joystick"},
+        {TurboMacroAction::LEFT_JOY_CLICK,    "left-joy-click",   "Press Left Joystick (L3)"},
+        {TurboMacroAction::RIGHT_JOY_CLICK,   "right-joy-click",  "Press Right Joystick (R3)"},
         {TurboMacroAction::B,                 "button-B",         "Press B"},
         {TurboMacroAction::A,                 "button-A",         "Press A"},
         {TurboMacroAction::Y,                 "button-Y",         "Press Y"},
@@ -92,6 +94,8 @@ void TurboMacroCell::value_changed(){
     switch (m_action){
     case TurboMacroAction::LEFT_JOYSTICK:
     case TurboMacroAction::RIGHT_JOYSTICK:
+    case TurboMacroAction::LEFT_JOY_CLICK:
+    case TurboMacroAction::RIGHT_JOY_CLICK:
     case TurboMacroAction::B:
     case TurboMacroAction::A:
     case TurboMacroAction::Y:
@@ -242,7 +246,8 @@ JsonValue TurboMacroRow::to_json() const{
 TurboMacroTable::TurboMacroTable()
     : EditableTableOption_t<TurboMacroRow>(
         "<b>Custom Macro Table:</b><br>"
-        "Set a list of button press to create a macro.",
+        "Set a list of button press to create a macro. 125 ticks = 1 second. Joystick direction is specified by (x, y).<br>"
+        "x = 0 is left, x = 255 is right. y = 0 is up, y = 255 is down. 128 is neutral for both. Ex. Move joystick fully left would be (0, 128). Move joystick up-right would be (255, 0).",
         LockWhileRunning::LOCKED
     )
 {}

--- a/SerialPrograms/Source/NintendoSwitch/Options/TurboMacroTable.h
+++ b/SerialPrograms/Source/NintendoSwitch/Options/TurboMacroTable.h
@@ -20,6 +20,8 @@ enum class TurboMacroAction{
     NO_ACTION,
     LEFT_JOYSTICK,
     RIGHT_JOYSTICK,
+    LEFT_JOY_CLICK,
+    RIGHT_JOY_CLICK,
     B,
     A,
     Y,

--- a/SerialPrograms/Source/NintendoSwitch/Programs/NintendoSwitch_TurboMacro.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/Programs/NintendoSwitch_TurboMacro.cpp
@@ -24,7 +24,14 @@ TurboMacro_Descriptor::TurboMacro_Descriptor()
     )
 {}
 
-TurboMacro::TurboMacro(){
+TurboMacro::TurboMacro()
+    : LOOP(
+        "<b>Number of times to loop:</b>",
+        LockWhileRunning::UNLOCKED,
+        100, 0
+        )
+{
+    PA_ADD_OPTION(LOOP);
     PA_ADD_OPTION(MACRO);
 }
 
@@ -45,6 +52,12 @@ void TurboMacro::execute_action(ConsoleHandle& console, BotBaseContext& context,
         break;
     case TurboMacroAction::RIGHT_JOYSTICK:
         pbf_move_right_joystick(context, cell.x_axis, cell.y_axis, cell.button_hold_ticks, cell.button_release_ticks);
+        break;
+    case TurboMacroAction::LEFT_JOY_CLICK:
+        pbf_press_button(context, BUTTON_LCLICK, cell.button_hold_ticks, cell.button_release_ticks);
+        break;
+    case TurboMacroAction::RIGHT_JOY_CLICK:
+        pbf_press_button(context, BUTTON_RCLICK, cell.button_hold_ticks, cell.button_release_ticks);
         break;
     case TurboMacroAction::B:
         pbf_press_button(context, BUTTON_B, cell.button_hold_ticks, cell.button_release_ticks);
@@ -99,9 +112,11 @@ void TurboMacro::execute_action(ConsoleHandle& console, BotBaseContext& context,
 void TurboMacro::program(SingleSwitchProgramEnvironment& env, BotBaseContext& context){
 
     //  Connect the controller.
-    pbf_press_button(context, BUTTON_LCLICK, 5, 5);
+    //pbf_press_button(context, BUTTON_LCLICK, 5, 5);
 
-    run_macro(env, context);
+    for (uint32_t c = 0; c < LOOP; c++) {
+        run_macro(env, context);
+    }
 }
 
 

--- a/SerialPrograms/Source/NintendoSwitch/Programs/NintendoSwitch_TurboMacro.h
+++ b/SerialPrograms/Source/NintendoSwitch/Programs/NintendoSwitch_TurboMacro.h
@@ -8,6 +8,7 @@
 #define PokemonAutomation_NintendoSwitch_TurboMacro_H
 
 #include "NintendoSwitch/NintendoSwitch_SingleSwitchProgram.h"
+#include "Common/Cpp/Options/SimpleIntegerOption.h"
 #include "NintendoSwitch/Options/TurboMacroTable.h"
 
 namespace PokemonAutomation{
@@ -32,6 +33,7 @@ private:
     void execute_action(ConsoleHandle& console, BotBaseContext& context, const TurboMacroRow& row);
 
 private:
+    SimpleIntegerOption<uint32_t> LOOP;
     TurboMacroTable MACRO;
 };
 


### PR DESCRIPTION
played around with turbo macro a bit and thought these would be nice to have.

- loop x number of times instead of only running once
- L3 and R3 now selectable
- added some information to the table description about how to use x/y coordinates on the joysticks since there isn't a wiki page