### PR TITLE
Tournament Farmer 2

### DIFF
--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -1296,6 +1296,8 @@ file(GLOB MAIN_SOURCES
     Source/PokemonSV/Inference/Dialogs/PokemonSV_DialogDetector.h
     Source/PokemonSV/Inference/Dialogs/PokemonSV_GradientArrowDetector.cpp
     Source/PokemonSV/Inference/Dialogs/PokemonSV_GradientArrowDetector.h
+    Source/PokemonSV/Inference/Map/PokemonSV_FastTravelDetector.cpp
+    Source/PokemonSV/Inference/Map/PokemonSV_FastTravelDetector.h
     Source/PokemonSV/Inference/Map/PokemonSV_MapDetector.cpp
     Source/PokemonSV/Inference/Map/PokemonSV_MapDetector.h
     Source/PokemonSV/Inference/Map/PokemonSV_MapMenuDetector.cpp

--- a/SerialPrograms/SerialPrograms.pro
+++ b/SerialPrograms/SerialPrograms.pro
@@ -648,6 +648,7 @@ SOURCES += \
     Source/PokemonSV/Inference/Dialogs/PokemonSV_DialogArrowDetector.cpp \
     Source/PokemonSV/Inference/Dialogs/PokemonSV_DialogDetector.cpp \
     Source/PokemonSV/Inference/Dialogs/PokemonSV_GradientArrowDetector.cpp \
+    Source/PokemonSV/Inference/Map/PokemonSV_FastTravelDetector.cpp \
     Source/PokemonSV/Inference/Map/PokemonSV_MapDetector.cpp \
     Source/PokemonSV/Inference/Map/PokemonSV_MapMenuDetector.cpp \
     Source/PokemonSV/Inference/Map/PokemonSV_MapPokeCenterIconDetector.cpp \
@@ -1704,6 +1705,7 @@ HEADERS += \
     Source/PokemonSV/Inference/Dialogs/PokemonSV_DialogArrowDetector.h \
     Source/PokemonSV/Inference/Dialogs/PokemonSV_DialogDetector.h \
     Source/PokemonSV/Inference/Dialogs/PokemonSV_GradientArrowDetector.h \
+    Source/PokemonSV/Inference/Map/PokemonSV_FastTravelDetector.h \
     Source/PokemonSV/Inference/Map/PokemonSV_MapDetector.h \
     Source/PokemonSV/Inference/Map/PokemonSV_MapMenuDetector.h \
     Source/PokemonSV/Inference/Map/PokemonSV_MapPokeCenterIconDetector.h \

--- a/SerialPrograms/Source/CommonFramework/ImageMatch/WaterfillTemplateMatcher.cpp
+++ b/SerialPrograms/Source/CommonFramework/ImageMatch/WaterfillTemplateMatcher.cpp
@@ -74,21 +74,18 @@ bool WaterfillTemplateMatcher::check_aspect_ratio(size_t candidate_width, size_t
     
     bool pass = m_aspect_ratio_lower <= error && error <= m_aspect_ratio_upper;
 
-    if (!pass && PreloadSettings::debug().IMAGE_TEMPLATE_MATCHING){
-        cout << "Failed to pass WaterfillTemplateMatcher aspect ratio check (W/H): "
-             << "expected: " << image_template.width() << " : " << image_template.height()
-             << " (" << (double)image_template.width()/image_template.height() << "), "
-             << "actual: " << candidate_width << " : " << candidate_height 
-             << " (" << (double)candidate_width/candidate_height << ") "
-             << "error: " << error << " bound [" << m_aspect_ratio_lower << ", " << m_aspect_ratio_upper << "]" << endl;
-    }
-    else if (pass && PreloadSettings::debug().IMAGE_TEMPLATE_MATCHING){
-        cout << "Passed WaterfillTemplateMatcher aspect ratio check (W/H): "
-                << "expected: " << image_template.width() << " : " << image_template.height()
-                << " (" << (double)image_template.width()/image_template.height() << "), "
-                << "actual: " << candidate_width << " : " << candidate_height 
-                << " (" << (double)candidate_width/candidate_height << ") "
-                << "error: " << error << " bound [" << m_aspect_ratio_lower << ", " << m_aspect_ratio_upper << "]" << endl;
+    if (PreloadSettings::debug().IMAGE_TEMPLATE_MATCHING){
+        if (!pass){
+            cout << "Failed to pass WaterfillTemplateMatcher aspect ratio check (W/H): ";
+        }
+        else {
+            cout << "Passed WaterfillTemplateMatcher aspect ratio check (W/H): ";
+        }
+        cout << "expected: " << image_template.width() << " : " << image_template.height()
+            << " (" << (double)image_template.width()/image_template.height() << "), "
+            << "actual: " << candidate_width << " : " << candidate_height 
+            << " (" << (double)candidate_width/candidate_height << ") "
+            << "error: " << error << " bound [" << m_aspect_ratio_lower << ", " << m_aspect_ratio_upper << "]" << endl;
     }
 
     return pass;
@@ -99,14 +96,14 @@ bool WaterfillTemplateMatcher::check_area_ratio(double candidate_area_ratio) con
     }
     double error = candidate_area_ratio / m_area_ratio;
     bool pass = m_area_ratio_lower <= error && error <= m_area_ratio_upper;
-    if (!pass && PreloadSettings::debug().IMAGE_TEMPLATE_MATCHING){
-        cout << "Failed to pass WaterfillTemplateMatcher area ratio check: "
-             << "Expected: " << m_area_ratio << ", actual: " << candidate_area_ratio << ", "
-             << "error: " << error << " bound [" << m_area_ratio_lower << ", " << m_area_ratio_upper << "]" << endl;
-    }
-    else if (pass && PreloadSettings::debug().IMAGE_TEMPLATE_MATCHING){
-        cout << "Passed WaterfillTemplateMatcher area ratio check: "
-             << "Expected: " << m_area_ratio << ", actual: " << candidate_area_ratio << ", "
+    if (PreloadSettings::debug().IMAGE_TEMPLATE_MATCHING){
+        if (!pass){
+            cout << "Failed to pass WaterfillTemplateMatcher area ratio check: ";
+        }
+        else {
+            cout << "Passed WaterfillTemplateMatcher area ratio check: ";
+        }
+        cout << "Expected: " << m_area_ratio << ", actual: " << candidate_area_ratio << ", "
              << "error: " << error << " bound [" << m_area_ratio_lower << ", " << m_area_ratio_upper << "]" << endl;
     }
     

--- a/SerialPrograms/Source/CommonFramework/ImageMatch/WaterfillTemplateMatcher.cpp
+++ b/SerialPrograms/Source/CommonFramework/ImageMatch/WaterfillTemplateMatcher.cpp
@@ -55,7 +55,7 @@ WaterfillTemplateMatcher::WaterfillTemplateMatcher(
     if (PreloadSettings::debug().IMAGE_TEMPLATE_MATCHING){
         const auto exact_image = extract_box_reference(reference, *best);
         cout << "Build waterfil template matcher from " << full_path << ", W x H: " << exact_image.width()
-             << " x " << exact_image.height() <<  ", area ratio: " << m_area_ratio << endl;
+             << " x " << exact_image.height() <<  ", area ratio: " << m_area_ratio << ", Object area: " << best->area << endl;
         dump_debug_image(global_logger_command_line(), "CommonFramework/WaterfillTemplateMatcher", "matcher_exact_image", exact_image);
     }
 }
@@ -82,6 +82,15 @@ bool WaterfillTemplateMatcher::check_aspect_ratio(size_t candidate_width, size_t
              << " (" << (double)candidate_width/candidate_height << ") "
              << "error: " << error << " bound [" << m_aspect_ratio_lower << ", " << m_aspect_ratio_upper << "]" << endl;
     }
+    else if (pass && PreloadSettings::debug().IMAGE_TEMPLATE_MATCHING){
+        cout << "Passed WaterfillTemplateMatcher aspect ratio check (W/H): "
+                << "expected: " << image_template.width() << " : " << image_template.height()
+                << " (" << (double)image_template.width()/image_template.height() << "), "
+                << "actual: " << candidate_width << " : " << candidate_height 
+                << " (" << (double)candidate_width/candidate_height << ") "
+                << "error: " << error << " bound [" << m_aspect_ratio_lower << ", " << m_aspect_ratio_upper << "]" << endl;
+    }
+
     return pass;
 }
 bool WaterfillTemplateMatcher::check_area_ratio(double candidate_area_ratio) const{
@@ -95,6 +104,12 @@ bool WaterfillTemplateMatcher::check_area_ratio(double candidate_area_ratio) con
              << "Expected: " << m_area_ratio << ", actual: " << candidate_area_ratio << ", "
              << "error: " << error << " bound [" << m_area_ratio_lower << ", " << m_area_ratio_upper << "]" << endl;
     }
+    else if (pass && PreloadSettings::debug().IMAGE_TEMPLATE_MATCHING){
+        cout << "Passed WaterfillTemplateMatcher area ratio check: "
+             << "Expected: " << m_area_ratio << ", actual: " << candidate_area_ratio << ", "
+             << "error: " << error << " bound [" << m_area_ratio_lower << ", " << m_area_ratio_upper << "]" << endl;
+    }
+    
     return pass;
 }
 double WaterfillTemplateMatcher::rmsd_precropped(const ImageViewRGB32& cropped_image, const WaterfillObject& object) const{

--- a/SerialPrograms/Source/CommonFramework/ImageMatch/WaterfillTemplateMatcher.cpp
+++ b/SerialPrograms/Source/CommonFramework/ImageMatch/WaterfillTemplateMatcher.cpp
@@ -74,6 +74,20 @@ bool WaterfillTemplateMatcher::check_aspect_ratio(size_t candidate_width, size_t
     
     bool pass = m_aspect_ratio_lower <= error && error <= m_aspect_ratio_upper;
 
+    if (PreloadSettings::debug().IMAGE_TEMPLATE_MATCHING){
+        if (!pass){
+            cout << "Failed to pass WaterfillTemplateMatcher aspect ratio check (W/H): ";
+        }
+        else {
+            cout << "Passed WaterfillTemplateMatcher aspect ratio check (W/H): ";
+        }
+        cout << "expected: " << image_template.width() << " : " << image_template.height()
+            << " (" << (double)image_template.width()/image_template.height() << "), "
+            << "actual: " << candidate_width << " : " << candidate_height 
+            << " (" << (double)candidate_width/candidate_height << ") "
+            << "error: " << error << " bound [" << m_aspect_ratio_lower << ", " << m_aspect_ratio_upper << "]" << endl;
+    }
+
     return pass;
 }
 bool WaterfillTemplateMatcher::check_area_ratio(double candidate_area_ratio) const{
@@ -82,7 +96,18 @@ bool WaterfillTemplateMatcher::check_area_ratio(double candidate_area_ratio) con
     }
     double error = candidate_area_ratio / m_area_ratio;
     bool pass = m_area_ratio_lower <= error && error <= m_area_ratio_upper;
-    
+
+    if (PreloadSettings::debug().IMAGE_TEMPLATE_MATCHING){
+        if (!pass){
+            cout << "Failed to pass WaterfillTemplateMatcher area ratio check: ";
+        }
+        else {
+            cout << "Passed WaterfillTemplateMatcher area ratio check: ";
+        }
+        cout << "Expected: " << m_area_ratio << ", actual: " << candidate_area_ratio << ", "
+            << "error: " << error << " bound [" << m_area_ratio_lower << ", " << m_area_ratio_upper << "]" << endl;
+    }
+
     return pass;
 }
 double WaterfillTemplateMatcher::rmsd_precropped(const ImageViewRGB32& cropped_image, const WaterfillObject& object) const{
@@ -118,9 +143,6 @@ double WaterfillTemplateMatcher::rmsd_original(const ImageViewRGB32& original_im
     if (PreloadSettings::debug().IMAGE_TEMPLATE_MATCHING){
         cout << "rmsd_original()" << endl;
         dump_debug_image(global_logger_command_line(), "CommonFramework/WaterfillTemplateMatcher", "rmsd_original_input", extract_box_reference(original_image, object));
-        check_aspect_ratio_debug(object.width(), object.height());
-        check_area_ratio_debug(object.area_ratio());
-        calc_rmsd_debug(original_image, object);
     }
 
     if (!check_aspect_ratio(object.width(), object.height())){
@@ -131,49 +153,11 @@ double WaterfillTemplateMatcher::rmsd_original(const ImageViewRGB32& original_im
     }
 
     double rmsd = this->rmsd(extract_box_reference(original_image, object));
+    if (PreloadSettings::debug().IMAGE_TEMPLATE_MATCHING){
+        cout << "Passed aspect and area ratio check, rmsd = " << rmsd << endl;
+    }
 
     return rmsd;
-}
-void WaterfillTemplateMatcher::check_aspect_ratio_debug(size_t candidate_width, size_t candidate_height) const {
-    ImageViewRGB32 image_template = m_matcher->image_template();
-
-    double error = (double)image_template.width() * candidate_height;
-    error /= (double)image_template.height() * candidate_width;
-    
-    bool pass = m_aspect_ratio_lower <= error && error <= m_aspect_ratio_upper;
-
-    if (!pass){
-        cout << " -Failed to pass WaterfillTemplateMatcher aspect ratio check (W/H): ";
-    }
-    else {
-        cout << " -Passed WaterfillTemplateMatcher aspect ratio check (W/H): ";
-    }
-    cout << "expected: " << image_template.width() << " : " << image_template.height()
-        << " (" << (double)image_template.width()/image_template.height() << "), "
-        << "actual: " << candidate_width << " : " << candidate_height 
-        << " (" << (double)candidate_width/candidate_height << ") "
-        << "error: " << error << " bound [" << m_aspect_ratio_lower << ", " << m_aspect_ratio_upper << "]" << endl;
-
-}
-void WaterfillTemplateMatcher::check_area_ratio_debug(double candidate_area_ratio) const {
-    if (m_area_ratio == 0){
-        return;
-    }
-    double error = candidate_area_ratio / m_area_ratio;
-    bool pass = m_area_ratio_lower <= error && error <= m_area_ratio_upper;
-
-    if (!pass){
-        cout << " -Failed to pass WaterfillTemplateMatcher area ratio check: ";
-    }
-    else {
-        cout << " -Passed WaterfillTemplateMatcher area ratio check: ";
-    }
-    cout << "Expected: " << m_area_ratio << ", actual: " << candidate_area_ratio << ", "
-            << "error: " << error << " bound [" << m_area_ratio_lower << ", " << m_area_ratio_upper << "]" << endl;    
-}
-void WaterfillTemplateMatcher::calc_rmsd_debug(const ImageViewRGB32& original_image, const WaterfillObject& object) const{
-    double rmsd = this->rmsd(extract_box_reference(original_image, object));
-    cout << " -Theoretical rmsd (if passed aspect and area ratio check) = " << rmsd << endl;
 }
 
 

--- a/SerialPrograms/Source/CommonFramework/ImageMatch/WaterfillTemplateMatcher.h
+++ b/SerialPrograms/Source/CommonFramework/ImageMatch/WaterfillTemplateMatcher.h
@@ -75,6 +75,11 @@ protected:
     bool check_aspect_ratio(size_t candidate_width, size_t candidate_height) const;
     bool check_area_ratio(double candidate_area_ratio) const;
 
+    // print out aspect ratio/area ratio/rmsd for debugging
+    void check_aspect_ratio_debug(size_t candidate_width, size_t candidate_height) const;
+    void check_area_ratio_debug(double candidate_area_ratio) const;
+    void calc_rmsd_debug(const ImageViewRGB32& original_image, const WaterfillObject& object) const;
+
 protected:
     // Below are thresholds of aspect ratio and area ratio to reject a candidate.
     // They are ususally set by the derived class of `WaterfillTemplateMatcher`.

--- a/SerialPrograms/Source/CommonFramework/ImageMatch/WaterfillTemplateMatcher.h
+++ b/SerialPrograms/Source/CommonFramework/ImageMatch/WaterfillTemplateMatcher.h
@@ -75,11 +75,6 @@ protected:
     bool check_aspect_ratio(size_t candidate_width, size_t candidate_height) const;
     bool check_area_ratio(double candidate_area_ratio) const;
 
-    // print out aspect ratio/area ratio/rmsd for debugging
-    void check_aspect_ratio_debug(size_t candidate_width, size_t candidate_height) const;
-    void check_area_ratio_debug(double candidate_area_ratio) const;
-    void calc_rmsd_debug(const ImageViewRGB32& original_image, const WaterfillObject& object) const;
-
 protected:
     // Below are thresholds of aspect ratio and area ratio to reject a candidate.
     // They are ususally set by the derived class of `WaterfillTemplateMatcher`.

--- a/SerialPrograms/Source/CommonFramework/ImageTools/WaterfillUtilities.cpp
+++ b/SerialPrograms/Source/CommonFramework/ImageTools/WaterfillUtilities.cpp
@@ -96,7 +96,8 @@ bool match_template_by_waterfill(
     for(PokemonAutomation::PackedBinaryMatrix &matrix : matrices){
         if (PreloadSettings::debug().IMAGE_TEMPLATE_MATCHING){
             ImageRGB32 binaryImage = image.copy();
-            filter_by_mask(matrix, binaryImage, Color(0xffffffff), true);
+            filter_by_mask(matrix, binaryImage, Color(COLOR_BLACK), true);
+            //filter_by_mask(matrix, binaryImage, Color(COLOR_WHITE), true);
             dump_debug_image(
                 global_logger_command_line(), 
                 "CommonFramework/WaterfillTemplateMatcher", 

--- a/SerialPrograms/Source/CommonFramework/ImageTools/WaterfillUtilities.cpp
+++ b/SerialPrograms/Source/CommonFramework/ImageTools/WaterfillUtilities.cpp
@@ -112,6 +112,7 @@ bool match_template_by_waterfill(
         const bool keep_object_matrix = false;
         while (finder->find_next(object, keep_object_matrix)){
             if (PreloadSettings::debug().IMAGE_TEMPLATE_MATCHING){
+                std::cout << "------------" << std::endl;
                 std::cout << "Object area: " << object.area << std::endl;
             }
 

--- a/SerialPrograms/Source/PokemonSV/Inference/Map/PokemonSV_FastTravelDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Map/PokemonSV_FastTravelDetector.cpp
@@ -60,7 +60,16 @@ bool FastTravelDetector::detect(const ImageViewRGB32& screen) const{
 std::vector<ImageFloatBox> FastTravelDetector::detect_all(const ImageViewRGB32& screen) const{
     const std::vector<std::pair<uint32_t, uint32_t>> filters = {
         {combine_rgb(0, 0, 80), combine_rgb(140, 140, 255)},
-        {combine_rgb(5, 100, 200), combine_rgb(60, 135, 255)},
+        {combine_rgb(5, 100, 200), combine_rgb(60, 135, 255)}, // matching at blueberry academy 1080p
+
+        // the below filters are for matching at blueberry academy at 720p
+        // however, they increase the risk of false positives. 
+        // as they select for images that are both wrong and have low RMSD (<85)
+        // {combine_rgb(0, 90, 180), combine_rgb(55, 140, 255)}, 
+        // {combine_rgb(0, 100, 180), combine_rgb(60, 135, 255)}, 
+        // {combine_rgb(0, 100, 195), combine_rgb(50, 135, 255)}, 
+        // {combine_rgb(0, 100, 180), combine_rgb(55, 130, 255)}, 
+        // {combine_rgb(0, 90, 180), combine_rgb(50, 125, 255)}, 
     };
 
     const double min_object_size = 400.0;

--- a/SerialPrograms/Source/PokemonSV/Inference/Map/PokemonSV_FastTravelDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Map/PokemonSV_FastTravelDetector.cpp
@@ -25,13 +25,22 @@ ImageFloatBox MINIMAP_AREA(0.815, 0.680, 0.180, 0.310);
 
 class FastTravelMatcher : public ImageMatch::WaterfillTemplateMatcher{
 public:
+    
+    /* 
+    - selects for the white, wing-shaped component of the fast travel icon
+    - Use Waterfilltemplate matcher to get your template so you get the correct area ratio
+    along with the blue background. You need the blue backgroun so you don't false positive
+    against the fly icon in Pokemon centers.
+
+     */
     FastTravelMatcher() : WaterfillTemplateMatcher(
-        "PokemonSV/Map/FastTravelIcon-Template.png", Color(0,0,0), Color(255, 255, 255), 450
+        "PokemonSV/Map/FastTravelIcon-Template.png", Color(200,200,200), Color(255, 255, 255), 50
     ) {
-        m_aspect_ratio_lower = 0.9;
+        m_aspect_ratio_lower = 0.8;
         m_aspect_ratio_upper = 1.2;
-        m_area_ratio_lower = 0.6;
-        m_area_ratio_upper = 1.1;
+        m_area_ratio_lower = 0.9;
+        m_area_ratio_upper = 1.4;
+
     }
 
     static const ImageMatch::WaterfillTemplateMatcher& instance() {
@@ -59,22 +68,20 @@ bool FastTravelDetector::detect(const ImageViewRGB32& screen) const{
 
 std::vector<ImageFloatBox> FastTravelDetector::detect_all(const ImageViewRGB32& screen) const{
     const std::vector<std::pair<uint32_t, uint32_t>> filters = {
-        {combine_rgb(0, 0, 80), combine_rgb(140, 140, 255)},
-        {combine_rgb(5, 100, 200), combine_rgb(60, 135, 255)}, // matching at blueberry academy 1080p
+        {combine_rgb(180, 180, 180), combine_rgb(255, 255, 255)},
 
-        // the below filters are for matching at blueberry academy at 720p
-        // however, they increase the risk of false positives. 
-        // as they select for images that are both wrong and have low RMSD (<85)
-        // {combine_rgb(0, 90, 180), combine_rgb(55, 140, 255)}, 
-        // {combine_rgb(0, 100, 180), combine_rgb(60, 135, 255)}, 
-        // {combine_rgb(0, 100, 195), combine_rgb(50, 135, 255)}, 
-        // {combine_rgb(0, 100, 180), combine_rgb(55, 130, 255)}, 
-        // {combine_rgb(0, 90, 180), combine_rgb(50, 125, 255)}, 
     };
 
-    const double min_object_size = 400.0;
-    // need to keep RMSD threshold below 100, else will false positive the blue dots at blueberry academy
+    /* 
+    - need to keep RMSD threshold below 100, 
+    else will false positive the fly icon at pokemon centers
+    */ 
     const double rmsd_threshold = 80.0;
+    /* 
+    - min object size restrictions also helps to filter out false positives
+    at pokemon centers
+    */
+    const double min_object_size = 150.0;
 
     const double screen_rel_size = (screen.height() / 1080.0);
     const size_t min_size = size_t(screen_rel_size * screen_rel_size * min_object_size);

--- a/SerialPrograms/Source/PokemonSV/Inference/Map/PokemonSV_FastTravelDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Map/PokemonSV_FastTravelDetector.cpp
@@ -30,7 +30,7 @@ public:
     ) {
         m_aspect_ratio_lower = 0.9;
         m_aspect_ratio_upper = 1.2;
-        m_area_ratio_lower = 0.7;
+        m_area_ratio_lower = 0.6;
         m_area_ratio_upper = 1.1;
     }
 
@@ -59,11 +59,13 @@ bool FastTravelDetector::detect(const ImageViewRGB32& screen) const{
 
 std::vector<ImageFloatBox> FastTravelDetector::detect_all(const ImageViewRGB32& screen) const{
     const std::vector<std::pair<uint32_t, uint32_t>> filters = {
-        {combine_rgb(0, 0, 80), combine_rgb(140, 140, 255)}
+        {combine_rgb(0, 0, 80), combine_rgb(140, 140, 255)},
+        {combine_rgb(5, 100, 200), combine_rgb(60, 135, 255)},
     };
 
     const double min_object_size = 400.0;
-    const double rmsd_threshold = 60.0;
+    // need to keep RMSD threshold below 100, else will false positive the blue dots at blueberry academy
+    const double rmsd_threshold = 80.0;
 
     const double screen_rel_size = (screen.height() / 1080.0);
     const size_t min_size = size_t(screen_rel_size * screen_rel_size * min_object_size);

--- a/SerialPrograms/Source/PokemonSV/Inference/Map/PokemonSV_FastTravelDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Map/PokemonSV_FastTravelDetector.cpp
@@ -1,0 +1,126 @@
+/*  Fast Travel Detector
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "Common/Cpp/Containers/FixedLimitVector.tpp"
+#include "CommonFramework/ImageMatch/WaterfillTemplateMatcher.h"
+#include "CommonFramework/ImageTypes/ImageViewRGB32.h"
+#include "CommonFramework/ImageTools/WaterfillUtilities.h"
+#include "CommonFramework/VideoPipeline/VideoOverlayScopes.h"
+#include "Kernels/Waterfill/Kernels_Waterfill_Types.h"
+#include "PokemonSV_FastTravelDetector.h"
+
+// #include <iostream>
+//using std::cout;
+//using std::endl;
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonSV{
+
+ImageFloatBox MINIMAP_AREA(0.815, 0.680, 0.180, 0.310);
+
+
+class FastTravelMatcher : public ImageMatch::WaterfillTemplateMatcher{
+public:
+    FastTravelMatcher() : WaterfillTemplateMatcher(
+        "PokemonSV/Map/FastTravelIcon-Template.png", Color(0,0,0), Color(255, 255, 255), 450
+    ) {
+        m_aspect_ratio_lower = 0.9;
+        m_aspect_ratio_upper = 1.2;
+        m_area_ratio_lower = 0.7;
+        m_area_ratio_upper = 1.1;
+    }
+
+    static const ImageMatch::WaterfillTemplateMatcher& instance() {
+        static FastTravelMatcher matcher;
+        return matcher;
+    }
+};
+
+
+FastTravelDetector::~FastTravelDetector() = default;
+
+FastTravelDetector::FastTravelDetector(Color color, const ImageFloatBox& box)
+    : m_color(color)
+    , m_box(box)
+{}
+
+void FastTravelDetector::make_overlays(VideoOverlaySet& items) const{
+    items.add(m_color, m_box);
+}
+
+bool FastTravelDetector::detect(const ImageViewRGB32& screen) const{
+    std::vector<ImageFloatBox> hits = detect_all(screen);
+    return !hits.empty();
+}
+
+std::vector<ImageFloatBox> FastTravelDetector::detect_all(const ImageViewRGB32& screen) const{
+    const std::vector<std::pair<uint32_t, uint32_t>> filters = {
+        {combine_rgb(0, 0, 80), combine_rgb(140, 140, 255)}
+    };
+
+    const double min_object_size = 400.0;
+    const double rmsd_threshold = 60.0;
+
+    const double screen_rel_size = (screen.height() / 1080.0);
+    const size_t min_size = size_t(screen_rel_size * screen_rel_size * min_object_size);
+
+    std::vector<ImageFloatBox> found_locations;
+
+    ImagePixelBox pixel_search_area = floatbox_to_pixelbox(screen.width(), screen.height(), m_box);    
+    match_template_by_waterfill(
+        extract_box_reference(screen, m_box), 
+        FastTravelMatcher::instance(),
+        filters,
+        {min_size, SIZE_MAX},
+        rmsd_threshold,
+        [&](Kernels::Waterfill::WaterfillObject& object) -> bool {
+            ImagePixelBox found_box(
+                object.min_x + pixel_search_area.min_x, object.min_y + pixel_search_area.min_y,
+                object.max_x + pixel_search_area.min_x, object.max_y + pixel_search_area.min_y);
+            found_locations.emplace_back(pixelbox_to_floatbox(screen.width(), screen.height(), found_box));
+            return false;
+        }
+    );
+
+    return found_locations;
+}
+
+
+
+FastTravelWatcher::~FastTravelWatcher() = default;
+
+FastTravelWatcher::FastTravelWatcher(Color color, VideoOverlay& overlay, const ImageFloatBox& box)
+    : VisualInferenceCallback("FastTravelWatcher")
+    , m_overlay(overlay)
+    , m_detector(color, box)
+{}
+
+void FastTravelWatcher::make_overlays(VideoOverlaySet& items) const{
+    m_detector.make_overlays(items);
+}
+
+bool FastTravelWatcher::process_frame(const ImageViewRGB32& screen, WallClock timestamp){
+    std::vector<ImageFloatBox> hits = m_detector.detect_all(screen);
+
+    m_hits.reset(hits.size());
+    for (const ImageFloatBox& hit : hits){
+        m_hits.emplace_back(m_overlay, hit, COLOR_MAGENTA);
+    }
+
+    return !hits.empty();
+}
+
+
+
+
+
+
+
+
+}
+}
+}

--- a/SerialPrograms/Source/PokemonSV/Inference/Map/PokemonSV_FastTravelDetector.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Map/PokemonSV_FastTravelDetector.h
@@ -1,8 +1,19 @@
 /*  Fast Travel Detector
 
  Detects the Fast Travel symbol on the screen. 
- Does not work if obstructed by the radar beam.
+
+ Limitations:
+ - Does not work if obstructed by the radar beam (while outdoors), or if obstructed by the radar dot
+ - Less reliable in areas where the map is blue. e.g. Blueberry academy.
  
+ Ideas for further improvements:
+ - Can try a two step waterfill+template match technique. Use waterfill algorithm to
+ get all blue portions of the screen. From these sub-image candidates, run a second
+ waterfill to select only white portions. Then compare to the template. Can use the same
+ template, but needs to be cropped down slightly. Make sure the template still has a blue
+ background. Need to be aware of false positives with the pokemon center, since it also
+ has the same wing symbol.
+
  *  From: https://github.com/PokemonAutomation/Arduino-Source
  *
  */

--- a/SerialPrograms/Source/PokemonSV/Inference/Map/PokemonSV_FastTravelDetector.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Map/PokemonSV_FastTravelDetector.h
@@ -1,0 +1,71 @@
+/*  Fast Travel Detector
+
+ Detects the Fast Travel symbol on the screen. 
+ Does not work if obstructed by the radar beam.
+ 
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonSV_FastTravelDetector_H
+#define PokemonAutomation_PokemonSV_FastTravelDetector_H
+
+#include <vector>
+#include "Common/Cpp/Color.h"
+#include "Common/Cpp/Containers/FixedLimitVector.h"
+#include "CommonFramework/ImageTools/ImageBoxes.h"
+#include "CommonFramework/VideoPipeline/VideoOverlayScopes.h"
+#include "CommonFramework/InferenceInfra/VisualInferenceCallback.h"
+#include "CommonFramework/Inference/VisualDetector.h"
+
+namespace PokemonAutomation{
+
+class VideoOverlaySet;
+class VideoOverlay;
+class OverlayBoxScope;
+
+namespace NintendoSwitch{
+namespace PokemonSV{
+
+// The area on the screen with the minimap
+extern ImageFloatBox MINIMAP_AREA;
+
+class FastTravelDetector : public StaticScreenDetector{
+public:
+    FastTravelDetector(Color color, const ImageFloatBox& box);
+    virtual ~FastTravelDetector();
+
+    virtual void make_overlays(VideoOverlaySet& items) const override;
+    virtual bool detect(const ImageViewRGB32& screen) const override;
+
+    std::vector<ImageFloatBox> detect_all(const ImageViewRGB32& screen) const;
+
+protected:
+    Color m_color;
+    ImageFloatBox m_box;
+};
+
+
+
+class FastTravelWatcher : public VisualInferenceCallback{
+public:
+    FastTravelWatcher(Color color, VideoOverlay& overlay, const ImageFloatBox& box);
+    virtual ~FastTravelWatcher();
+
+    virtual void make_overlays(VideoOverlaySet& items) const override;
+    virtual bool process_frame(const ImageViewRGB32& frame, WallClock timestamp) override;
+
+
+protected:
+    VideoOverlay& m_overlay;
+    FastTravelDetector m_detector;
+    FixedLimitVector<OverlayBoxScope> m_hits;
+};
+
+
+
+
+}
+}
+}
+#endif

--- a/SerialPrograms/Source/PokemonSV/Inference/Map/PokemonSV_FastTravelDetector.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Map/PokemonSV_FastTravelDetector.h
@@ -3,16 +3,8 @@
  Detects the Fast Travel symbol on the screen. 
 
  Limitations:
- - Does not work if obstructed by the radar beam (while outdoors), or if obstructed by the radar dot
- - Less reliable in areas where the map is blue. e.g. Blueberry academy.
- 
- Ideas for further improvements:
- - Can try a two step waterfill+template match technique. Use waterfill algorithm to
- get all blue portions of the screen. From these sub-image candidates, run a second
- waterfill to select only white portions. Then compare to the template. Can use the same
- template, but needs to be cropped down slightly. Make sure the template still has a blue
- background. Need to be aware of false positives with the pokemon center, since it also
- has the same wing symbol.
+ - Does not work if obstructed by the radar beam (while outdoors), 
+ or if obstructed by the radar dot
 
  *  From: https://github.com/PokemonAutomation/Arduino-Source
  *

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_TournamentFarmer.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_TournamentFarmer.cpp
@@ -559,10 +559,8 @@ void TournamentFarmer::handle_end_of_tournament(SingleSwitchProgramEnvironment& 
 //Fly to academy from west pokemon center after losing.
 void return_to_academy_after_loss(SingleSwitchProgramEnvironment& env, BotBaseContext& context) {
     env.log("Tournament lost! Navigating back to academy.");
-    open_map_from_overworld(env.program_info(), env.console, context);
-    pbf_press_button(context, BUTTON_ZR, 50, 40);
-    pbf_move_left_joystick(context, 187, 0, 50, 0);
-    fly_to_overworld_from_map(env.program_info(), env.console, context);
+    go_to_academy_fly_point(env, context);
+
 
     pbf_wait(context, 100);
     context.wait_for_all_requests();
@@ -603,6 +601,35 @@ void return_to_academy_after_loss(SingleSwitchProgramEnvironment& env, BotBaseCo
     pbf_move_left_joystick(context, 0, 128, 100, 0);
     pbf_move_left_joystick(context, 255, 0, 100, 0);
     context.wait_for_all_requests();
+}
+
+void go_to_academy_fly_point(SingleSwitchProgramEnvironment& env, BotBaseContext& context){
+    int numAttempts = 0;
+    int maxAttempts = 5;
+
+    bool isFlySuccessful = false;
+
+    while (!isFlySuccessful && numAttempts < maxAttempts ){
+        open_map_from_overworld(env.program_info(), env.console, context);
+        pbf_press_button(context, BUTTON_ZR, 50, 40);
+        pbf_move_left_joystick(context, 200, 0, 47, 25);  
+        // pbf_move_left_joystick(context, 187, 0, 50, 0);
+        numAttempts++;
+        isFlySuccessful = fly_to_overworld_from_map(env.program_info(), env.console, context, true);
+        if (!isFlySuccessful){
+            env.log("Unsuccessful fly attempt.");
+        }
+        pbf_mash_button(context, BUTTON_B, 100);
+    }
+
+    if(!isFlySuccessful){
+        throw OperationFailedException(
+            ErrorReport::SEND_ERROR_REPORT, env.console,
+            "Failed to fly back to academy!",
+            true
+        );
+    }
+
 }
 
 

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_TournamentFarmer.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_TournamentFarmer.h
@@ -23,7 +23,8 @@ namespace PokemonSV{
 
 void return_to_academy_after_loss(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
 
-
+// attempt to fly back to academy fly point from the West Mesogoza Pokecenter. Will attempt maxAttempts times.
+void go_to_academy_fly_point(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
 
 class TournamentFarmer_Descriptor : public SingleSwitchProgramDescriptor{
 public:

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_TournamentFarmer2.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_TournamentFarmer2.cpp
@@ -244,14 +244,19 @@ void TournamentFarmer2::program(SingleSwitchProgramEnvironment& env, BotBaseCont
             if (battles == 3){
                 env.log("Final battle of the tournament complete, checking for overworld/loss.");
 
-                //  Clear dialog, mash B
-                pbf_mash_button(context, BUTTON_B, 400);
                 context.wait_for_all_requests();
 
-                ret = wait_until(
+                /* 
+                - mash B to clear dialog. if reaches overworld within 15 seconds, you likely lost. else you likely won.
+                    - if lose, it takes approx 7-8 seconds from battle end to overworld
+                    - if win, it takes approx 30 seconds from battle end to overworld
+                */
+                ret = run_until(
                     env.console, context,
-                    std::chrono::seconds(3),
-                    {overworld}
+                    [](BotBaseContext& context) {
+                        pbf_mash_button(context, BUTTON_B, 15 * TICKS_PER_SECOND);
+                    },
+                    {overworld} 
                 );
                 switch (ret){
                 case 0:

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_TournamentFarmer2.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_TournamentFarmer2.cpp
@@ -202,6 +202,7 @@ void TournamentFarmer2::program(SingleSwitchProgramEnvironment& env, BotBaseCont
         context.wait_for_all_requests();
 
         stats.tournaments++;
+        env.update_stats();
 
         bool battle_lost = false;
         for (uint16_t battles = 0; battles < 4; battles++){
@@ -281,6 +282,7 @@ void TournamentFarmer2::program(SingleSwitchProgramEnvironment& env, BotBaseCont
         //  Tournament won
         if (!battle_lost){
             stats.wins++;
+            env.update_stats();
             OverworldWatcher overworld(COLOR_CYAN);
             int ret = run_until(
                 env.console, context,

--- a/SerialPrograms/Source/Tests/PokemonSV_Tests.cpp
+++ b/SerialPrograms/Source/Tests/PokemonSV_Tests.cpp
@@ -18,6 +18,7 @@
 #include "PokemonSV/Inference/Map/PokemonSV_MapDetector.h"
 #include "PokemonSV/Inference/Map/PokemonSV_MapMenuDetector.h"
 #include "PokemonSV/Inference/Map/PokemonSV_MapPokeCenterIconDetector.h"
+#include "PokemonSV/Inference/Map/PokemonSV_FastTravelDetector.h"
 #include "PokemonSV/Inference/Tera/PokemonSV_TeraCardDetector.h"
 #include "PokemonSV/Inference/Tera/PokemonSV_TeraSilhouetteReader.h"
 #include "PokemonSV/Inference/Tera/PokemonSV_TeraTypeReader.h"
@@ -454,6 +455,14 @@ int test_pokemonSV_DialogBoxDetector(const ImageViewRGB32& image, bool target) {
     DialogBoxDetector detector(COLOR_RED);
     bool result = detector.detect(image);
     TEST_RESULT_EQUAL(result, target);
+    return 0;
+}
+
+int test_pokemonSV_FastTravelDetector(const ImageViewRGB32& image, bool target) {
+    FastTravelDetector detector(COLOR_RED, MINIMAP_AREA);
+    bool result = detector.detect(image);
+    TEST_RESULT_EQUAL(result, target);
+
     return 0;
 }
 

--- a/SerialPrograms/Source/Tests/PokemonSV_Tests.h
+++ b/SerialPrograms/Source/Tests/PokemonSV_Tests.h
@@ -54,6 +54,8 @@ int test_pokemonSV_SwapMenuDetector(const ImageViewRGB32& image, bool target);
 
 int test_pokemonSV_DialogBoxDetector(const ImageViewRGB32& image, bool target);
 
+int test_pokemonSV_FastTravelDetector(const ImageViewRGB32& image, bool target);
+
 int test_pokemonSV_MapPokeCenterIconDetector(const ImageViewRGB32& image, int target);
 
 int test_pokemonSV_ESPPressedEmotionDetector(const ImageViewRGB32& image, bool target);

--- a/SerialPrograms/Source/Tests/TestMap.cpp
+++ b/SerialPrograms/Source/Tests/TestMap.cpp
@@ -280,6 +280,7 @@ const std::map<std::string, TestFunction> TEST_MAP = {
     {"PokemonSV_AdvanceDialogDetector", std::bind(image_bool_detector_helper, test_pokemonSV_AdvanceDialogDetector, _1)},
     {"PokemonSV_SwapMenuDetector", std::bind(image_bool_detector_helper, test_pokemonSV_SwapMenuDetector, _1)},
     {"PokemonSV_DialogBoxDetector", std::bind(image_bool_detector_helper, test_pokemonSV_DialogBoxDetector, _1)},
+    {"PokemonSV_FastTravelDetector", std::bind(image_bool_detector_helper, test_pokemonSV_FastTravelDetector, _1)},
     {"PokemonSV_MapPokeCenterIconDetector", std::bind(image_int_detector_helper, test_pokemonSV_MapPokeCenterIconDetector, _1)},
     {"PokemonSV_ESPPressedEmotionDetector", std::bind(image_bool_detector_helper, test_pokemonSV_ESPPressedEmotionDetector, _1)},
     {"PokemonSV_MapFlyMenuDetector", std::bind(image_bool_detector_helper, test_pokemonSV_MapFlyMenuDetector, _1)},


### PR DESCRIPTION
- Added new FastTravelDetector (along with tests), to detect win vs loss instead of using timeout.
- added more print statements for debugging.
- adjusted the stick movement for `return_to_academy_after_loss`, to make it more consistently move to the fly point. Also, gives it multiple attempts if fails to fly there. To do this, `fly_to_overworld_from_map` now uses `MapFlyMenuWatcher` and `MapDestinationMenuWatcher`, since `check_fly_menuitem` is set to true.
