### PR TITLE
separate sandwich maker functions

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
@@ -297,7 +297,7 @@ int EggAutonomous::fetch_eggs_full_routine(SingleSwitchProgramEnvironment& env, 
 
     picnic_at_zero_gate(env.program_info(), env.console, context);
     // Now we are at picnic. We are at one end of picnic table while the egg basket is at the other end
-    bool can_make_sandwich = eat_egg_sandwich_at_picnic(env, env.realtime_dispatcher(), env.console, context,
+    bool can_make_sandwich = eat_egg_sandwich_at_picnic(env.program_info(), env.realtime_dispatcher(), env.console, context,
         EGG_SANDWICH.EGG_SANDWICH_TYPE, LANGUAGE);
     if (can_make_sandwich == false){
         throw UserSetupError(env.console, "No sandwich recipe or ingredients. Cannot open and select the sandwich recipe.");

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
@@ -297,7 +297,7 @@ int EggAutonomous::fetch_eggs_full_routine(SingleSwitchProgramEnvironment& env, 
 
     picnic_at_zero_gate(env.program_info(), env.console, context);
     // Now we are at picnic. We are at one end of picnic table while the egg basket is at the other end
-    bool can_make_sandwich = eat_egg_sandwich_at_picnic(env.program_info(), env.realtime_dispatcher(), env.console, context,
+    bool can_make_sandwich = eat_egg_sandwich_at_picnic(env, env.realtime_dispatcher(), env.console, context,
         EGG_SANDWICH.EGG_SANDWICH_TYPE, LANGUAGE);
     if (can_make_sandwich == false){
         throw UserSetupError(env.console, "No sandwich recipe or ingredients. Cannot open and select the sandwich recipe.");

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
@@ -297,7 +297,7 @@ int EggAutonomous::fetch_eggs_full_routine(SingleSwitchProgramEnvironment& env, 
 
     picnic_at_zero_gate(env.program_info(), env.console, context);
     // Now we are at picnic. We are at one end of picnic table while the egg basket is at the other end
-    bool can_make_sandwich = eat_egg_sandwich_at_picnic(env, env.realtime_dispatcher(), env.console, context,
+    bool can_make_sandwich = eat_egg_sandwich_at_picnic(env, env.console, context,
         EGG_SANDWICH.EGG_SANDWICH_TYPE, LANGUAGE);
     if (can_make_sandwich == false){
         throw UserSetupError(env.console, "No sandwich recipe or ingredients. Cannot open and select the sandwich recipe.");

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggFetcher.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggFetcher.cpp
@@ -101,7 +101,7 @@ void EggFetcher::program(SingleSwitchProgramEnvironment& env, BotBaseContext& co
             picnic_at_zero_gate(env.program_info(), env.console, context);
             // Now we are at picnic. We are at one end of picnic table while the egg basket is at the other end
 
-            bool can_make_sandwich = eat_egg_sandwich_at_picnic(env, env.realtime_dispatcher(), env.console, context,
+            bool can_make_sandwich = eat_egg_sandwich_at_picnic(env.program_info(), env.realtime_dispatcher(), env.console, context,
                 EGG_SANDWICH.EGG_SANDWICH_TYPE, LANGUAGE);
             if (can_make_sandwich == false){
                 throw UserSetupError(env.console, "No sandwich recipe or ingredients. Cannot open and select the sandwich recipe.");

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggFetcher.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggFetcher.cpp
@@ -101,7 +101,7 @@ void EggFetcher::program(SingleSwitchProgramEnvironment& env, BotBaseContext& co
             picnic_at_zero_gate(env.program_info(), env.console, context);
             // Now we are at picnic. We are at one end of picnic table while the egg basket is at the other end
 
-            bool can_make_sandwich = eat_egg_sandwich_at_picnic(env.program_info(), env.realtime_dispatcher(), env.console, context,
+            bool can_make_sandwich = eat_egg_sandwich_at_picnic(env, env.realtime_dispatcher(), env.console, context,
                 EGG_SANDWICH.EGG_SANDWICH_TYPE, LANGUAGE);
             if (can_make_sandwich == false){
                 throw UserSetupError(env.console, "No sandwich recipe or ingredients. Cannot open and select the sandwich recipe.");

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggFetcher.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggFetcher.cpp
@@ -101,7 +101,7 @@ void EggFetcher::program(SingleSwitchProgramEnvironment& env, BotBaseContext& co
             picnic_at_zero_gate(env.program_info(), env.console, context);
             // Now we are at picnic. We are at one end of picnic table while the egg basket is at the other end
 
-            bool can_make_sandwich = eat_egg_sandwich_at_picnic(env, env.realtime_dispatcher(), env.console, context,
+            bool can_make_sandwich = eat_egg_sandwich_at_picnic(env, env.console, context,
                 EGG_SANDWICH.EGG_SANDWICH_TYPE, LANGUAGE);
             if (can_make_sandwich == false){
                 throw UserSetupError(env.console, "No sandwich recipe or ingredients. Cannot open and select the sandwich recipe.");

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.cpp
@@ -275,7 +275,7 @@ bool eat_egg_sandwich_at_picnic(SingleSwitchProgramEnvironment& env, AsyncDispat
         std::vector<std::string> fillings_sorted;
         fillings_sorted.push_back("banana");
         int plates = 1;
-        run_sandwich_maker(env, context, language, fillings, fillings_sorted, plates);
+        run_sandwich_maker(env, console, context, language, fillings, fillings_sorted, plates);
         break;
     }
     case EggSandwichType::TWO_SWEET_HERBS:

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.cpp
@@ -253,21 +253,21 @@ void picnic_at_zero_gate(const ProgramInfo& info, ConsoleHandle& console, BotBas
     picnic_from_overworld(info, console, context);
 }
 
-bool eat_egg_sandwich_at_picnic(const ProgramInfo& info, AsyncDispatcher& dispatcher, ConsoleHandle& console, BotBaseContext& context,
+bool eat_egg_sandwich_at_picnic(SingleSwitchProgramEnvironment& env, AsyncDispatcher& dispatcher, ConsoleHandle& console, BotBaseContext& context,
     EggSandwichType sandwich_type, Language language)
 {
     // Move forward to table to make sandwich
     pbf_move_left_joystick(context, 128, 0, 30, 40);
     context.wait_for_all_requests();
 
-    clear_mons_in_front(info, console, context);
-    if (enter_sandwich_recipe_list(info, console, context) == false){
+    clear_mons_in_front(env.program_info(), console, context);
+    if (enter_sandwich_recipe_list(env.program_info(), console, context) == false){
         return false;
     }
     switch (sandwich_type){
     case EggSandwichType::GREAT_PEANUT_BUTTER:
     {
-        if (select_sandwich_recipe(info, console, context, 17) == false){
+        if (select_sandwich_recipe(env.program_info(), console, context, 17) == false){
             // cannot find the sandwich recipe, either user has not unlocked it or does not have enough ingredients:
             return false;
         }
@@ -275,18 +275,18 @@ bool eat_egg_sandwich_at_picnic(const ProgramInfo& info, AsyncDispatcher& dispat
         std::vector<std::string> fillings_sorted;
         fillings_sorted.push_back("banana");
         int plates = 1;
-        run_sandwich_maker(info, dispatcher, console, context, language, fillings, fillings_sorted, plates);
+        run_sandwich_maker(env, context, language, fillings, fillings_sorted, plates);
         break;
     }
     case EggSandwichType::TWO_SWEET_HERBS:
     case EggSandwichType::SALTY_SWEET_HERBS:
     case EggSandwichType::BITTER_SWEET_HERBS:
-        enter_custom_sandwich_mode(info, console, context);
+        enter_custom_sandwich_mode(env.program_info(), console, context);
         if (language == Language::None){
             throw UserSetupError(console.logger(), "Must set game langauge option to read ingredient lists to make herb sandwich.");
         }
-        make_two_herbs_sandwich(info, dispatcher, console, context, sandwich_type, language);
-        finish_sandwich_eating(info, console, context);
+        make_two_herbs_sandwich(env.program_info(), dispatcher, console, context, sandwich_type, language);
+        finish_sandwich_eating(env.program_info(), console, context);
         break;
     default:
         throw InternalProgramError(&console.logger(), PA_CURRENT_FUNCTION, "Unknown EggSandwichType");

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.cpp
@@ -253,7 +253,7 @@ void picnic_at_zero_gate(const ProgramInfo& info, ConsoleHandle& console, BotBas
     picnic_from_overworld(info, console, context);
 }
 
-bool eat_egg_sandwich_at_picnic(SingleSwitchProgramEnvironment& env, AsyncDispatcher& dispatcher, ConsoleHandle& console, BotBaseContext& context,
+bool eat_egg_sandwich_at_picnic(ProgramEnvironment& env, ConsoleHandle& console, BotBaseContext& context,
     EggSandwichType sandwich_type, Language language)
 {
     // Move forward to table to make sandwich
@@ -285,7 +285,7 @@ bool eat_egg_sandwich_at_picnic(SingleSwitchProgramEnvironment& env, AsyncDispat
         if (language == Language::None){
             throw UserSetupError(console.logger(), "Must set game langauge option to read ingredient lists to make herb sandwich.");
         }
-        make_two_herbs_sandwich(env.program_info(), dispatcher, console, context, sandwich_type, language);
+        make_two_herbs_sandwich(env.program_info(), env.realtime_dispatcher(), console, context, sandwich_type, language);
         finish_sandwich_eating(env.program_info(), console, context);
         break;
     default:

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.cpp
@@ -253,21 +253,21 @@ void picnic_at_zero_gate(const ProgramInfo& info, ConsoleHandle& console, BotBas
     picnic_from_overworld(info, console, context);
 }
 
-bool eat_egg_sandwich_at_picnic(SingleSwitchProgramEnvironment& env, AsyncDispatcher& dispatcher, ConsoleHandle& console, BotBaseContext& context,
+bool eat_egg_sandwich_at_picnic(const ProgramInfo& info, AsyncDispatcher& dispatcher, ConsoleHandle& console, BotBaseContext& context,
     EggSandwichType sandwich_type, Language language)
 {
     // Move forward to table to make sandwich
     pbf_move_left_joystick(context, 128, 0, 30, 40);
     context.wait_for_all_requests();
 
-    clear_mons_in_front(env.program_info(), console, context);
-    if (enter_sandwich_recipe_list(env.program_info(), console, context) == false){
+    clear_mons_in_front(info, console, context);
+    if (enter_sandwich_recipe_list(info, console, context) == false){
         return false;
     }
     switch (sandwich_type){
     case EggSandwichType::GREAT_PEANUT_BUTTER:
     {
-        if (select_sandwich_recipe(env.program_info(), console, context, 17) == false){
+        if (select_sandwich_recipe(info, console, context, 17) == false){
             // cannot find the sandwich recipe, either user has not unlocked it or does not have enough ingredients:
             return false;
         }
@@ -275,18 +275,18 @@ bool eat_egg_sandwich_at_picnic(SingleSwitchProgramEnvironment& env, AsyncDispat
         std::vector<std::string> fillings_sorted;
         fillings_sorted.push_back("banana");
         int plates = 1;
-        run_sandwich_maker(env, context, language, fillings, fillings_sorted, plates);
+        run_sandwich_maker(info, dispatcher, console, context, language, fillings, fillings_sorted, plates);
         break;
     }
     case EggSandwichType::TWO_SWEET_HERBS:
     case EggSandwichType::SALTY_SWEET_HERBS:
     case EggSandwichType::BITTER_SWEET_HERBS:
-        enter_custom_sandwich_mode(env.program_info(), console, context);
+        enter_custom_sandwich_mode(info, console, context);
         if (language == Language::None){
             throw UserSetupError(console.logger(), "Must set game langauge option to read ingredient lists to make herb sandwich.");
         }
-        make_two_herbs_sandwich(env.program_info(), dispatcher, console, context, sandwich_type, language);
-        finish_sandwich_eating(env.program_info(), console, context);
+        make_two_herbs_sandwich(info, dispatcher, console, context, sandwich_type, language);
+        finish_sandwich_eating(info, console, context);
         break;
     default:
         throw InternalProgramError(&console.logger(), PA_CURRENT_FUNCTION, "Unknown EggSandwichType");

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.h
@@ -45,7 +45,7 @@ void picnic_at_zero_gate(const ProgramInfo& info, ConsoleHandle& console, BotBas
 // - Two-sweet-herbs, bitter-sweet-herbs or salty-sweet-herbs custom sandwich to gain egg power Lv 3, must have enough ingredinets and
 //   provide game language for OCR ingredient lists.
 // Return false if no needed sandwich ingredients or recipe.
-bool eat_egg_sandwich_at_picnic(SingleSwitchProgramEnvironment& env, AsyncDispatcher& dispatcher, ConsoleHandle& console,
+bool eat_egg_sandwich_at_picnic(ProgramEnvironment& env, ConsoleHandle& console,
     BotBaseContext& context, EggSandwichType sandwich_type, Language language);
 
 // After eating a sandwich, go around picnic table to wait at basket and collect eggs.

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.h
@@ -45,7 +45,7 @@ void picnic_at_zero_gate(const ProgramInfo& info, ConsoleHandle& console, BotBas
 // - Two-sweet-herbs, bitter-sweet-herbs or salty-sweet-herbs custom sandwich to gain egg power Lv 3, must have enough ingredinets and
 //   provide game language for OCR ingredient lists.
 // Return false if no needed sandwich ingredients or recipe.
-bool eat_egg_sandwich_at_picnic(SingleSwitchProgramEnvironment& env, AsyncDispatcher& dispatcher, ConsoleHandle& console,
+bool eat_egg_sandwich_at_picnic(const ProgramInfo& info, AsyncDispatcher& dispatcher, ConsoleHandle& console,
     BotBaseContext& context, EggSandwichType sandwich_type, Language language);
 
 // After eating a sandwich, go around picnic table to wait at basket and collect eggs.

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.h
@@ -45,7 +45,7 @@ void picnic_at_zero_gate(const ProgramInfo& info, ConsoleHandle& console, BotBas
 // - Two-sweet-herbs, bitter-sweet-herbs or salty-sweet-herbs custom sandwich to gain egg power Lv 3, must have enough ingredinets and
 //   provide game language for OCR ingredient lists.
 // Return false if no needed sandwich ingredients or recipe.
-bool eat_egg_sandwich_at_picnic(const ProgramInfo& info, AsyncDispatcher& dispatcher, ConsoleHandle& console,
+bool eat_egg_sandwich_at_picnic(SingleSwitchProgramEnvironment& env, AsyncDispatcher& dispatcher, ConsoleHandle& console,
     BotBaseContext& context, EggSandwichType sandwich_type, Language language);
 
 // After eating a sandwich, go around picnic table to wait at basket and collect eggs.

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichMaker.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichMaker.cpp
@@ -53,7 +53,7 @@ SandwichMaker::SandwichMaker()
 void SandwichMaker::program(SingleSwitchProgramEnvironment& env, BotBaseContext& context) {
     assert_16_9_720p_min(env.logger(), env.console);
 
-    run_sandwich_maker(env, context, SANDWICH_OPTIONS);
+    make_sandwich_option(env, context, SANDWICH_OPTIONS);
 
     GO_HOME_WHEN_DONE.run_end_of_program(context);
     send_program_finished_notification(env, NOTIFICATION_PROGRAM_FINISH);

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichMaker.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichMaker.cpp
@@ -53,7 +53,7 @@ SandwichMaker::SandwichMaker()
 void SandwichMaker::program(SingleSwitchProgramEnvironment& env, BotBaseContext& context) {
     assert_16_9_720p_min(env.logger(), env.console);
 
-    make_sandwich_option(env, context, SANDWICH_OPTIONS);
+    make_sandwich_option(env.program_info(), env.realtime_dispatcher(), env.console, context, SANDWICH_OPTIONS);
 
     GO_HOME_WHEN_DONE.run_end_of_program(context);
     send_program_finished_notification(env, NOTIFICATION_PROGRAM_FINISH);

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichMaker.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichMaker.cpp
@@ -53,7 +53,7 @@ SandwichMaker::SandwichMaker()
 void SandwichMaker::program(SingleSwitchProgramEnvironment& env, BotBaseContext& context) {
     assert_16_9_720p_min(env.logger(), env.console);
 
-    make_sandwich_option(env.program_info(), env.realtime_dispatcher(), env.console, context, SANDWICH_OPTIONS);
+    make_sandwich_option(env, context, SANDWICH_OPTIONS);
 
     GO_HOME_WHEN_DONE.run_end_of_program(context);
     send_program_finished_notification(env, NOTIFICATION_PROGRAM_FINISH);

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichMaker.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichMaker.cpp
@@ -53,7 +53,7 @@ SandwichMaker::SandwichMaker()
 void SandwichMaker::program(SingleSwitchProgramEnvironment& env, BotBaseContext& context) {
     assert_16_9_720p_min(env.logger(), env.console);
 
-    make_sandwich_option(env, context, SANDWICH_OPTIONS);
+    make_sandwich_option(env, env.console, context, SANDWICH_OPTIONS);
 
     GO_HOME_WHEN_DONE.run_end_of_program(context);
     send_program_finished_notification(env, NOTIFICATION_PROGRAM_FINISH);

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
@@ -636,10 +636,10 @@ void make_two_herbs_sandwich(
     finish_two_herbs_sandwich(info, dispatcher, console, context);
 }
 
-void make_sandwich_option(SingleSwitchProgramEnvironment& env, BotBaseContext& context, SandwichMakerOption& SANDWICH_OPTIONS) {
+void make_sandwich_option(const ProgramInfo& info, AsyncDispatcher& dispatcher, ConsoleHandle& console, BotBaseContext& context, SandwichMakerOption& SANDWICH_OPTIONS) {
     const Language language = SANDWICH_OPTIONS.LANGUAGE;
     if (language == Language::None) {
-        throw UserSetupError(env.console.logger(), "Must set game langauge option to read ingredient lists.");
+        throw UserSetupError(console.logger(), "Must set game langauge option to read ingredient lists.");
     }
 
     int num_fillings = 0;
@@ -649,8 +649,8 @@ void make_sandwich_option(SingleSwitchProgramEnvironment& env, BotBaseContext& c
 
     //Add the selected ingredients to the maps if set to custom
     if (SANDWICH_OPTIONS.BASE_RECIPE == BaseRecipe::custom) {
-        env.log("Custom sandwich selected. Validating ingredients.", COLOR_BLACK);
-        env.console.overlay().add_log("Custom sandwich selected.");
+        console.log("Custom sandwich selected. Validating ingredients.", COLOR_BLACK);
+        console.overlay().add_log("Custom sandwich selected.");
 
         std::vector<std::unique_ptr<SandwichIngredientsTableRow>> table = SANDWICH_OPTIONS.SANDWICH_INGREDIENTS.copy_snapshot();
 
@@ -667,25 +667,25 @@ void make_sandwich_option(SingleSwitchProgramEnvironment& env, BotBaseContext& c
                 }
             }
             else {
-                env.log("Skipping baguette as it is unobtainable.");
-                env.console.overlay().add_log("Skipping baguette as it is unobtainable.", COLOR_WHITE);
+                console.log("Skipping baguette as it is unobtainable.");
+                console.overlay().add_log("Skipping baguette as it is unobtainable.", COLOR_WHITE);
             }
         }
 
         if (num_fillings == 0 || num_condiments == 0) {
-            throw UserSetupError(env.console.logger(), "Must have at least one filling and at least one condiment.");
+            throw UserSetupError(console.logger(), "Must have at least one filling and at least one condiment.");
         }
 
         if (num_fillings > 6 || num_condiments > 4) {
-            throw UserSetupError(env.console.logger(), "Number of fillings exceed 6 and/or number of condiments exceed 4.");
+            throw UserSetupError(console.logger(), "Number of fillings exceed 6 and/or number of condiments exceed 4.");
         }
-        env.log("Ingredients validated.", COLOR_BLACK);
-        env.console.overlay().add_log("Ingredients validated.", COLOR_WHITE);
+        console.log("Ingredients validated.", COLOR_BLACK);
+        console.overlay().add_log("Ingredients validated.", COLOR_WHITE);
     }
     //Otherwise get the preset ingredients
     else {
-        env.log("Preset sandwich selected.", COLOR_BLACK);
-        env.console.overlay().add_log("Preset sandwich selected.");
+        console.log("Preset sandwich selected.", COLOR_BLACK);
+        console.overlay().add_log("Preset sandwich selected.");
 
         std::vector<std::string> table = SANDWICH_OPTIONS.get_premade_ingredients(
             SANDWICH_OPTIONS.get_premade_sandwich_recipe(SANDWICH_OPTIONS.BASE_RECIPE, SANDWICH_OPTIONS.TYPE, SANDWICH_OPTIONS.PARADOX));
@@ -726,10 +726,10 @@ void make_sandwich_option(SingleSwitchProgramEnvironment& env, BotBaseContext& c
     }
     */
 
-    make_sandwich_preset(env, context, SANDWICH_OPTIONS.LANGUAGE, fillings, condiments);
+    make_sandwich_preset(info, dispatcher, console, context, SANDWICH_OPTIONS.LANGUAGE, fillings, condiments);
 }
 
-void make_sandwich_preset(SingleSwitchProgramEnvironment& env, BotBaseContext& context, Language language, std::map<std::string, uint8_t>& fillings, std::map<std::string, uint8_t>& condiments) {
+void make_sandwich_preset(const ProgramInfo& info, AsyncDispatcher& dispatcher, ConsoleHandle& console, BotBaseContext& context, Language language, std::map<std::string, uint8_t>& fillings, std::map<std::string, uint8_t>& condiments) {
     //Sort the fillings by priority for building (ex. large items on bottom, cherry tomatoes on top)
     //std::vector<std::string> fillings_game_order = {"lettuce", "tomato", "cherry-tomatoes", "cucumber", "pickle", "onion", "red-onion", "green-bell-pepper", "red-bell-pepper",
     //    "yellow-bell-pepper", "avocado", "bacon", "ham", "prosciutto", "chorizo", "herbed-sausage", "hamburger", "klawf-stick", "smoked-fillet", "fried-fillet", "egg", "potato-tortilla",
@@ -787,46 +787,46 @@ void make_sandwich_preset(SingleSwitchProgramEnvironment& env, BotBaseContext& c
     }
     //cout << "Number of plates: " << plates << endl;
     int plates_string = plates;
-    env.log("Number of plates: " + std::to_string(plates_string), COLOR_BLACK);
-    env.console.overlay().add_log("Number of plates: " + std::to_string(plates_string), COLOR_WHITE);
+    console.log("Number of plates: " + std::to_string(plates_string), COLOR_BLACK);
+    console.overlay().add_log("Number of plates: " + std::to_string(plates_string), COLOR_WHITE);
     for (const auto& filling: fillings){
-        env.log("Require filling " + filling.first + " x" + std::to_string(int(filling.second)));
+        console.log("Require filling " + filling.first + " x" + std::to_string(int(filling.second)));
     }
     for (const auto& condiment: condiments){
-        env.log("Require condiment " + condiment.first + " x" + std::to_string(int(condiment.second)));
+        console.log("Require condiment " + condiment.first + " x" + std::to_string(int(condiment.second)));
     }
 
     //Player must be on default sandwich menu
     std::map<std::string, uint8_t> fillings_copy(fillings); //Making a copy as we need the map for later
-    enter_custom_sandwich_mode(env.program_info(), env.console, context);
-    add_sandwich_ingredients(env.realtime_dispatcher(), env.console, context, language,
+    enter_custom_sandwich_mode(info, console, context);
+    add_sandwich_ingredients(dispatcher, console, context, language,
         std::move(fillings_copy), std::move(condiments));
 
-    run_sandwich_maker(env, context, language, fillings, fillings_sorted, plates);
+    run_sandwich_maker(info, dispatcher, console, context, language, fillings, fillings_sorted, plates);
 }
 
-void run_sandwich_maker(SingleSwitchProgramEnvironment& env, BotBaseContext& context, Language language, std::map<std::string, uint8_t>& fillings, std::vector<std::string>& fillings_sorted, int& plates) {
+void run_sandwich_maker(const ProgramInfo& info, AsyncDispatcher& dispatcher, ConsoleHandle& console, BotBaseContext& context, Language language, std::map<std::string, uint8_t>& fillings, std::vector<std::string>& fillings_sorted, int& plates) {
 
-    wait_for_initial_hand(env.program_info(), env.console, context);
+    wait_for_initial_hand(info, console, context);
 
     //Wait for labels to appear
-    env.log("Waiting for labels to appear.", COLOR_BLACK);
-    env.console.overlay().add_log("Waiting for labels to appear.", COLOR_WHITE);
+    console.log("Waiting for labels to appear.", COLOR_BLACK);
+    console.overlay().add_log("Waiting for labels to appear.", COLOR_WHITE);
     pbf_wait(context, 300);
     context.wait_for_all_requests();
 
     //Now read in plate labels and store which plate has what
-    env.log("Reading plate labels.", COLOR_BLACK);
-    env.console.overlay().add_log("Reading plate labels.", COLOR_WHITE);
+    console.log("Reading plate labels.", COLOR_BLACK);
+    console.overlay().add_log("Reading plate labels.", COLOR_WHITE);
 
     std::vector<std::string> plate_order;
 
-    SandwichPlateDetector left_plate_detector(env.console.logger(), COLOR_RED, language, SandwichPlateDetector::Side::LEFT);
-    SandwichPlateDetector middle_plate_detector(env.console.logger(), COLOR_RED, language, SandwichPlateDetector::Side::MIDDLE);
-    SandwichPlateDetector right_plate_detector(env.console.logger(), COLOR_RED, language, SandwichPlateDetector::Side::RIGHT);
+    SandwichPlateDetector left_plate_detector(console.logger(), COLOR_RED, language, SandwichPlateDetector::Side::LEFT);
+    SandwichPlateDetector middle_plate_detector(console.logger(), COLOR_RED, language, SandwichPlateDetector::Side::MIDDLE);
+    SandwichPlateDetector right_plate_detector(console.logger(), COLOR_RED, language, SandwichPlateDetector::Side::RIGHT);
 
     {
-        VideoSnapshot screen = env.console.video().snapshot();
+        VideoSnapshot screen = console.video().snapshot();
 
         const int max_read_label_tries = 4;
         for(int read_label_try_count = 0; read_label_try_count < max_read_label_tries; ++read_label_try_count){
@@ -838,14 +838,14 @@ void run_sandwich_maker(SingleSwitchProgramEnvironment& env, BotBaseContext& con
                     context.wait_for_all_requests();
                     continue;
                 } else{
-                    env.console.log("Read nothing on center plate label.");
+                    console.log("Read nothing on center plate label.");
                     throw OperationFailedException(
-                        ErrorReport::SEND_ERROR_REPORT, env.console, "No ingredient found on center plate label.", true
+                        ErrorReport::SEND_ERROR_REPORT, console, "No ingredient found on center plate label.", true
                     );
                 }
             }
-            env.console.log("Read center plate label: " + center_filling);
-            env.console.overlay().add_log("Center plate: " + center_filling);
+            console.log("Read center plate label: " + center_filling);
+            console.overlay().add_log("Center plate: " + center_filling);
             plate_order.push_back(center_filling);
             break;
         }
@@ -853,24 +853,24 @@ void run_sandwich_maker(SingleSwitchProgramEnvironment& env, BotBaseContext& con
         //Get left (2nd) ingredient
         std::string left_filling = left_plate_detector.detect_filling_name(screen);
         if (left_filling.empty()) {
-            env.log("No ingredient found on left label.");
-            env.console.overlay().add_log("No left plate");
+            console.log("No ingredient found on left label.");
+            console.overlay().add_log("No left plate");
         }
         else{
-            env.console.log("Read left plate label: " + left_filling);
-            env.console.overlay().add_log("Left plate: " + left_filling);
+            console.log("Read left plate label: " + left_filling);
+            console.overlay().add_log("Left plate: " + left_filling);
             plate_order.push_back(left_filling);
         }
 
         //Get right (3rd) ingredient
         std::string right_filling = right_plate_detector.detect_filling_name(screen);
         if (right_filling.empty()) {
-            env.log("No ingredient found on right label.");
-            env.console.overlay().add_log("No right plate");
+            console.log("No ingredient found on right label.");
+            console.overlay().add_log("No right plate");
         }
         else{
-            env.console.log("Read right plate label: " + right_filling);
-            env.console.overlay().add_log("Right plate: " + right_filling);
+            console.log("Read right plate label: " + right_filling);
+            console.overlay().add_log("Right plate: " + right_filling);
             plate_order.push_back(right_filling);
         }
 
@@ -882,31 +882,31 @@ void run_sandwich_maker(SingleSwitchProgramEnvironment& env, BotBaseContext& con
             pbf_press_button(context, BUTTON_R, 20, 180);
             context.wait_for_all_requests();
 
-            screen = env.console.video().snapshot();
+            screen = console.video().snapshot();
             left_filling = left_plate_detector.detect_filling_name(screen);
 
             if (left_filling.empty()) {
                 throw OperationFailedException(
-                    ErrorReport::SEND_ERROR_REPORT, env.console, "No ingredient label found on remaining plate " + std::to_string(i) + ".", true
+                    ErrorReport::SEND_ERROR_REPORT, console, "No ingredient label found on remaining plate " + std::to_string(i) + ".", true
                 );
             }
-            env.console.log("Read remaining plate " + std::to_string(i) + " label: " + left_filling);
-            env.console.overlay().add_log("Remaining plate " + std::to_string(i) + ": " + left_filling);
+            console.log("Read remaining plate " + std::to_string(i) + " label: " + left_filling);
+            console.overlay().add_log("Remaining plate " + std::to_string(i) + ": " + left_filling);
             plate_order.push_back(left_filling);
         }
 
         //Now re-center plates
-        env.log("Re-centering plates if needed.");
-        env.console.overlay().add_log("Re-centering plates if needed.");
+        console.log("Re-centering plates if needed.");
+        console.overlay().add_log("Re-centering plates if needed.");
         for (int i = 0; i < (plates - 3); i++) {
             pbf_press_button(context, BUTTON_L, 20, 80);
         }
 
         //If a label fails to read it'll cause issues down the line
         if ((int)plate_order.size() != plates) {
-            env.log("Found # plate labels " + std::to_string(plate_order.size()) + ", not same as desired # plates " + std::to_string(plates));
+            console.log("Found # plate labels " + std::to_string(plate_order.size()) + ", not same as desired # plates " + std::to_string(plates));
             throw OperationFailedException(
-                ErrorReport::SEND_ERROR_REPORT, env.console,
+                ErrorReport::SEND_ERROR_REPORT, console,
                 "Number of plate labels did not match number of plates.",
                 true
             );
@@ -914,8 +914,8 @@ void run_sandwich_maker(SingleSwitchProgramEnvironment& env, BotBaseContext& con
     }
 
     //Finally.
-    env.log("Start making sandwich", COLOR_BLACK);
-    env.console.overlay().add_log("Start making sandwich.", COLOR_WHITE);
+    console.log("Start making sandwich", COLOR_BLACK);
+    console.overlay().add_log("Start making sandwich.", COLOR_WHITE);
 
     const ImageFloatBox center_plate{ 0.455, 0.130, 0.090, 0.030 };
     const ImageFloatBox left_plate{ 0.190, 0.136, 0.096, 0.031 };
@@ -923,20 +923,20 @@ void run_sandwich_maker(SingleSwitchProgramEnvironment& env, BotBaseContext& con
 
     ImageFloatBox target_plate = center_plate;
     //Initial position handling
-    auto end_box = move_sandwich_hand(env.program_info(), env.realtime_dispatcher(), env.console, context, SandwichHandType::FREE, false, HAND_INITIAL_BOX, HAND_INITIAL_BOX);
-    move_sandwich_hand(env.program_info(), env.realtime_dispatcher(), env.console, context, SandwichHandType::GRABBING, true, { 0, 0, 1.0, 1.0 }, HAND_INITIAL_BOX);
+    auto end_box = move_sandwich_hand(info, dispatcher, console, context, SandwichHandType::FREE, false, HAND_INITIAL_BOX, HAND_INITIAL_BOX);
+    move_sandwich_hand(info, dispatcher, console, context, SandwichHandType::GRABBING, true, { 0, 0, 1.0, 1.0 }, HAND_INITIAL_BOX);
     context.wait_for_all_requests();
 
     //Find fillings and add them in order
     for (const std::string& i : fillings_sorted) {
         //cout << "Placing " << i << endl;
-        env.console.overlay().add_log("Placing " + i, COLOR_WHITE);
+        console.overlay().add_log("Placing " + i, COLOR_WHITE);
 
         int times_to_place = (int)(FillingsCoordinates::instance().get_filling_information(i).piecesPerServing) * (fillings.find(i)->second);
         int placement_number = 0;
 
         //cout << "Times to place: " << times_to_place << endl;
-        env.console.overlay().add_log("Times to place: " + std::to_string(times_to_place), COLOR_WHITE);
+        console.overlay().add_log("Times to place: " + std::to_string(times_to_place), COLOR_WHITE);
 
         std::vector<int> plate_index;
         //Get the plates we want to go to
@@ -950,7 +950,7 @@ void run_sandwich_maker(SingleSwitchProgramEnvironment& env, BotBaseContext& con
         for (int j = 0; j < (int)plate_index.size(); j++) {
             //Navigate to plate and set target plate
             //cout << "Target plate: " << plate_index.at(j) << endl;
-            env.console.overlay().add_log("Target plate: " + std::to_string(plate_index.at(j)), COLOR_WHITE);
+            console.overlay().add_log("Target plate: " + std::to_string(plate_index.at(j)), COLOR_WHITE);
             switch (plate_index.at(j)) {
             case 0:
                 target_plate = center_plate;
@@ -979,7 +979,7 @@ void run_sandwich_maker(SingleSwitchProgramEnvironment& env, BotBaseContext& con
                     break;
                 }
 
-                end_box = move_sandwich_hand(env.program_info(), env.realtime_dispatcher(), env.console, context, SandwichHandType::FREE,
+                end_box = move_sandwich_hand(info, dispatcher, console, context, SandwichHandType::FREE,
                     false, { 0, 0, 1.0, 1.0 }, target_plate);
                 context.wait_for_all_requests();
 
@@ -987,12 +987,12 @@ void run_sandwich_maker(SingleSwitchProgramEnvironment& env, BotBaseContext& con
                 ImageFloatBox placement_target = FillingsCoordinates::instance().get_filling_information(i).placementCoordinates.at(
                     (int)fillings.find(i)->second).at(placement_number);
 
-                end_box = move_sandwich_hand(env.program_info(), env.realtime_dispatcher(), env.console, context, SandwichHandType::GRABBING,
+                end_box = move_sandwich_hand(info, dispatcher, console, context, SandwichHandType::GRABBING,
                     true, expand_box(end_box), placement_target);
                 context.wait_for_all_requests();
 
                 //If any of the labels are yellow continue. Otherwise assume plate is empty move on to the next.
-                auto screen = env.console.video().snapshot();
+                auto screen = console.video().snapshot();
 
                 //The label check is needed for ingredients with multiple plates as we don't know which plate has what amount
                 if (!left_plate_detector.is_label_yellow(screen) && !middle_plate_detector.is_label_yellow(screen)
@@ -1013,10 +1013,10 @@ void run_sandwich_maker(SingleSwitchProgramEnvironment& env, BotBaseContext& con
     }
     // Handle top slice by tossing it away
     SandwichHandWatcher grabbing_hand(SandwichHandType::FREE, { 0, 0, 1.0, 1.0 });
-    int ret = wait_until(env.console, context, std::chrono::seconds(30), { grabbing_hand });
+    int ret = wait_until(console, context, std::chrono::seconds(30), { grabbing_hand });
     if (ret < 0) {
         throw OperationFailedException(
-            ErrorReport::SEND_ERROR_REPORT, env.console,
+            ErrorReport::SEND_ERROR_REPORT, console,
             "SandwichMaker: Cannot detect grabing hand when waiting for upper bread.",
             grabbing_hand.last_snapshot()
         );
@@ -1024,16 +1024,16 @@ void run_sandwich_maker(SingleSwitchProgramEnvironment& env, BotBaseContext& con
 
     auto hand_box = hand_location_to_box(grabbing_hand.location());
 
-    end_box = move_sandwich_hand(env.program_info(), env.realtime_dispatcher(), env.console, context, SandwichHandType::GRABBING, false, expand_box(hand_box), center_plate);
+    end_box = move_sandwich_hand(info, dispatcher, console, context, SandwichHandType::GRABBING, false, expand_box(hand_box), center_plate);
     pbf_mash_button(context, BUTTON_A, 125 * 5);
 
-    env.log("Hand end box " + box_to_string(end_box));
-    env.log("Built sandwich", COLOR_BLACK);
+    console.log("Hand end box " + box_to_string(end_box));
+    console.log("Built sandwich", COLOR_BLACK);
     // env.console.overlay().add_log("Hand end box " + box_to_string(end_box), COLOR_WHITE);
-    env.console.overlay().add_log("Built sandwich.", COLOR_WHITE);
+    console.overlay().add_log("Built sandwich.", COLOR_WHITE);
     context.wait_for_all_requests();
 
-    finish_sandwich_eating(env.program_info(), env.console, context);
+    finish_sandwich_eating(info, console, context);
 }
 
 }

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.h
@@ -75,19 +75,19 @@ void make_two_herbs_sandwich(
 
 // Assuming starting at the sandwich recipe list,
 // Process sandwich options and make a custom sandwich by calling make_sandwich_preset
-void make_sandwich_option(SingleSwitchProgramEnvironment& env, BotBaseContext& context, SandwichMakerOption& SANDWICH_OPTIONS);
+void make_sandwich_option(ProgramEnvironment& env, ConsoleHandle& console, BotBaseContext& context, SandwichMakerOption& SANDWICH_OPTIONS);
 
 // Assuming starting at the sandwich recipe list, make a sandwich given a preset ingredient/filling list
 // calls run_sandwich_maker() when done
 // ex. fillings = {{"apple", (uint8_t)1}}; condiments = {{"marmalade", (uint8_t)1}};
 // make_sandwich_preset(env, context, language, fillings, condiments);
-void make_sandwich_preset(SingleSwitchProgramEnvironment& env, BotBaseContext& context, Language language, std::map<std::string, uint8_t>& fillings, std::map<std::string, uint8_t>& condiments);
+void make_sandwich_preset(ProgramEnvironment& env, ConsoleHandle& console, BotBaseContext& context, Language language, std::map<std::string, uint8_t>& fillings, std::map<std::string, uint8_t>& condiments);
 
 // Assuming starting waiting for sandwich hand,
 // Take a list of ingredients and make a sandwich
 // Not meant to be run directly, use make_sandwich_option() or make_sandwich_preset() instead
 // make great pb sandwich does call this directly, as it skips the custom sandwich menu
-void run_sandwich_maker(SingleSwitchProgramEnvironment& env, BotBaseContext& context, Language language, std::map<std::string, uint8_t>& fillings, std::vector<std::string>& fillings_sorted, int& plates);
+void run_sandwich_maker(ProgramEnvironment& env, ConsoleHandle& console, BotBaseContext& context, Language language, std::map<std::string, uint8_t>& fillings, std::vector<std::string>& fillings_sorted, int& plates);
 
 
 }

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.h
@@ -40,10 +40,6 @@ bool enter_sandwich_recipe_list(const ProgramInfo& info, ConsoleHandle& console,
 // the recipe cell is semi-transparent, failed to be detected.
 bool select_sandwich_recipe(const ProgramInfo& info, ConsoleHandle& console, BotBaseContext& context, size_t sandwich_index);
 
-// Starting at the sandwich minigame of dropping ingredients, assume the selected recipe is Great Peanut Butter Sandwich,
-// make the sandwich.
-void build_great_peanut_butter_sandwich(const ProgramInfo& info, AsyncDispatcher& dispatcher, ConsoleHandle& console, BotBaseContext& context);
-
 // Assuming sandwich is made, press A repeatedly to finish eating animation until returning to picnic
 void finish_sandwich_eating(const ProgramInfo& info, ConsoleHandle& console, BotBaseContext& context);
 
@@ -78,8 +74,21 @@ void make_two_herbs_sandwich(
 );
 
 // Assuming starting at the sandwich recipe list,
-// Make a custom sandwich as set in the sandwich maker options
-void run_sandwich_maker(SingleSwitchProgramEnvironment& env, BotBaseContext& context, SandwichMakerOption& SANDWICH_OPTIONS);
+// Process sandwich options and make a custom sandwich by calling make_sandwich_preset
+void make_sandwich_option(SingleSwitchProgramEnvironment& env, BotBaseContext& context, SandwichMakerOption& SANDWICH_OPTIONS);
+
+// Assuming starting at the sandwich recipe list, make a sandwich given a preset ingredient/filling list
+// calls run_sandwich_maker() when done
+// ex. fillings = {{"apple", (uint8_t)1}}; condiments = {{"marmalade", (uint8_t)1}};
+// make_sandwich_preset(env, context, language, fillings, condiments);
+void make_sandwich_preset(SingleSwitchProgramEnvironment& env, BotBaseContext& context, Language language, std::map<std::string, uint8_t>& fillings, std::map<std::string, uint8_t>& condiments);
+
+// Assuming starting waiting for sandwich hand,
+// Take a list of ingredients and make a sandwich
+// Not meant to be run directly, use make_sandwich_option() or make_sandwich_preset() instead
+// make great pb sandwich does call this directly, as it skips the custom sandwich menu
+void run_sandwich_maker(SingleSwitchProgramEnvironment& env, BotBaseContext& context, Language language, std::map<std::string, uint8_t>& fillings, std::vector<std::string>& fillings_sorted, int& plates);
+
 
 }
 }

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.h
@@ -75,19 +75,19 @@ void make_two_herbs_sandwich(
 
 // Assuming starting at the sandwich recipe list,
 // Process sandwich options and make a custom sandwich by calling make_sandwich_preset
-void make_sandwich_option(const ProgramInfo& info, AsyncDispatcher& dispatcher, ConsoleHandle& console, BotBaseContext& context, SandwichMakerOption& SANDWICH_OPTIONS);
+void make_sandwich_option(SingleSwitchProgramEnvironment& env, BotBaseContext& context, SandwichMakerOption& SANDWICH_OPTIONS);
 
 // Assuming starting at the sandwich recipe list, make a sandwich given a preset ingredient/filling list
 // calls run_sandwich_maker() when done
 // ex. fillings = {{"apple", (uint8_t)1}}; condiments = {{"marmalade", (uint8_t)1}};
 // make_sandwich_preset(env, context, language, fillings, condiments);
-void make_sandwich_preset(const ProgramInfo& info, AsyncDispatcher& dispatcher, ConsoleHandle& console, BotBaseContext& context, Language language, std::map<std::string, uint8_t>& fillings, std::map<std::string, uint8_t>& condiments);
+void make_sandwich_preset(SingleSwitchProgramEnvironment& env, BotBaseContext& context, Language language, std::map<std::string, uint8_t>& fillings, std::map<std::string, uint8_t>& condiments);
 
 // Assuming starting waiting for sandwich hand,
 // Take a list of ingredients and make a sandwich
 // Not meant to be run directly, use make_sandwich_option() or make_sandwich_preset() instead
 // make great pb sandwich does call this directly, as it skips the custom sandwich menu
-void run_sandwich_maker(const ProgramInfo& info, AsyncDispatcher& dispatcher, ConsoleHandle& console, BotBaseContext& context, Language language, std::map<std::string, uint8_t>& fillings, std::vector<std::string>& fillings_sorted, int& plates);
+void run_sandwich_maker(SingleSwitchProgramEnvironment& env, BotBaseContext& context, Language language, std::map<std::string, uint8_t>& fillings, std::vector<std::string>& fillings_sorted, int& plates);
 
 
 }

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.h
@@ -75,19 +75,19 @@ void make_two_herbs_sandwich(
 
 // Assuming starting at the sandwich recipe list,
 // Process sandwich options and make a custom sandwich by calling make_sandwich_preset
-void make_sandwich_option(SingleSwitchProgramEnvironment& env, BotBaseContext& context, SandwichMakerOption& SANDWICH_OPTIONS);
+void make_sandwich_option(const ProgramInfo& info, AsyncDispatcher& dispatcher, ConsoleHandle& console, BotBaseContext& context, SandwichMakerOption& SANDWICH_OPTIONS);
 
 // Assuming starting at the sandwich recipe list, make a sandwich given a preset ingredient/filling list
 // calls run_sandwich_maker() when done
 // ex. fillings = {{"apple", (uint8_t)1}}; condiments = {{"marmalade", (uint8_t)1}};
 // make_sandwich_preset(env, context, language, fillings, condiments);
-void make_sandwich_preset(SingleSwitchProgramEnvironment& env, BotBaseContext& context, Language language, std::map<std::string, uint8_t>& fillings, std::map<std::string, uint8_t>& condiments);
+void make_sandwich_preset(const ProgramInfo& info, AsyncDispatcher& dispatcher, ConsoleHandle& console, BotBaseContext& context, Language language, std::map<std::string, uint8_t>& fillings, std::map<std::string, uint8_t>& condiments);
 
 // Assuming starting waiting for sandwich hand,
 // Take a list of ingredients and make a sandwich
 // Not meant to be run directly, use make_sandwich_option() or make_sandwich_preset() instead
 // make great pb sandwich does call this directly, as it skips the custom sandwich menu
-void run_sandwich_maker(SingleSwitchProgramEnvironment& env, BotBaseContext& context, Language language, std::map<std::string, uint8_t>& fillings, std::vector<std::string>& fillings_sorted, int& plates);
+void run_sandwich_maker(const ProgramInfo& info, AsyncDispatcher& dispatcher, ConsoleHandle& console, BotBaseContext& context, Language language, std::map<std::string, uint8_t>& fillings, std::vector<std::string>& fillings_sorted, int& plates);
 
 
 }

--- a/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-AreaZeroPlatform.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-AreaZeroPlatform.cpp
@@ -371,7 +371,7 @@ void ShinyHuntAreaZeroPlatform::run_state(SingleSwitchProgramEnvironment& env, B
         picnic_at_zero_gate(info, console, context);
         pbf_move_left_joystick(context, 128, 0, 70, 0);
         enter_sandwich_recipe_list(info, console, context);
-        make_sandwich_option(env, context, SANDWICH_OPTIONS);
+        make_sandwich_option(env, console, context, SANDWICH_OPTIONS);
 
         console.log("Sandwich Reset: Starting new sandwich timer...");
         m_last_sandwich = current_time();

--- a/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-AreaZeroPlatform.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-AreaZeroPlatform.cpp
@@ -371,7 +371,7 @@ void ShinyHuntAreaZeroPlatform::run_state(SingleSwitchProgramEnvironment& env, B
         picnic_at_zero_gate(info, console, context);
         pbf_move_left_joystick(context, 128, 0, 70, 0);
         enter_sandwich_recipe_list(info, console, context);
-        make_sandwich_option(info, env.realtime_dispatcher(), env.console, context, SANDWICH_OPTIONS);
+        make_sandwich_option(env, context, SANDWICH_OPTIONS);
 
         console.log("Sandwich Reset: Starting new sandwich timer...");
         m_last_sandwich = current_time();

--- a/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-AreaZeroPlatform.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-AreaZeroPlatform.cpp
@@ -371,7 +371,7 @@ void ShinyHuntAreaZeroPlatform::run_state(SingleSwitchProgramEnvironment& env, B
         picnic_at_zero_gate(info, console, context);
         pbf_move_left_joystick(context, 128, 0, 70, 0);
         enter_sandwich_recipe_list(info, console, context);
-        make_sandwich_option(env, context, SANDWICH_OPTIONS);
+        make_sandwich_option(info, env.realtime_dispatcher(), env.console, context, SANDWICH_OPTIONS);
 
         console.log("Sandwich Reset: Starting new sandwich timer...");
         m_last_sandwich = current_time();

--- a/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-AreaZeroPlatform.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-AreaZeroPlatform.cpp
@@ -371,7 +371,7 @@ void ShinyHuntAreaZeroPlatform::run_state(SingleSwitchProgramEnvironment& env, B
         picnic_at_zero_gate(info, console, context);
         pbf_move_left_joystick(context, 128, 0, 70, 0);
         enter_sandwich_recipe_list(info, console, context);
-        run_sandwich_maker(env, context, SANDWICH_OPTIONS);
+        make_sandwich_option(env, context, SANDWICH_OPTIONS);
 
         console.log("Sandwich Reset: Starting new sandwich timer...");
         m_last_sandwich = current_time();

--- a/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-Scatterbug.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-Scatterbug.cpp
@@ -307,7 +307,7 @@ void ShinyHuntScatterbug::run_one_sandwich_iteration(SingleSwitchProgramEnvironm
 
                 pbf_move_left_joystick(context, 128, 0, 30, 40);
                 enter_sandwich_recipe_list(env.program_info(), env.console, context);
-                make_sandwich_option(env, context, SANDWICH_OPTIONS);
+                make_sandwich_option(env.program_info(), env.realtime_dispatcher(), env.console, context, SANDWICH_OPTIONS);
                 last_sandwich_time = current_time();
                 leave_picnic(env.program_info(), env.console, context);
             } else {

--- a/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-Scatterbug.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-Scatterbug.cpp
@@ -307,7 +307,7 @@ void ShinyHuntScatterbug::run_one_sandwich_iteration(SingleSwitchProgramEnvironm
 
                 pbf_move_left_joystick(context, 128, 0, 30, 40);
                 enter_sandwich_recipe_list(env.program_info(), env.console, context);
-                make_sandwich_option(env.program_info(), env.realtime_dispatcher(), env.console, context, SANDWICH_OPTIONS);
+                make_sandwich_option(env, context, SANDWICH_OPTIONS);
                 last_sandwich_time = current_time();
                 leave_picnic(env.program_info(), env.console, context);
             } else {

--- a/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-Scatterbug.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-Scatterbug.cpp
@@ -307,7 +307,7 @@ void ShinyHuntScatterbug::run_one_sandwich_iteration(SingleSwitchProgramEnvironm
 
                 pbf_move_left_joystick(context, 128, 0, 30, 40);
                 enter_sandwich_recipe_list(env.program_info(), env.console, context);
-                run_sandwich_maker(env, context, SANDWICH_OPTIONS);
+                make_sandwich_option(env, context, SANDWICH_OPTIONS);
                 last_sandwich_time = current_time();
                 leave_picnic(env.program_info(), env.console, context);
             } else {

--- a/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-Scatterbug.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-Scatterbug.cpp
@@ -307,7 +307,7 @@ void ShinyHuntScatterbug::run_one_sandwich_iteration(SingleSwitchProgramEnvironm
 
                 pbf_move_left_joystick(context, 128, 0, 30, 40);
                 enter_sandwich_recipe_list(env.program_info(), env.console, context);
-                make_sandwich_option(env, context, SANDWICH_OPTIONS);
+                make_sandwich_option(env, env.console, context, SANDWICH_OPTIONS);
                 last_sandwich_time = current_time();
                 leave_picnic(env.program_info(), env.console, context);
             } else {


### PR DESCRIPTION
The old run_sandwich_maker() is replaced with make_sandwich_option(). This uses the ingredients/presets from the sandwich options. It processes the option and then calls make_sandwich_preset().

To make a custom preset sandwich:
fillings = {{"apple", (uint8_t)1}};
condiments = {{"marmalade", (uint8_t)1}};
make_sandwich_preset(env, context, language, fillings, condiments);

Removed build_great_peanut_butter_sandwich and used the custom sandwich builder in its place. The replacement is a bit messy because it skips the custom sandwich menu and goes straight to the new run_sandwich_maker(). I didn't want to use make_sandwich_preset() since selecting the recipe is faster than selecting custom ingredients.

Tested that they still work but otherwise didn't touch the two Herba lv3 egg sandwiches.