### PR TITLE
Sandwich mode fixes

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Programs/PokemonSV_AreaZero.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/PokemonSV_AreaZero.cpp
@@ -224,7 +224,7 @@ void return_to_inside_zero_gate_from_picnic(const ProgramInfo& info, ConsoleHand
     int ret = run_until(
         console, context,
         [](BotBaseContext& context){
-            pbf_move_left_joystick(context, 128, 255, 30, 40);
+            pbf_move_left_joystick(context, 128, 255, 100, 40);
             pbf_mash_button(context, BUTTON_L, 60);
             pbf_move_left_joystick(context, 128, 0, 10 * TICKS_PER_SECOND, 0);
         },

--- a/SerialPrograms/Source/PokemonSV/Programs/PokemonSV_AreaZero.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/PokemonSV_AreaZero.cpp
@@ -219,6 +219,38 @@ void return_to_inside_zero_gate(const ProgramInfo& info, ConsoleHandle& console,
         );
     }
 }
+void return_to_inside_zero_gate_from_picnic(const ProgramInfo& info, ConsoleHandle& console, BotBaseContext& context){
+    BlackScreenOverWatcher black_screen;
+    int ret = run_until(
+        console, context,
+        [](BotBaseContext& context){
+            pbf_move_left_joystick(context, 128, 255, 30, 40);
+            pbf_mash_button(context, BUTTON_L, 60);
+            pbf_move_left_joystick(context, 128, 0, 10 * TICKS_PER_SECOND, 0);
+        },
+        {black_screen}
+    );
+    if (ret < 0){
+        throw OperationFailedException(
+            ErrorReport::SEND_ERROR_REPORT, console,
+            "Unable to enter Zero Gate.",
+            true
+        );
+    }
+
+    OverworldWatcher overworld;
+    ret = wait_until(
+        console, context, std::chrono::seconds(10),
+        {overworld}
+    );
+    if (ret < 0){
+        throw OperationFailedException(
+            ErrorReport::SEND_ERROR_REPORT, console,
+            "Unable to detect overworld inside Zero Gate.",
+            true
+        );
+    }
+}
 
 
 

--- a/SerialPrograms/Source/PokemonSV/Programs/PokemonSV_AreaZero.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/PokemonSV_AreaZero.h
@@ -31,6 +31,7 @@ void return_to_outside_zero_gate(const ProgramInfo& info, ConsoleHandle& console
 //  You are inside Area Zero having traveled there via the Zero Gate. Return to
 //  inside the zero gate to setup for a subsequent call to "inside_zero_gate_to_station()".
 void return_to_inside_zero_gate(const ProgramInfo& info, ConsoleHandle& console, BotBaseContext& context);
+void return_to_inside_zero_gate_from_picnic(const ProgramInfo& info, ConsoleHandle& console, BotBaseContext& context);
 
 
 

--- a/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-AreaZeroPlatform.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-AreaZeroPlatform.cpp
@@ -395,16 +395,12 @@ void ShinyHuntAreaZeroPlatform::run_state(SingleSwitchProgramEnvironment& env, B
 
             switch (m_last_save){
             case SavedLocation::NONE:
+            case SavedLocation::AREA_ZERO:
                 return_to_outside_zero_gate(info, console, context);
                 save_game_from_overworld(info, console, context);
                 m_last_save = SavedLocation::ZERO_GATE_FLY_SPOT;
                 break;
             case SavedLocation::ZERO_GATE_FLY_SPOT:
-                break;
-            case SavedLocation::AREA_ZERO:
-                return_to_outside_zero_gate(info, console, context);
-                save_game_from_overworld(info, console, context);
-                m_last_save = SavedLocation::ZERO_GATE_FLY_SPOT;
                 break;
             }
 
@@ -417,8 +413,6 @@ void ShinyHuntAreaZeroPlatform::run_state(SingleSwitchProgramEnvironment& env, B
                 stats.m_game_resets++;
                 m_env->update_stats();
             };
-
-            return_to_outside_zero_gate(info, console, context);
 
             // Open picnic and make sandwich
             picnic_at_zero_gate(info, console, context);

--- a/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-AreaZeroPlatform.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-AreaZeroPlatform.cpp
@@ -13,7 +13,6 @@
 #include "CommonFramework/Exceptions/FatalProgramException.h"
 #include "CommonFramework/Notifications/ProgramNotifications.h"
 #include "CommonFramework/InferenceInfra/InferenceRoutines.h"
-#include "CommonFramework/Tools/ErrorDumper.h"
 #include "CommonFramework/Tools/StatsTracking.h"
 #include "CommonFramework/Tools/VideoResolutionCheck.h"
 #include "NintendoSwitch/Commands/NintendoSwitch_Commands_PushButtons.h"
@@ -28,7 +27,6 @@
 #include "PokemonSV/Programs/PokemonSV_SaveGame.h"
 #include "PokemonSV/Programs/PokemonSV_Battles.h"
 #include "PokemonSV/Programs/PokemonSV_AreaZero.h"
-#include "PokemonSV/Programs/Sandwiches/PokemonSV_SandwichMaker.h"
 #include "PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.h"
 #include "PokemonSV_LetsGoTools.h"
 #include "PokemonSV_ShinyHunt-AreaZeroPlatform.h"
@@ -395,10 +393,22 @@ void ShinyHuntAreaZeroPlatform::run_state(SingleSwitchProgramEnvironment& env, B
         case State::RESET_SANDWICH:
             console.log("Resetting sandwich...");
 
-            recovery_state = State::LEAVE_AND_RETURN;
+            switch (m_last_save){
+            case SavedLocation::NONE:
+                return_to_outside_zero_gate(info, console, context);
+                save_game_from_overworld(info, console, context);
+                m_last_save = SavedLocation::ZERO_GATE_FLY_SPOT;
+                break;
+            case SavedLocation::ZERO_GATE_FLY_SPOT:
+                break;
+            case SavedLocation::AREA_ZERO:
+                return_to_outside_zero_gate(info, console, context);
+                save_game_from_overworld(info, console, context);
+                m_last_save = SavedLocation::ZERO_GATE_FLY_SPOT;
+                break;
+            }
 
-//            // connect controller
-//            pbf_press_button(context, BUTTON_L, 20, 105);
+            recovery_state = State::LEAVE_AND_RETURN;
 
             if (stats.m_sandwiches > 0) {
                 pbf_press_button(context, BUTTON_HOME, 20, GameSettings::instance().GAME_TO_HOME_DELAY);

--- a/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-AreaZeroPlatform.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-AreaZeroPlatform.cpp
@@ -211,17 +211,6 @@ bool ShinyHuntAreaZeroPlatform::run_traversal(BotBaseContext& context){
 
     WallClock start = current_time();
 
-    do{
-        if (start - m_last_sandwich < std::chrono::minutes(SANDWICH_RESET_IN_MINUTES)){
-            console.log("Sandwich Reset: Not enough time since last sandwich.", COLOR_ORANGE);
-            break;
-        }
-
-        console.log("Conditions met for sandwich reset.", COLOR_ORANGE);
-        m_state = State::RESET_SANDWICH;
-        return false;
-    }while (false);
-
     size_t kills, encounters;
     std::chrono::minutes window_minutes(PLATFORM_RESET.WINDOW_IN_MINUTES);
     WallDuration window = m_time_tracker->last_window_in_realtime(start, window_minutes);
@@ -309,12 +298,10 @@ void ShinyHuntAreaZeroPlatform::run_state(SingleSwitchProgramEnvironment& env, B
         {}, m_encounter_tracker->encounter_frequencies().dump_sorted_map("")
     );
 
-#if 0
     WallClock now = current_time();
-    if (m_last_sandwich + std::chrono::minutes() < now){
+    if (m_last_sandwich + std::chrono::minutes(SANDWICH_RESET_IN_MINUTES) < now){
         m_state = State::RESET_SANDWICH;
     }
-#endif
 
     State recovery_state = State::LEAVE_AND_RETURN;
     try{

--- a/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-AreaZeroPlatform.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-AreaZeroPlatform.cpp
@@ -385,6 +385,7 @@ void ShinyHuntAreaZeroPlatform::run_state(SingleSwitchProgramEnvironment& env, B
             case SavedLocation::AREA_ZERO:
                 return_to_outside_zero_gate(info, console, context);
                 save_game_from_overworld(info, console, context);
+                console.log("Saving at Zero Gate...");
                 m_last_save = SavedLocation::ZERO_GATE_FLY_SPOT;
                 break;
             case SavedLocation::ZERO_GATE_FLY_SPOT:

--- a/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-AreaZeroPlatform.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-AreaZeroPlatform.cpp
@@ -411,10 +411,9 @@ void ShinyHuntAreaZeroPlatform::run_state(SingleSwitchProgramEnvironment& env, B
             run_sandwich_maker(env, context, SANDWICH_OPTIONS);
 
             leave_picnic(info, console, context);
-            pbf_move_left_joystick(context, 128, 255, 30, 40);
 
             // Return to platform
-            return_to_inside_zero_gate(info, console, context);
+            return_to_inside_zero_gate_from_picnic(info, console, context);
             inside_zero_gate_to_platform(info, console, context, NAVIGATE_TO_PLATFORM);
 
             console.log("Sandwich Reset: Starting new sandwich timer...");


### PR DESCRIPTION
Fix reset loop. Shift reset logic to run_state(). Reduce unnecessary flying. Minor code & comment clean-up.