### PR TITLE
Fix Pokemon Home OT ID size

### DIFF
--- a/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxSorting.cpp
+++ b/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxSorting.cpp
@@ -177,7 +177,7 @@ struct Pokemon{
     bool gmax = false;
     std::string ball_slug = "";
     StatsHuntGenderFilter gender = StatsHuntGenderFilter::Genderless;
-    uint16_t ot_id = 0;
+    uint32_t ot_id = 0;
 };
 
 bool operator==(const Pokemon& lhs, const Pokemon& rhs){


### PR DESCRIPTION
The OT ID shown in Pokemon Home can be at least 6 digits, leading to it being larger than uint16_t. Change to uint32_t to allow for this.