### PR TITLE
Implement new AutoSave mode AutoSave::AfterFetchComplete for sv-egg-autonomous

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
@@ -104,6 +104,7 @@ EggAutonomous::EggAutonomous()
             {AutoSave::NoAutoSave, "none", "No auto-saving."},
             {AutoSave::AfterStartAndKeep, "start-and-keep", "Save at beginning and after keeping a baby."},
             {AutoSave::EveryBatch, "every-batch", "Save before every batch of 4 or 5 eggs."},
+            {AutoSave::AfterFetchComplete, "after-fetch", "Save after all eggs have been fetched from picnic."}
         },
         LockWhileRunning::LOCKED,
         AutoSave::AfterStartAndKeep
@@ -388,7 +389,9 @@ void EggAutonomous::hatch_eggs_full_routine(SingleSwitchProgramEnvironment& env,
     }
 
     auto save_game_if_needed = [&](){
-        if (AUTO_SAVING == AutoSave::EveryBatch || (AUTO_SAVING == AutoSave::AfterStartAndKeep && m_in_critical_to_save_stage)){
+        if (AUTO_SAVING == AutoSave::EveryBatch ||
+            (AUTO_SAVING == AutoSave::AfterFetchComplete && m_saved_after_fetched_eggs == false) ||
+            (AUTO_SAVING == AutoSave::AfterStartAndKeep && m_in_critical_to_save_stage)){
             env.log("Saving game during egg hatching routine.");
             save_game(env, context, true);
             m_saved_after_fetched_eggs = true;

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.h
@@ -83,6 +83,7 @@ private:
         NoAutoSave,
         AfterStartAndKeep,
         EveryBatch,
+        AfterFetchComplete,
     };
     EnumDropdownOption<AutoSave> AUTO_SAVING;
 


### PR DESCRIPTION
This PR adds a new AutoSave option, `AutoSave::AfterFetchComplete` for the SV egg autonomous program.

Unlike `AutoSave::AfterEveryBatch`, this only saves once: when all eggs have been fetched from the picnic AND before the first batch of hatching begins. This gives the user the ability to "un-hatch" the whole egg box if they want to do so.