### PR TITLE
Another fix to close game sequence

### DIFF
--- a/SerialPrograms/Source/NintendoSwitch/Commands/NintendoSwitch_Commands_Routines.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/Commands/NintendoSwitch_Commands_Routines.cpp
@@ -32,7 +32,8 @@ void close_game(BotBaseContext& context){
     pbf_press_dpad(context, DPAD_DOWN, 50, 50);      // - Does nothing.          |  - moves selector away from the closed game to avoid opening it.
     pbf_press_dpad(context, DPAD_DOWN, 50, 50);      // - Does nothing.          |  - Press Down a second time in case we drop one.
     pbf_mash_button(context, BUTTON_A, 50);          // - Confirm close game.    |  - opens an app on the home screen (e.g. Online)
-    pbf_press_button(context, BUTTON_HOME, 50, 50);  // - Does nothing.          |  - goes back to home screen.
+    pbf_press_button(context, BUTTON_HOME, 50, 125); // - Does nothing.          |  - goes back to home screen.
+    context.wait_for_all_requests();
     pbf_press_button(context, BUTTON_HOME, 50, 50);  // - Does nothing.          |  - Press Home a second time in case we drop one.
 
 

--- a/SerialPrograms/Source/NintendoSwitch/Commands/NintendoSwitch_Commands_Routines.h
+++ b/SerialPrograms/Source/NintendoSwitch/Commands/NintendoSwitch_Commands_Routines.h
@@ -8,12 +8,13 @@
 #define PokemonAutomation_NintendoSwitch_Commands_Routines_H
 
 #include "ClientSource/Connection/BotBase.h"
+#include "CommonFramework/Tools/ConsoleHandle.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
 
 
-void close_game(BotBaseContext& device);
+void close_game(ConsoleHandle& console, BotBaseContext& device);
 
 
 

--- a/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_GameEntry.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_GameEntry.cpp
@@ -79,7 +79,7 @@ bool reset_game_from_home(
         ConsoleSettings::instance().START_GAME_REQUIRES_INTERNET ||
         tolerate_update_menu
     ){
-        close_game(context);
+        close_game(console, context);
         start_game_from_home(
             console,
             context,

--- a/SerialPrograms/Source/PokemonLA/Programs/PokemonLA_GameEntry.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/PokemonLA_GameEntry.cpp
@@ -35,7 +35,7 @@ bool reset_game_to_gamemenu(
         ConsoleSettings::instance().START_GAME_REQUIRES_INTERNET ||
         tolerate_update_menu
     ){
-        close_game(context);
+        close_game(console, context);
         start_game_from_home(
             console,
             context,

--- a/SerialPrograms/Source/PokemonSV/Programs/PokemonSV_GameEntry.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/PokemonSV_GameEntry.cpp
@@ -64,7 +64,7 @@ private:
 
 
 bool reset_game_to_gamemenu(ConsoleHandle& console, BotBaseContext& context){
-    close_game(context);
+    close_game(console, context);
     start_game_from_home(
         console,
         context,

--- a/SerialPrograms/Source/PokemonSwSh/Commands/PokemonSwSh_Commands_GameEntry.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Commands/PokemonSwSh_Commands_GameEntry.cpp
@@ -72,7 +72,7 @@ void fast_reset_game(
 #endif
 }
 
-void reset_game_from_home(BotBaseContext& context, bool tolerate_update_menu){
+void reset_game_from_home(ConsoleHandle& console, BotBaseContext& context, bool tolerate_update_menu){
     if (!ConsoleSettings::instance().START_GAME_REQUIRES_INTERNET && !tolerate_update_menu){
         fast_reset_game(
             context,
@@ -82,7 +82,7 @@ void reset_game_from_home(BotBaseContext& context, bool tolerate_update_menu){
         return;
     }
 
-    close_game(context);
+    close_game(console, context);
     start_game_from_home(context, tolerate_update_menu, 0, 0, false);
 }
 void settings_to_enter_game(BotBaseContext& context, bool fast){

--- a/SerialPrograms/Source/PokemonSwSh/Commands/PokemonSwSh_Commands_GameEntry.h
+++ b/SerialPrograms/Source/PokemonSwSh/Commands/PokemonSwSh_Commands_GameEntry.h
@@ -8,6 +8,7 @@
 #define PokemonAutomation_PokemonSwSh_Commands_GameEntry_H
 
 #include "ClientSource/Connection/BotBase.h"
+#include "CommonFramework/Tools/ConsoleHandle.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
@@ -31,7 +32,7 @@ void fast_reset_game(
     uint16_t start_game_mash, uint16_t start_game_wait,
     uint16_t enter_game_mash, uint16_t enter_game_wait
 );
-void reset_game_from_home               (BotBaseContext& device, bool tolerate_update_menu);
+void reset_game_from_home               (ConsoleHandle& console, BotBaseContext& device, bool tolerate_update_menu);
 
 
 

--- a/SerialPrograms/Source/PokemonSwSh/Programs/DenHunting/PokemonSwSh_BeamReset.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/DenHunting/PokemonSwSh_BeamReset.cpp
@@ -75,7 +75,7 @@ void BeamReset::program(SingleSwitchProgramEnvironment& env, BotBaseContext& con
         }
         pbf_wait(context, DELAY_BEFORE_RESET);
 
-        reset_game_from_home(context, ConsoleSettings::instance().TOLERATE_SYSTEM_UPDATE_MENU_SLOW);
+        reset_game_from_home(env.console, context, ConsoleSettings::instance().TOLERATE_SYSTEM_UPDATE_MENU_SLOW);
     }
 }
 

--- a/SerialPrograms/Source/PokemonSwSh/Programs/Hosting/PokemonSwSh_AutoHost-MultiGame.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/Hosting/PokemonSwSh_AutoHost-MultiGame.cpp
@@ -228,7 +228,7 @@ void AutoHostMultiGame::program(SingleSwitchProgramEnvironment& env, BotBaseCont
 
             //  Exit game.
             pbf_press_button(context, BUTTON_HOME, 10, GameSettings::instance().GAME_TO_HOME_DELAY_SAFE);
-            close_game(context);
+            close_game(env.console, context);
 
             //  Post-raid delay.
             pbf_wait(context, game.post_raid_delay);

--- a/SerialPrograms/Source/PokemonSwSh/Programs/Hosting/PokemonSwSh_AutoHost-Rolling.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/Hosting/PokemonSwSh_AutoHost-Rolling.cpp
@@ -203,7 +203,7 @@ void AutoHostRolling::program(SingleSwitchProgramEnvironment& env, BotBaseContex
 
         //  Exit game.
         ssf_press_button2(context, BUTTON_HOME, GameSettings::instance().GAME_TO_HOME_DELAY_SAFE, 10);
-        close_game(context);
+        close_game(env.console, context);
 
         //  Post-raid delay.
         pbf_wait(context, EXTRA_DELAY_BETWEEN_RAIDS);

--- a/SerialPrograms/Source/PokemonSwSh/Programs/PokemonSwSh_GameEntry.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/PokemonSwSh_GameEntry.cpp
@@ -133,7 +133,7 @@ void reset_game_from_home_with_inference(
         ConsoleSettings::instance().START_GAME_REQUIRES_INTERNET ||
         tolerate_update_menu
     ){
-        close_game(context);
+        close_game(console, context);
         start_game_from_home_with_inference(
             console, context, tolerate_update_menu, 0, 0, backup_save, post_wait_time
         );

--- a/SerialPrograms/Source/PokemonSwSh/Programs/PokemonSwSh_RaidItemFarmerOKHO.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/PokemonSwSh_RaidItemFarmerOKHO.cpp
@@ -177,7 +177,7 @@ void RaidItemFarmerOHKO::program(MultiSwitchProgramEnvironment& env, Cancellable
                     //  Add a little extra wait time since correctness matters here.
                     ssf_press_button2(context, BUTTON_HOME, GameSettings::instance().GAME_TO_HOME_DELAY_SAFE, 10);
 
-                    close_game(context);
+                    close_game(console, context);
 
                     //  Touch the date.
                     if (TOUCH_DATE_INTERVAL > 0 && system_clock(context) - last_touch >= TOUCH_DATE_INTERVAL){

--- a/SerialPrograms/Source/PokemonSwSh/Programs/ShinyHuntUnattended/PokemonSwSh_MultiGameFossil.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/ShinyHuntUnattended/PokemonSwSh_MultiGameFossil.cpp
@@ -39,6 +39,7 @@ MultiGameFossil::MultiGameFossil(){
 }
 
 void run_fossil_batch(
+    ConsoleHandle& console, 
     Logger& logger,
     BotBaseContext& context,
     const FossilGame& batch,
@@ -134,7 +135,7 @@ void run_fossil_batch(
 
     //  Exit game.
     ssf_press_button2(context, BUTTON_HOME, GameSettings::instance().GAME_TO_HOME_DELAY_SAFE, 10);
-    close_game(context);
+    close_game(console, context);
 }
 
 
@@ -155,7 +156,7 @@ void MultiGameFossil::program(SingleSwitchProgramEnvironment& env, BotBaseContex
     bool game_slot_flipped = false;
     for (size_t c = 0; c < games; c++){
 //        batch = GAME_LIST2[c];
-        run_fossil_batch(env.logger(), context, *list[c], &game_slot_flipped, c + 1 < games);
+        run_fossil_batch(env.console, env.logger(), context, *list[c], &game_slot_flipped, c + 1 < games);
     }
 
     ssf_press_button2(context, BUTTON_HOME, GameSettings::instance().GAME_TO_HOME_DELAY_SAFE, 10);

--- a/SerialPrograms/Source/PokemonSwSh/Programs/ShinyHuntUnattended/PokemonSwSh_ShinyHuntTools.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/ShinyHuntUnattended/PokemonSwSh_ShinyHuntTools.cpp
@@ -34,7 +34,7 @@ void enter_summary(BotBaseContext& context, bool regi_move_right){
     pbf_press_dpad(context, DPAD_DOWN, 10, 0);
     pbf_press_button(context, BUTTON_A, 10, 10);    //  For Regi, this clears the dialog after running.
 }
-void close_game_if_overworld(BotBaseContext& context, bool touch_date, uint8_t rollback_hours){
+void close_game_if_overworld(ConsoleHandle& console, BotBaseContext& context, bool touch_date, uint8_t rollback_hours){
     //  Enter Y-COMM.
     ssf_press_button2(context, BUTTON_Y, GameSettings::instance().OPEN_YCOMM_DELAY, 10);
 
@@ -67,7 +67,7 @@ void close_game_if_overworld(BotBaseContext& context, bool touch_date, uint8_t r
     pbf_press_dpad(context, DPAD_DOWN, 10, 10);
 
     //  Close and restart game.
-    close_game(context);
+    close_game(console, context);
     pbf_press_button(context, BUTTON_HOME, 10, 190);
 }
 

--- a/SerialPrograms/Source/PokemonSwSh/Programs/ShinyHuntUnattended/PokemonSwSh_ShinyHuntTools.h
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/ShinyHuntUnattended/PokemonSwSh_ShinyHuntTools.h
@@ -16,7 +16,7 @@ namespace PokemonSwSh{
 
 void run_away_with_lights(BotBaseContext& context);
 void enter_summary(BotBaseContext& context, bool regi_move_right);
-void close_game_if_overworld(BotBaseContext& context, bool touch_date, uint8_t rollback_hours);
+void close_game_if_overworld(ConsoleHandle& console, BotBaseContext& context, bool touch_date, uint8_t rollback_hours);
 
 
 

--- a/SerialPrograms/Source/PokemonSwSh/Programs/ShinyHuntUnattended/PokemonSwSh_ShinyHuntUnattended-IoATrade.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/ShinyHuntUnattended/PokemonSwSh_ShinyHuntUnattended-IoATrade.cpp
@@ -138,6 +138,7 @@ void ShinyHuntUnattendedIoATrade::program(SingleSwitchProgramEnvironment& env, B
 
         //  Conditional close game.
         close_game_if_overworld(
+            env.console,
             context,
             TOUCH_DATE_INTERVAL.ok_to_touch_now(),
             0

--- a/SerialPrograms/Source/PokemonSwSh/Programs/ShinyHuntUnattended/PokemonSwSh_ShinyHuntUnattended-Regigigas2.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/ShinyHuntUnattended/PokemonSwSh_ShinyHuntUnattended-Regigigas2.cpp
@@ -109,6 +109,7 @@ void ShinyHuntUnattendedRegigigas2::program(SingleSwitchProgramEnvironment& env,
 
         //  Conditional close game.
         close_game_if_overworld(
+            env.console,
             context,
             TOUCH_DATE_INTERVAL.ok_to_touch_now(),
             0

--- a/SerialPrograms/Source/PokemonSwSh/Programs/ShinyHuntUnattended/PokemonSwSh_ShinyHuntUnattended-StrongSpawn.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/ShinyHuntUnattended/PokemonSwSh_ShinyHuntUnattended-StrongSpawn.cpp
@@ -104,9 +104,9 @@ void ShinyHuntUnattendedStrongSpawn::program(SingleSwitchProgramEnvironment& env
 //        if (true){
         if (TIME_ROLLBACK_HOURS > 0 && system_clock(context) - last_touch >= PERIOD){
             last_touch += PERIOD;
-            close_game_if_overworld(context, false, TIME_ROLLBACK_HOURS);
+            close_game_if_overworld(env.console, context, false, TIME_ROLLBACK_HOURS);
         }else{
-            close_game_if_overworld(context, false, 0);
+            close_game_if_overworld(env.console, context, false, 0);
         }
 
     }


### PR DESCRIPTION
There's another report of the zoom in issue. 
https://discord.com/channels/695809740428673034/711649658220314635/1231603132509720766
They report it only occurs every 150 resets, so I'm guessing that sometimes the program isn't respecting the delay between the 2 home button presses. Because from my testing, the zoom feature should only activate if the delay between home button presses is less than 40 ticks (currently, the delay is 100 ticks). I'm hoping that increasing the delay between presses and using `wait_for_all_requests` will solve the issue.
