### PR TITLE
Fixed recovery on errors with fly_to_closest_pokecenter_on_map

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Programs/PokemonSV_Navigation.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/PokemonSV_Navigation.cpp
@@ -603,7 +603,7 @@ void fly_to_closest_pokecenter_on_map(const ProgramInfo& info, ConsoleHandle& co
             // no visible pokecenters at this zoom level. Move on to part 2.
             break;
         }
-        catch (OperationFailedException e){ // pokecenter was detected, but failed to fly there
+        catch (OperationFailedException& e){ // pokecenter was detected, but failed to fly there
             if (try_count >= max_try_count){
                 throw e;
             }
@@ -651,7 +651,7 @@ void fly_to_closest_pokecenter_on_map(const ProgramInfo& info, ConsoleHandle& co
                 );
             }
         }
-        catch (OperationFailedException e){ // pokecenter was detected, but failed to fly there
+        catch (OperationFailedException& e){ // pokecenter was detected, but failed to fly there
             if (try_count >= max_try_count){
                 throw e;
             }


### PR DESCRIPTION
Currently, `fly_to_visible_closest_pokecenter_cur_zoom_level` will re-try if it fails to fly to the pokecenter at a given zoom level. However, on its re-tries, it tries again at the default zoom level, because all it does is close the map and re-open it at the default zoom level. If the initial zoom level was different, this recovery sequence won't work.

My new change pulls this recovery logic into `fly_to_closest_pokecenter_on_map` instead and will ensure the correct zoom level before reattempting.