### PR TITLE
stats reset snacksworth legendaries

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_StatsReset.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_StatsReset.cpp
@@ -535,6 +535,9 @@ bool StatsReset::check_stats(SingleSwitchProgramEnvironment& env, BotBaseContext
         switch (action) {
         case StatsHuntAction::StopProgram:
             match = true;
+
+            pbf_press_button(context, BUTTON_CAPTURE, 2 * TICKS_PER_SECOND, 5 * TICKS_PER_SECOND);
+
             env.console.log("Match found!");
             stats.matches++;
             env.update_stats();

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_StatsReset.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_StatsReset.cpp
@@ -36,7 +36,7 @@ StatsReset_Descriptor::StatsReset_Descriptor()
         "PokemonSV:StatsReset",
         STRING_POKEMON + " SV", "Stats Reset",
         "ComputerControl/blob/master/Wiki/Programs/PokemonSV/StatsReset.md",
-        "Repeatedly catch the Treasures of Ruin or Loyal Three until you get the stats you want.",
+        "Repeatedly catch static encounters until you get the stats you want.",
         FeedbackType::REQUIRED,
         AllowCommandsWhenRunning::DISABLE_COMMANDS,
         PABotBaseLevel::PABOTBASE_12KB
@@ -67,17 +67,17 @@ std::unique_ptr<StatsTracker> StatsReset_Descriptor::make_stats() const {
 }
 StatsReset::StatsReset()
     : TARGET(
-        "<b>Target:</b><br>The Pokemon you are resetting for.<br>"
-        "Treasures of Ruin: Stand in front of the unsealed vaults of one of the Ruinous Quartet.<br>"
-        "Loyal Three: Stand in front of Okidogi/Munkidori/Fezandipiti.<br>"
-        "Snacksworth Legendary: After unlocking a legendary from Snacksworth, stand in front of it.<br>"
+        "<b>Target:</b><br>The Pokemon you are resetting for.",
+        //"Treasures of Ruin: Stand in front of the unsealed vaults of one of the Ruinous Quartet.<br>"
+        //"Loyal Three: Stand in front of Okidogi/Munkidori/Fezandipiti.<br>"
+        //"Snacksworth Legendary: After unlocking a legendary from Snacksworth, stand in front of it.<br>"
         //"Generic: You are standing in front of a Pokemon that requires an A press to initiate battle.<br>",
-        "Gimmighoul: Stand in front of a Gimmighoul chest.<br>",
+        //"Gimmighoul: Stand in front of a Gimmighoul chest.<br>",
         {
             {Target::TreasuresOfRuin, "treasures-of-ruin", "Treasures of Ruin"},
             {Target::LoyalThree, "loyal-three", "Loyal Three"},
-            {Target::Snacksworth, "snacksworth", "Snacksworth Legendary"},
-            {Target::Generic, "generic", "Gimmighoul"},
+            {Target::Snacksworth, "snacksworth", "Snacksworth Legendaries + Meloetta"},
+            {Target::Generic, "generic", "Indigo Disk Paradoxes (nature only) + Gimmighoul"},
         },
         LockMode::LOCK_WHILE_RUNNING,
         Target::TreasuresOfRuin

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_StatsReset.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_StatsReset.cpp
@@ -522,10 +522,6 @@ bool StatsReset::check_stats(SingleSwitchProgramEnvironment& env, BotBaseContext
             env.console.log("Match found!");
             stats.matches++;
             env.update_stats();
-            send_program_status_notification(
-                env, NOTIFICATION_PROGRAM_FINISH,
-                "Match found!"
-            );
             break;
         case StatsHuntAction::Discard:
             match = false;
@@ -604,8 +600,12 @@ void StatsReset::program(SingleSwitchProgramEnvironment& env, BotBaseContext& co
         }
     }
     env.update_stats();
+    auto screenshot = env.console.video().snapshot();
+    send_program_finished_notification(
+        env, NOTIFICATION_PROGRAM_FINISH,
+        "Match found!", screenshot, true
+    );
     GO_HOME_WHEN_DONE.run_end_of_program(context);
-    send_program_finished_notification(env, NOTIFICATION_PROGRAM_FINISH);
 }
     
 }

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_StatsReset.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_StatsReset.h
@@ -37,6 +37,7 @@ private:
     enum class Target {
         TreasuresOfRuin,
         LoyalThree,
+        Snacksworth,
         Generic,
     };
     EnumDropdownOption<Target> TARGET;

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_StatsResetBloodmoon.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_StatsResetBloodmoon.cpp
@@ -573,6 +573,7 @@ void StatsResetBloodmoon::program(SingleSwitchProgramEnvironment& env, BotBaseCo
         pbf_press_button(context, BUTTON_HOME, 20, GameSettings::instance().GAME_TO_HOME_DELAY);
         reset_game_from_home(env.program_info(), env.console, context, 5 * TICKS_PER_SECOND);
     }
+    stats.matches++;
     env.update_stats();
 
     auto snapshot = env.console.video().snapshot();


### PR DESCRIPTION
tested on latias and kyogre. had to make a new option for them instead of reusing generic/gimmi because none of the legendaries are in the dex, and catching them bypasses the caught screen/add to party prompt.