### PR TITLE
stats reset: switch fainted, 1st move instead of bounce reset

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_StatsReset.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_StatsReset.h
@@ -47,6 +47,10 @@ private:
     GoHomeWhenDoneOption GO_HOME_WHEN_DONE;
     EventNotificationOption NOTIFICATION_STATUS_UPDATE;
     EventNotificationsOption NOTIFICATIONS;
+
+    void enter_battle(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
+    bool run_battle(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
+    bool check_stats(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
 };
 
 }


### PR DESCRIPTION
Working on the ursaluna reset gave me the excuse I needed to fix up the older stats reset.

New features:
Detect fainted pokemon and switch it out, this allows for more ball throws per battle as the new legendaries mean that toxic is everywhere.
Use first move instead of resetting when Chi-Yu uses Bounce - new requirement that the first move is non damaging.