### PR TITLE
Adding Tears of the Kingdom - Bow Item Duper

### DIFF
--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -1856,6 +1856,12 @@ file(GLOB MAIN_SOURCES
     Source/Tests/TestMap.h
     Source/Tests/TestUtils.cpp
     Source/Tests/TestUtils.h
+    Source/ZeldaTotK/ZeldaTotK_Panels.cpp
+    Source/ZeldaTotK/ZeldaTotK_Panels.h
+    Source/ZeldaTotK/ZeldaTotK_Settings.cpp
+    Source/ZeldaTotK/ZeldaTotK_Settings.h
+    Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.cpp
+    Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.h
 )
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}../../ FILES ${MAIN_SOURCES})
 add_executable(SerialPrograms WIN32 ${MAIN_SOURCES})

--- a/SerialPrograms/SerialPrograms.pro
+++ b/SerialPrograms/SerialPrograms.pro
@@ -919,7 +919,13 @@ SOURCES += \
     Source/Tests/PokemonSV_Tests.cpp \
     Source/Tests/PokemonSwSh_Tests.cpp \
     Source/Tests/TestMap.cpp \
-    Source/Tests/TestUtils.cpp
+    Source/Tests/TestUtils.cpp \
+    Source/ZeldaTotK/ZeldaTotK_Panels.cpp \
+    Source/ZeldaTotK/ZeldaTotK_Panels.h \
+    Source/ZeldaTotK/ZeldaTotK_Settings.cpp \
+    Source/ZeldaTotK/ZeldaTotK_Settings.h \
+    Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.cpp \
+    Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.h
 
 HEADERS += \
     ../3rdParty/QtWavFile/WavFile.h \

--- a/SerialPrograms/Source/PanelLists.cpp
+++ b/SerialPrograms/Source/PanelLists.cpp
@@ -18,6 +18,7 @@
 #include "PokemonBDSP/PokemonBDSP_Panels.h"
 #include "PokemonLA/PokemonLA_Panels.h"
 #include "PokemonSV/PokemonSV_Panels.h"
+#include "ZeldaTotK/ZeldaTotK_Panels.h"
 #include "PanelLists.h"
 
 //#include <iostream>
@@ -46,6 +47,7 @@ ProgramSelect::ProgramSelect(QWidget& parent, PanelHolder& holder)
     add(std::make_unique<NintendoSwitch::PokemonBDSP::PanelListFactory>());
     add(std::make_unique<NintendoSwitch::PokemonLA::PanelListFactory>());
     add(std::make_unique<NintendoSwitch::PokemonSV::PanelListFactory>());
+    add(std::make_unique<NintendoSwitch::ZeldaTotK::PanelListFactory>());
 
 
 

--- a/SerialPrograms/Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.cpp
+++ b/SerialPrograms/Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.cpp
@@ -60,7 +60,7 @@ BowItemDuper::BowItemDuper()
         100
     )
     , TICK_DELAY(
-        "<b>Delay Between Menu Mashing:</b><br>Adjustable delay for exiting and reentering the menu. This should not typically be lower than 5 nor exceed 15 for successful results.",
+        "<b>Menu Delay:</b><br>Adjustable delay for exiting and reentering the menu. This should not typically be lower than 5 nor exceed 25 for successful results. Too low and the game will eat inputs and put the program in an irrecoverable state. Too high and the dupes will not be successful.",
         LockWhileRunning::UNLOCKED,
         15
     )

--- a/SerialPrograms/Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.cpp
+++ b/SerialPrograms/Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.cpp
@@ -79,7 +79,7 @@ BowItemDuper::BowItemDuper()
 }
 
 void BowItemDuper::program(SingleSwitchProgramEnvironment& env, BotBaseContext& context) {
-    assert_16_9_720p_min(env.logger(), env.console);
+    // assert_16_9_720p_min(env.logger(), env.console);
 
     // just do a forever loop where we have to do stuff
     uint32_t c = 0;

--- a/SerialPrograms/Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.cpp
+++ b/SerialPrograms/Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.cpp
@@ -1,0 +1,162 @@
+/*  TotK Bow Item Duper
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "Common/Cpp/PrettyPrint.h"
+#include "CommonFramework/Exceptions/OperationFailedException.h"
+#include "CommonFramework/Notifications/ProgramNotifications.h"
+#include "CommonFramework/InferenceInfra/InferenceRoutines.h"
+#include "CommonFramework/Tools/StatsTracking.h"
+#include "CommonFramework/Tools/VideoResolutionCheck.h"
+#include "NintendoSwitch/NintendoSwitch_Settings.h"
+#include "NintendoSwitch/Commands/NintendoSwitch_Commands_PushButtons.h"
+#include "NintendoSwitch/Commands/NintendoSwitch_Commands_ScalarButtons.h"
+#include "NintendoSwitch/Programs/NintendoSwitch_GameEntry.h"
+
+
+#include "ZeldaTotK/ZeldaTotK_Settings.h"
+
+#include "ZeldaTotK_BowItemDuper.h"
+
+namespace PokemonAutomation {
+namespace NintendoSwitch {
+namespace ZeldaTotK {
+
+using namespace Pokemon;
+
+BowItemDuper_Descriptor::BowItemDuper_Descriptor()
+    : SingleSwitchProgramDescriptor(
+        "ZeldaTotK:BowItemDuper",
+        "Zelda: TotK", "Bow Item Duper",
+        "ComputerControl/blob/master/Wiki/Programs/ZeldaTotK/BowItemDuper.md",
+        "Use the Bow Swap Glitch to farm any fusable items.",
+        FeedbackType::REQUIRED,
+        AllowCommandsWhenRunning::DISABLE_COMMANDS,
+        PABotBaseLevel::PABOTBASE_12KB
+    )
+{}
+
+struct BowItemDuper_Descriptor::Stats : public StatsTracker {
+    Stats()
+        : dupe_attempts(m_stats["Dupe Attempts"])
+        , errors(m_stats["Errors"])
+    {
+        m_display_order.emplace_back("Dupe Attempts");
+        m_display_order.emplace_back("Errors", true);
+    }
+    std::atomic<uint64_t>& dupe_attempts;
+    std::atomic<uint64_t>& errors;
+};
+std::unique_ptr<StatsTracker> BowItemDuper_Descriptor::make_stats() const {
+    return std::unique_ptr<StatsTracker>(new Stats());
+}
+
+BowItemDuper::BowItemDuper()
+    : ATTEMPTS(
+        "<b>Duplication Attempts:</b><br>The number of times you wish to run this routine.",
+        LockWhileRunning::LOCKED,
+        100
+    )
+    , TICK_DELAY(
+        "<b>Delay Between Menu Mashing:</b><br>Adjustable delay for exiting and reentering the menu. This should not typically be lower than 5 nor exceed 15 for successful results.",
+        LockWhileRunning::LOCKED,
+        15
+    )
+    , GO_HOME_WHEN_DONE(false)
+    , NOTIFICATION_STATUS_UPDATE("Status Update", true, false, std::chrono::seconds(3600))
+    , NOTIFICATIONS({
+        &NOTIFICATION_STATUS_UPDATE,
+        &NOTIFICATION_PROGRAM_FINISH,
+        &NOTIFICATION_ERROR_FATAL,
+        })
+{
+    PA_ADD_OPTION(ATTEMPTS);
+    PA_ADD_OPTION(TICK_DELAY);
+    PA_ADD_OPTION(GO_HOME_WHEN_DONE);
+    PA_ADD_OPTION(NOTIFICATIONS);
+}
+
+void BowItemDuper::program(SingleSwitchProgramEnvironment& env, BotBaseContext& context) {
+    assert_16_9_720p_min(env.logger(), env.console);
+
+    // just do a forever loop where we have to do stuff
+    uint32_t c = 0;
+
+    while (c < ATTEMPTS) {
+
+        env.log("Current Attempts: " + tostr_u_commas(c));
+
+        // zr to pull out bow
+        pbf_press_button(context, BUTTON_ZR, 12, 12);
+        // dpad up to try to fuse the item, release for a while to make sure fused
+        pbf_press_dpad(context, DPAD_UP, 20, 200);
+        
+        // then go ahead and enter the menu and do the various menuing in order to actually perform glitch
+        pbf_press_button(context, BUTTON_PLUS, 20, 150);
+
+        // drop current bow
+        pbf_press_button(context, BUTTON_A, 20, 20);
+        pbf_press_dpad(context, DPAD_DOWN, 10, 10);
+        pbf_press_button(context, BUTTON_A, 20, 20);
+        // now go to other bow and equip
+        pbf_press_dpad(context, DPAD_RIGHT, 10, 5);
+        pbf_press_button(context, BUTTON_A, 15, 15);
+        pbf_press_button(context, BUTTON_A, 20, 20);
+
+        // NOW WE HAVE TO PRESS PLUS AS FAST AS POSSIBLE
+        pbf_press_button(context, BUTTON_PLUS, 5, TICK_DELAY);
+        pbf_press_button(context, BUTTON_PLUS, 5, 5);
+
+        // navigate back to the "current" bow, then drop it
+        pbf_press_dpad(context, DPAD_LEFT, 10, 10);
+        pbf_press_button(context, BUTTON_A, 20, 20);
+        pbf_press_dpad(context, DPAD_DOWN, 10, 10);
+        pbf_press_button(context, BUTTON_A, 20, 20);
+
+        // back to overworld
+        pbf_press_button(context, BUTTON_PLUS, 20, 20);
+
+        // turn around
+        pbf_move_left_joystick(context, 128, 0, 10, 10);
+        // wait half a second
+        pbf_wait(context, (0.5 * TICKS_PER_SECOND));
+
+        // pick up both bows
+        pbf_press_button(context, BUTTON_A, 20, 20);
+        pbf_press_button(context, BUTTON_A, 20, 20);
+
+        // turn back around and wait before reopening menu
+        pbf_move_left_joystick(context, 128, 255, 10, 10);
+        // wait half a second
+        pbf_wait(context, (0.5 * TICKS_PER_SECOND));
+
+        // now go back into the menu
+        pbf_press_button(context, BUTTON_PLUS, 20, 50);
+
+        // reset the cursor location, then go back to overworld to start again
+        pbf_press_dpad(context, DPAD_LEFT, 15, 15);
+
+        pbf_press_button(context, BUTTON_PLUS, 20, 20);
+
+        // wait for everything before we try anything else
+        context.wait_for_all_requests();
+
+        // increment counter, increment stats
+        c++;
+        stats.dupe_attempts++;
+        env.update_stats();
+        send_program_status_notification(env, NOTIFICATION_STATUS_UPDATE);
+
+    }
+
+    // then we can finish up
+    GO_HOME_WHEN_DONE.run_end_of_program(context);
+    send_program_finished_notification(env, NOTIFICATION_PROGRAM_FINISH);
+}
+
+}
+}
+}
+

--- a/SerialPrograms/Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.cpp
+++ b/SerialPrograms/Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.cpp
@@ -32,7 +32,7 @@ BowItemDuper_Descriptor::BowItemDuper_Descriptor()
         "Zelda: TotK", "Bow Item Duper",
         "ComputerControl/blob/master/Wiki/Programs/ZeldaTotK/BowItemDuper.md",
         "Use the Bow Swap Glitch to farm any fusable items.",
-        FeedbackType::REQUIRED,
+        FeedbackType::NONE,
         AllowCommandsWhenRunning::DISABLE_COMMANDS,
         PABotBaseLevel::PABOTBASE_12KB
     )
@@ -56,12 +56,12 @@ std::unique_ptr<StatsTracker> BowItemDuper_Descriptor::make_stats() const {
 BowItemDuper::BowItemDuper()
     : ATTEMPTS(
         "<b>Duplication Attempts:</b><br>The number of times you wish to run this routine.",
-        LockWhileRunning::LOCKED,
+        LockWhileRunning::UNLOCKED,
         100
     )
     , TICK_DELAY(
         "<b>Delay Between Menu Mashing:</b><br>Adjustable delay for exiting and reentering the menu. This should not typically be lower than 5 nor exceed 15 for successful results.",
-        LockWhileRunning::LOCKED,
+        LockWhileRunning::UNLOCKED,
         15
     )
     , GO_HOME_WHEN_DONE(false)
@@ -69,7 +69,7 @@ BowItemDuper::BowItemDuper()
     , NOTIFICATIONS({
         &NOTIFICATION_STATUS_UPDATE,
         &NOTIFICATION_PROGRAM_FINISH,
-        &NOTIFICATION_ERROR_FATAL,
+        // &NOTIFICATION_ERROR_FATAL,
         })
 {
     PA_ADD_OPTION(ATTEMPTS);
@@ -95,51 +95,52 @@ void BowItemDuper::program(SingleSwitchProgramEnvironment& env, BotBaseContext& 
         pbf_press_dpad(context, DPAD_UP, 20, 200);
         
         // then go ahead and enter the menu and do the various menuing in order to actually perform glitch
-        pbf_press_button(context, BUTTON_PLUS, 20, 150);
+        pbf_press_button(context, BUTTON_PLUS, 20, 10);
 
         // drop current bow
-        pbf_press_button(context, BUTTON_A, 20, 20);
-        pbf_press_dpad(context, DPAD_DOWN, 10, 10);
-        pbf_press_button(context, BUTTON_A, 20, 20);
+        pbf_press_button(context, BUTTON_A, 10, 10);
+        pbf_press_dpad(context, DPAD_DOWN, 10, 5);
+        pbf_press_button(context, BUTTON_A, 10, 10);
         // now go to other bow and equip
         pbf_press_dpad(context, DPAD_RIGHT, 10, 5);
-        pbf_press_button(context, BUTTON_A, 15, 15);
-        pbf_press_button(context, BUTTON_A, 20, 20);
+        pbf_press_button(context, BUTTON_A, 10, 10);
+        pbf_press_button(context, BUTTON_A, 10, 15);
 
         // NOW WE HAVE TO PRESS PLUS AS FAST AS POSSIBLE
         pbf_press_button(context, BUTTON_PLUS, 3, TICK_DELAY);
         pbf_press_button(context, BUTTON_PLUS, 3, 3);
 
         // navigate back to the "current" bow, then drop it
-        pbf_press_dpad(context, DPAD_LEFT, 10, 10);
-        pbf_press_button(context, BUTTON_A, 20, 20);
-        pbf_press_dpad(context, DPAD_DOWN, 10, 10);
-        pbf_press_button(context, BUTTON_A, 20, 20);
+        pbf_press_dpad(context, DPAD_LEFT, 10, 5);
+        pbf_press_button(context, BUTTON_A, 10, 10);
+        pbf_press_dpad(context, DPAD_DOWN, 10, 5);
+        pbf_press_button(context, BUTTON_A, 10, 20);
 
         // back to overworld
-        pbf_press_button(context, BUTTON_PLUS, 20, 20);
+        pbf_press_button(context, BUTTON_PLUS, 10, 10);
 
         // turn around
         pbf_move_left_joystick(context, 128, 0, 3, 10);
         // wait half a second
-        pbf_wait(context, (uint16_t)(0.7 * TICKS_PER_SECOND));
+        pbf_wait(context, (uint16_t)(0.3 * TICKS_PER_SECOND));
 
         // pick up both bows
-        pbf_press_button(context, BUTTON_A, 20, 20);
+        pbf_press_button(context, BUTTON_A, 20, 10);
         pbf_press_button(context, BUTTON_A, 20, 20);
 
         // turn back around and wait before reopening menu
         pbf_move_left_joystick(context, 128, 255, 3, 10);
         // wait half a second
-        pbf_wait(context, (uint16_t)(0.7 * TICKS_PER_SECOND));
+        pbf_wait(context, (uint16_t)(0.4 * TICKS_PER_SECOND));
 
         // now go back into the menu
-        pbf_press_button(context, BUTTON_PLUS, 20, 50);
+        pbf_press_button(context, BUTTON_PLUS, 10, 10);
 
         // reset the cursor location, then go back to overworld to start again
-        pbf_press_dpad(context, DPAD_LEFT, 15, 15);
+        pbf_press_dpad(context, DPAD_LEFT, 10, 5);
 
-        pbf_press_button(context, BUTTON_PLUS, 20, 20);
+        pbf_press_button(context, BUTTON_PLUS, 20, 40);
+        // NOTE: needs a short buffer between runs to make sure new bow is ready
 
         // wait for everything before we try anything else
         context.wait_for_all_requests();

--- a/SerialPrograms/Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.cpp
+++ b/SerialPrograms/Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.cpp
@@ -89,6 +89,9 @@ void BowItemDuper::program(SingleSwitchProgramEnvironment& env, BotBaseContext& 
 
         env.log("Current Attempts: " + tostr_u_commas(c));
 
+        // this routine is thanks to koboldtime#2248 on the PA discord server
+        // it has been adjusted and modified by denvoros#0001
+
         // zr to pull out bow
         pbf_press_button(context, BUTTON_ZR, 12, 12);
         // dpad up to try to fuse the item, release for a while to make sure fused

--- a/SerialPrograms/Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.cpp
+++ b/SerialPrograms/Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.cpp
@@ -24,7 +24,7 @@ namespace PokemonAutomation {
 namespace NintendoSwitch {
 namespace ZeldaTotK {
 
-using namespace Pokemon;
+// using namespace Pokemon;
 
 BowItemDuper_Descriptor::BowItemDuper_Descriptor()
     : SingleSwitchProgramDescriptor(
@@ -83,6 +83,7 @@ void BowItemDuper::program(SingleSwitchProgramEnvironment& env, BotBaseContext& 
 
     // just do a forever loop where we have to do stuff
     uint32_t c = 0;
+    BowItemDuper_Descriptor::Stats& stats = env.current_stats<BowItemDuper_Descriptor::Stats>();
 
     while (c < ATTEMPTS) {
 
@@ -106,8 +107,8 @@ void BowItemDuper::program(SingleSwitchProgramEnvironment& env, BotBaseContext& 
         pbf_press_button(context, BUTTON_A, 20, 20);
 
         // NOW WE HAVE TO PRESS PLUS AS FAST AS POSSIBLE
-        pbf_press_button(context, BUTTON_PLUS, 5, TICK_DELAY);
-        pbf_press_button(context, BUTTON_PLUS, 5, 5);
+        pbf_press_button(context, BUTTON_PLUS, 3, TICK_DELAY);
+        pbf_press_button(context, BUTTON_PLUS, 3, 3);
 
         // navigate back to the "current" bow, then drop it
         pbf_press_dpad(context, DPAD_LEFT, 10, 10);
@@ -119,18 +120,18 @@ void BowItemDuper::program(SingleSwitchProgramEnvironment& env, BotBaseContext& 
         pbf_press_button(context, BUTTON_PLUS, 20, 20);
 
         // turn around
-        pbf_move_left_joystick(context, 128, 0, 10, 10);
+        pbf_move_left_joystick(context, 128, 0, 3, 10);
         // wait half a second
-        pbf_wait(context, (0.5 * TICKS_PER_SECOND));
+        pbf_wait(context, (uint16_t)(0.7 * TICKS_PER_SECOND));
 
         // pick up both bows
         pbf_press_button(context, BUTTON_A, 20, 20);
         pbf_press_button(context, BUTTON_A, 20, 20);
 
         // turn back around and wait before reopening menu
-        pbf_move_left_joystick(context, 128, 255, 10, 10);
+        pbf_move_left_joystick(context, 128, 255, 3, 10);
         // wait half a second
-        pbf_wait(context, (0.5 * TICKS_PER_SECOND));
+        pbf_wait(context, (uint16_t)(0.7 * TICKS_PER_SECOND));
 
         // now go back into the menu
         pbf_press_button(context, BUTTON_PLUS, 20, 50);

--- a/SerialPrograms/Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.h
+++ b/SerialPrograms/Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.h
@@ -1,0 +1,49 @@
+/*  Gimmighoul Chest Farmer
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_ZeldaTotK_BowItemDuper_H
+#define PokemonAutomation_ZeldaTotK_BowItemDuper_H
+
+#include "Common/Cpp/Options/BooleanCheckBoxOption.h"
+#include "Common/Cpp/Options/SimpleIntegerOption.h"
+#include "Common/Cpp/Options/EnumDropdownOption.h"
+#include "CommonFramework/Notifications/EventNotificationsTable.h"
+#include "NintendoSwitch/NintendoSwitch_SingleSwitchProgram.h"
+#include "NintendoSwitch/Options/NintendoSwitch_GoHomeWhenDoneOption.h"
+
+namespace PokemonAutomation {
+namespace NintendoSwitch {
+namespace ZeldaTotK {
+
+class BowItemDuper_Descriptor : public SingleSwitchProgramDescriptor {
+public:
+    BowItemDuper_Descriptor();
+    struct Stats;
+    virtual std::unique_ptr<StatsTracker> make_stats() const override;
+};
+
+class BowItemDuper : public SingleSwitchProgramInstance {
+public:
+    BowItemDuper();
+    virtual void program(SingleSwitchProgramEnvironment& env, BotBaseContext& context) override;
+
+private:
+    SimpleIntegerOption<uint32_t> ATTEMPTS;
+    SimpleIntegerOption<uint32_t> TICK_DELAY;
+    GoHomeWhenDoneOption GO_HOME_WHEN_DONE;
+
+    BooleanCheckBoxOption FIX_TIME_WHEN_DONE;
+    EventNotificationOption NOTIFICATION_STATUS_UPDATE;
+    EventNotificationsOption NOTIFICATIONS;
+};
+
+}
+}
+}
+#endif
+
+
+

--- a/SerialPrograms/Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.h
+++ b/SerialPrograms/Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.h
@@ -32,10 +32,8 @@ public:
 
 private:
     SimpleIntegerOption<uint32_t> ATTEMPTS;
-    SimpleIntegerOption<uint32_t> TICK_DELAY;
+    SimpleIntegerOption<uint16_t> TICK_DELAY;
     GoHomeWhenDoneOption GO_HOME_WHEN_DONE;
-
-    BooleanCheckBoxOption FIX_TIME_WHEN_DONE;
     EventNotificationOption NOTIFICATION_STATUS_UPDATE;
     EventNotificationsOption NOTIFICATIONS;
 };

--- a/SerialPrograms/Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.h
+++ b/SerialPrograms/Source/ZeldaTotK/Programs/ZeldaTotK_BowItemDuper.h
@@ -1,4 +1,4 @@
-/*  Gimmighoul Chest Farmer
+/*  TotK Bow Item Duper
  *
  *  From: https://github.com/PokemonAutomation/Arduino-Source
  *

--- a/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Panels.cpp
+++ b/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Panels.cpp
@@ -1,0 +1,52 @@
+/*  Pokemon SV Panels
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "CommonFramework/GlobalSettingsPanel.h"
+#include "ZeldaTotK_Panels.h"
+
+#include "ZeldaTotK_Settings.h"
+
+#include "Programs/ZeldaTotK_BowItemDuper.h"
+
+#ifdef PA_OFFICIAL
+#include "../../Internal/SerialPrograms/NintendoSwitch_TestPrograms.h"
+#endif
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonSV{
+
+
+
+PanelListFactory::PanelListFactory()
+    : PanelListDescriptor(Pokemon::STRING_POKEMON + " Scarlet and Violet")
+{}
+
+std::vector<PanelEntry> PanelListFactory::make_panels() const{
+    std::vector<PanelEntry> ret;
+    
+    ret.emplace_back("---- Settings ----");
+    ret.emplace_back(make_settings<GameSettings_Descriptor, GameSettingsPanel>());
+
+    ret.emplace_back("---- General ----");
+    ret.emplace_back(make_single_switch_program<BowItemDuper_Descriptor, BowItemDuper>());
+
+#ifdef PA_OFFICIAL
+    if (PreloadSettings::instance().DEVELOPER_MODE){
+        ret.emplace_back("---- Research ----");
+        add_panels(ret);
+    }
+#endif
+
+    return ret;
+}
+
+
+
+
+}
+}
+}

--- a/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Panels.cpp
+++ b/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Panels.cpp
@@ -17,12 +17,12 @@
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
-namespace PokemonSV{
+namespace ZeldaTotK{
 
 
 
 PanelListFactory::PanelListFactory()
-    : PanelListDescriptor(Pokemon::STRING_POKEMON + " Scarlet and Violet")
+    : PanelListDescriptor("Zelda: Tears of the Kingdom")
 {}
 
 std::vector<PanelEntry> PanelListFactory::make_panels() const{

--- a/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Panels.cpp
+++ b/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Panels.cpp
@@ -11,9 +11,6 @@
 
 #include "Programs/ZeldaTotK_BowItemDuper.h"
 
-#ifdef PA_OFFICIAL
-#include "../../Internal/SerialPrograms/NintendoSwitch_TestPrograms.h"
-#endif
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
@@ -28,18 +25,11 @@ PanelListFactory::PanelListFactory()
 std::vector<PanelEntry> PanelListFactory::make_panels() const{
     std::vector<PanelEntry> ret;
     
-    ret.emplace_back("---- Settings ----");
-    ret.emplace_back(make_settings<GameSettings_Descriptor, GameSettingsPanel>());
+    // ret.emplace_back("---- Settings ----");
+    // ret.emplace_back(make_settings<GameSettings_Descriptor, GameSettingsPanel>());
 
     ret.emplace_back("---- General ----");
     ret.emplace_back(make_single_switch_program<BowItemDuper_Descriptor, BowItemDuper>());
-
-#ifdef PA_OFFICIAL
-    if (PreloadSettings::instance().DEVELOPER_MODE){
-        ret.emplace_back("---- Research ----");
-        add_panels(ret);
-    }
-#endif
 
     return ret;
 }

--- a/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Panels.cpp
+++ b/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Panels.cpp
@@ -1,4 +1,4 @@
-/*  Pokemon SV Panels
+/*  Zelda: TotK Panels
  *
  *  From: https://github.com/PokemonAutomation/Arduino-Source
  *

--- a/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Panels.h
+++ b/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Panels.h
@@ -1,4 +1,4 @@
-/*  Pokemon Scarlet/Violet Panels
+/*  Zelda: TotK Panels
  *
  *  From: https://github.com/PokemonAutomation/Arduino-Source
  *

--- a/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Panels.h
+++ b/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Panels.h
@@ -1,0 +1,29 @@
+/*  Pokemon Scarlet/Violet Panels
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_ZeldaTotK_Panels_H
+#define PokemonAutomation_ZeldaTotK_Panels_H
+
+#include "CommonFramework/Panels/PanelList.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace ZeldaTotK{
+
+
+
+class PanelListFactory : public PanelListDescriptor{
+public:
+    PanelListFactory();
+    virtual std::vector<PanelEntry> make_panels() const;
+};
+
+
+
+}
+}
+}
+#endif

--- a/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Settings.cpp
+++ b/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Settings.cpp
@@ -6,14 +6,12 @@
 
 #include "Common/NintendoSwitch/NintendoSwitch_ControllerDefs.h"
 #include "CommonFramework/Globals.h"
-#include "Pokemon/Pokemon_Strings.h"
+
 #include "ZeldaTotK_Settings.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
 namespace ZeldaTotK{
-
-using namespace Pokemon;
 
 
 

--- a/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Settings.cpp
+++ b/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Settings.cpp
@@ -1,4 +1,4 @@
-/*  Pokemon SV Settings
+/*  Zelda: TotK Settings
  *
  *  From: https://github.com/PokemonAutomation/Arduino-Source
  *

--- a/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Settings.cpp
+++ b/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Settings.cpp
@@ -1,0 +1,101 @@
+/*  Pokemon SV Settings
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "Common/NintendoSwitch/NintendoSwitch_ControllerDefs.h"
+#include "CommonFramework/Globals.h"
+#include "Pokemon/Pokemon_Strings.h"
+#include "ZeldaTotK_Settings.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace ZeldaTotK{
+
+using namespace Pokemon;
+
+
+
+GameSettings& GameSettings::instance(){
+    static GameSettings settings;
+    return settings;
+}
+GameSettings::GameSettings()
+    : BatchOption(LockWhileRunning::LOCKED)
+    , m_menu_navigation("<font size=4><b>Menu Navigation Timings:</b></font>")
+    , GAME_TO_HOME_DELAY(
+        "<b>Game to Home Delay:</b><br>Delay from pressing home to entering the the Switch home menu.",
+        LockWhileRunning::LOCKED,
+        TICKS_PER_SECOND,
+        "125"
+    )
+    , m_start_game_timings("<font size=4><b>Start Game Timings:</b></font>")
+    , START_GAME_MASH(
+        "<b>1. Start Game Mash:</b><br>Mash A for this long to start the game.",
+        LockWhileRunning::LOCKED,
+        TICKS_PER_SECOND,
+        "2 * TICKS_PER_SECOND"
+    )
+    , START_GAME_WAIT(
+        "<b>2. Start Game Wait:</b><br>Wait this long for the game to load.",
+        LockWhileRunning::LOCKED,
+        TICKS_PER_SECOND,
+        "60 * TICKS_PER_SECOND"
+    )
+    , ENTER_GAME_MASH(
+        "<b>3. Enter Game Mash:</b><br>Mash A for this long to enter the game.",
+        LockWhileRunning::LOCKED,
+        TICKS_PER_SECOND,
+        "5 * TICKS_PER_SECOND"
+    )
+    , ENTER_GAME_WAIT(
+        "<b>4. Enter Game Wait:</b><br>Wait this long for the game to enter the overworld.",
+        LockWhileRunning::LOCKED,
+        TICKS_PER_SECOND,
+        "60 * TICKS_PER_SECOND"
+    )
+{
+    PA_ADD_STATIC(m_start_game_timings);
+    PA_ADD_OPTION(START_GAME_MASH);
+    PA_ADD_OPTION(START_GAME_WAIT);
+    PA_ADD_OPTION(ENTER_GAME_MASH);
+    PA_ADD_OPTION(ENTER_GAME_WAIT);
+}
+
+
+
+
+
+GameSettings_Descriptor::GameSettings_Descriptor()
+    : PanelDescriptor(
+        Color(),
+        "ZeldaTotK:GlobalSettings",
+        "Zelda: TotK", "Tears of the Kingdom Settings",
+        "ComputerControl/blob/master/Wiki/Programs/ZeldaTotK/TotKSettings.md",
+        "Global Zelda: Tears of the Kingom Settings"
+    )
+{}
+
+
+
+GameSettingsPanel::GameSettingsPanel(const GameSettings_Descriptor& descriptor)
+    : SettingsPanelInstance(descriptor)
+    , settings(GameSettings::instance())
+{
+    PA_ADD_OPTION(settings);
+}
+
+
+
+
+
+}
+}
+}
+
+
+
+
+
+

--- a/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Settings.h
+++ b/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Settings.h
@@ -1,0 +1,57 @@
+/*  Pokemon SV Settings
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_ZeldaTotK_Settings_H
+#define PokemonAutomation_ZeldaTotK_Settings_H
+
+#include "Common/Cpp/Options/StaticTextOption.h"
+#include "Common/Cpp/Options/BooleanCheckBoxOption.h"
+#include "Common/Cpp/Options/FloatingPointOption.h"
+#include "Common/Cpp/Options/TimeExpressionOption.h"
+#include "CommonFramework/Panels/SettingsPanel.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace ZeldaTotK{
+
+
+class GameSettings : public BatchOption{
+    GameSettings();
+public:
+    static GameSettings& instance();
+
+    SectionDividerOption m_menu_navigation;
+    TimeExpressionOption<uint16_t> GAME_TO_HOME_DELAY;
+
+    SectionDividerOption m_start_game_timings;
+    TimeExpressionOption<uint16_t> START_GAME_MASH;
+    TimeExpressionOption<uint16_t> START_GAME_WAIT;
+    TimeExpressionOption<uint16_t> ENTER_GAME_MASH;
+    TimeExpressionOption<uint16_t> ENTER_GAME_WAIT;
+
+};
+
+
+
+
+class GameSettings_Descriptor : public PanelDescriptor{
+public:
+    GameSettings_Descriptor();
+};
+
+
+class GameSettingsPanel : public SettingsPanelInstance{
+public:
+    GameSettingsPanel(const GameSettings_Descriptor& descriptor);
+private:
+    GameSettings& settings;
+};
+
+
+}
+}
+}
+#endif

--- a/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Settings.h
+++ b/SerialPrograms/Source/ZeldaTotK/ZeldaTotK_Settings.h
@@ -1,4 +1,4 @@
-/*  Pokemon SV Settings
+/*  Zelda: TotK Settings
  *
  *  From: https://github.com/PokemonAutomation/Arduino-Source
  *


### PR DESCRIPTION
This PR adds The Legend of Zelda: Tears of the Kingdom as a game for automation programs.

Additionally, it adds the via-bow-attaching-equipping-unequipping-duplication glitch as a program named Bow Item Duper. Special thanks to koboldtime#2248 on the Pokemon Automation Discord server for developing the routine. The routine is heavily based on that, but with minor timing adjustments to speed-up iterations while also isolating the timing that individual users will need control over as a single input parameter.

Unfortunately, there are a lot of inconsistencies with how the game handles this glitch (individual items to duplicate seem to have different timings, different bows have different timings, and even locations have different timings), so it will not have a 100% success rate. More research needs to be done for a suitable low-noise location that can replicate this glitch consistently.