### PR TITLE
Add material farmer to item printer

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmer.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmer.cpp
@@ -40,6 +40,21 @@ namespace PokemonSV{
 
 using namespace Pokemon;
 
+MaterialFarmer_Descriptor::MaterialFarmer_Descriptor()
+    : SingleSwitchProgramDescriptor(
+        "PokemonSV:MaterialFarmer",
+        STRING_POKEMON + " SV", "Material Farmer",
+        "ComputerControl/blob/master/Wiki/Programs/PokemonSV/MaterialFarmer.md",
+        "Farm materials - Happiny dust from Chanseys/Blisseys, for Item Printer.",
+        FeedbackType::VIDEO_AUDIO,
+        AllowCommandsWhenRunning::DISABLE_COMMANDS,
+        PABotBaseLevel::PABOTBASE_12KB
+    )
+{}
+
+std::unique_ptr<StatsTracker> MaterialFarmer_Descriptor::make_stats() const{
+    return std::unique_ptr<StatsTracker>(new MaterialFarmerTools::Stats());
+}
 
 
 MaterialFarmer::MaterialFarmer()
@@ -80,7 +95,7 @@ void MaterialFarmer::program(SingleSwitchProgramEnvironment& env, BotBaseContext
         reset_to_pokecenter(env.program_info(), env.console, context);
     }
 
-    MaterialFarmer_Descriptor::Stats& stats = env.current_stats<MaterialFarmer_Descriptor::Stats>();
+    MaterialFarmerTools::Stats& stats = env.current_stats<MaterialFarmerTools::Stats>();
     run_material_farmer(env, context, MATERIAL_FARMER_OPTIONS, stats);
     
 }

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmer.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmer.cpp
@@ -53,7 +53,7 @@ MaterialFarmer_Descriptor::MaterialFarmer_Descriptor()
 {}
 
 std::unique_ptr<StatsTracker> MaterialFarmer_Descriptor::make_stats() const{
-    return std::unique_ptr<StatsTracker>(new MaterialFarmerTools::Stats());
+    return std::unique_ptr<StatsTracker>(new MaterialFarmerStats());
 }
 
 
@@ -95,7 +95,7 @@ void MaterialFarmer::program(SingleSwitchProgramEnvironment& env, BotBaseContext
         reset_to_pokecenter(env.program_info(), env.console, context);
     }
 
-    MaterialFarmerTools::Stats& stats = env.current_stats<MaterialFarmerTools::Stats>();
+    MaterialFarmerStats& stats = env.current_stats<MaterialFarmerStats>();
     run_material_farmer(env, context, MATERIAL_FARMER_OPTIONS, stats);
     
 }

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmer.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmer.cpp
@@ -28,7 +28,7 @@
 #include "PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.h"
 #include "PokemonSV/Programs/ShinyHunting/PokemonSV_LetsGoTools.h"
 #include "PokemonSV_MaterialFarmer.h"
-#include "PokemonSV_MaterialFarmerTools.h"
+
 
 // #include <iostream>
 // using std::cout;
@@ -39,23 +39,6 @@ namespace NintendoSwitch{
 namespace PokemonSV{
 
 using namespace Pokemon;
-
-
-
-MaterialFarmer_Descriptor::MaterialFarmer_Descriptor()
-    : SingleSwitchProgramDescriptor(
-        "PokemonSV:MaterialFarmer",
-        STRING_POKEMON + " SV", "Material Farmer",
-        "ComputerControl/blob/master/Wiki/Programs/PokemonSV/MaterialFarmer.md",
-        "Farm materials - Happiny dust from Chanseys/Blisseys, for Item Printer.",
-        FeedbackType::VIDEO_AUDIO,
-        AllowCommandsWhenRunning::DISABLE_COMMANDS,
-        PABotBaseLevel::PABOTBASE_12KB
-    )
-{}
-std::unique_ptr<StatsTracker> MaterialFarmer_Descriptor::make_stats() const{
-    return std::unique_ptr<StatsTracker>(new Stats());
-}
 
 
 
@@ -97,8 +80,8 @@ void MaterialFarmer::program(SingleSwitchProgramEnvironment& env, BotBaseContext
         reset_to_pokecenter(env.program_info(), env.console, context);
     }
 
-
-    run_material_farmer(env, context, MATERIAL_FARMER_OPTIONS);
+    MaterialFarmer_Descriptor::Stats& stats = env.current_stats<MaterialFarmer_Descriptor::Stats>();
+    run_material_farmer(env, context, MATERIAL_FARMER_OPTIONS, stats);
     
 }
 

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmer.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmer.h
@@ -22,33 +22,6 @@ namespace PokemonAutomation{
 namespace NintendoSwitch{
 namespace PokemonSV{
 
-class LetsGoEncounterBotTracker;
-
-
-class MaterialFarmer_Descriptor : public SingleSwitchProgramDescriptor{
-public:
-    MaterialFarmer_Descriptor();
-
-    struct Stats : public LetsGoEncounterBotStats{
-        Stats()
-            : m_sandwiches(m_stats["Sandwiches"])
-            , m_autoheals(m_stats["Auto Heals"])
-            , m_game_resets(m_stats["Game Resets"])
-            , m_errors(m_stats["Errors"])
-        {
-            m_display_order.insert(m_display_order.begin() + 2, {"Sandwiches", HIDDEN_IF_ZERO});
-            m_display_order.insert(m_display_order.begin() + 3, {"Auto Heals", HIDDEN_IF_ZERO});
-            m_display_order.insert(m_display_order.begin() + 4, {"Game Resets", HIDDEN_IF_ZERO});
-            m_display_order.insert(m_display_order.begin() + 5, {"Errors", HIDDEN_IF_ZERO});
-        }
-        std::atomic<uint64_t>& m_sandwiches;
-        std::atomic<uint64_t>& m_autoheals;
-        std::atomic<uint64_t>& m_game_resets;
-        std::atomic<uint64_t>& m_errors;
-    };
-    virtual std::unique_ptr<StatsTracker> make_stats() const override;
-};
-
 
 class MaterialFarmer : public SingleSwitchProgramInstance{
 public:

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmer.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmer.h
@@ -22,6 +22,13 @@ namespace PokemonAutomation{
 namespace NintendoSwitch{
 namespace PokemonSV{
 
+class MaterialFarmer_Descriptor : public SingleSwitchProgramDescriptor{
+public:
+    MaterialFarmer_Descriptor();
+
+    virtual std::unique_ptr<StatsTracker> make_stats() const override;
+};
+
 
 class MaterialFarmer : public SingleSwitchProgramInstance{
 public:

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.cpp
@@ -191,25 +191,10 @@ MaterialFarmerOptions::MaterialFarmerOptions(
     }
 }
 
-MaterialFarmer_Descriptor::MaterialFarmer_Descriptor()
-    : SingleSwitchProgramDescriptor(
-        "PokemonSV:MaterialFarmer",
-        STRING_POKEMON + " SV", "Material Farmer",
-        "ComputerControl/blob/master/Wiki/Programs/PokemonSV/MaterialFarmer.md",
-        "Farm materials - Happiny dust from Chanseys/Blisseys, for Item Printer.",
-        FeedbackType::VIDEO_AUDIO,
-        AllowCommandsWhenRunning::DISABLE_COMMANDS,
-        PABotBaseLevel::PABOTBASE_12KB
-    )
-{}
-
-std::unique_ptr<StatsTracker> MaterialFarmer_Descriptor::make_stats() const{
-    return std::unique_ptr<StatsTracker>(new Stats());
-}
 
 
 void run_material_farmer(SingleSwitchProgramEnvironment& env, BotBaseContext& context, 
-    MaterialFarmerOptions& options, MaterialFarmer_Descriptor::Stats& stats
+    MaterialFarmerOptions& options, MaterialFarmerTools::Stats& stats
 ){
     
     LetsGoEncounterBotTracker encounter_tracker(
@@ -271,7 +256,7 @@ void run_one_sandwich_iteration(SingleSwitchProgramEnvironment& env, BotBaseCont
     LetsGoEncounterBotTracker& encounter_tracker, MaterialFarmerOptions& options)
 {
 
-    MaterialFarmer_Descriptor::Stats& stats = env.current_stats<MaterialFarmer_Descriptor::Stats>();
+    MaterialFarmerTools::Stats& stats = env.current_stats<MaterialFarmerTools::Stats>();
 
     WallClock last_sandwich_time = WallClock::min();
 

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.cpp
@@ -28,7 +28,6 @@
 #include "PokemonSV/Programs/Battles/PokemonSV_Battles.h"
 #include "PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.h"
 #include "PokemonSV/Programs/ShinyHunting/PokemonSV_LetsGoTools.h"
-#include "PokemonSV_MaterialFarmer.h"
 #include "PokemonSV_MaterialFarmerTools.h"
 #include "PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-Scatterbug.h"
 #include "NintendoSwitch/Programs/NintendoSwitch_SnapshotDumper.h"
@@ -192,11 +191,27 @@ MaterialFarmerOptions::MaterialFarmerOptions(
     }
 }
 
+MaterialFarmer_Descriptor::MaterialFarmer_Descriptor()
+    : SingleSwitchProgramDescriptor(
+        "PokemonSV:MaterialFarmer",
+        STRING_POKEMON + " SV", "Material Farmer",
+        "ComputerControl/blob/master/Wiki/Programs/PokemonSV/MaterialFarmer.md",
+        "Farm materials - Happiny dust from Chanseys/Blisseys, for Item Printer.",
+        FeedbackType::VIDEO_AUDIO,
+        AllowCommandsWhenRunning::DISABLE_COMMANDS,
+        PABotBaseLevel::PABOTBASE_12KB
+    )
+{}
 
-void run_material_farmer(SingleSwitchProgramEnvironment& env, BotBaseContext& context, MaterialFarmerOptions& options){
+std::unique_ptr<StatsTracker> MaterialFarmer_Descriptor::make_stats() const{
+    return std::unique_ptr<StatsTracker>(new Stats());
+}
+
+
+void run_material_farmer(SingleSwitchProgramEnvironment& env, BotBaseContext& context, 
+    MaterialFarmerOptions& options, MaterialFarmer_Descriptor::Stats& stats
+){
     
-    MaterialFarmer_Descriptor::Stats& stats = env.current_stats<MaterialFarmer_Descriptor::Stats>();
-
     LetsGoEncounterBotTracker encounter_tracker(
         env, env.console, context,
         stats,

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.cpp
@@ -194,7 +194,7 @@ MaterialFarmerOptions::MaterialFarmerOptions(
 
 
 void run_material_farmer(SingleSwitchProgramEnvironment& env, BotBaseContext& context, 
-    MaterialFarmerOptions& options, MaterialFarmerTools::Stats& stats
+    MaterialFarmerOptions& options, MaterialFarmerStats& stats
 ){
     
     LetsGoEncounterBotTracker encounter_tracker(
@@ -256,7 +256,7 @@ void run_one_sandwich_iteration(SingleSwitchProgramEnvironment& env, BotBaseCont
     LetsGoEncounterBotTracker& encounter_tracker, MaterialFarmerOptions& options)
 {
 
-    MaterialFarmerTools::Stats& stats = env.current_stats<MaterialFarmerTools::Stats>();
+    MaterialFarmerStats& stats = env.current_stats<MaterialFarmerStats>();
 
     WallClock last_sandwich_time = WallClock::min();
 

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.cpp
@@ -681,7 +681,7 @@ void move_from_blueberry_entrance_to_league_club(SingleSwitchProgramEnvironment&
         int ret = wait_until(env.console, context, Milliseconds(5000), { select_entrance });
         if (ret == 0){
             env.log("Blueberry navigation menu detected.");
-        } else {
+        }else{
             env.console.log("Failed to detect Blueberry navigation menu.");
             continue;
         }
@@ -695,7 +695,7 @@ void move_from_blueberry_entrance_to_league_club(SingleSwitchProgramEnvironment&
         ret = wait_until(env.console, context, Milliseconds(5000), { select_league_club });
         if (ret == 0){
             env.log("League club room selected.");
-        } else {
+        }else{
             env.console.log("Failed to select League club room in navigation menu.");
             continue;            
         }
@@ -707,7 +707,7 @@ void move_from_blueberry_entrance_to_league_club(SingleSwitchProgramEnvironment&
         ret = wait_until(env.console, context, Milliseconds(10000), { overworld });
         if (ret == 0){
             env.log("Entered League club room.");
-        } else {
+        }else{
             env.console.log("Failed to enter League club room from menu selection.");
             continue;            
         }
@@ -766,7 +766,7 @@ void move_from_item_printer_to_blueberry_entrance(SingleSwitchProgramEnvironment
     int ret = wait_until(env.console, context, Milliseconds(5000), { select_entrance }, Milliseconds(1000));
     if (ret == 0){
         env.log("Blueberry navigation menu detected.");
-    } else {
+    }else{
         env.console.log("Failed to detect Blueberry navigation menu.");
         throw OperationFailedException(
             ErrorReport::SEND_ERROR_REPORT, env.console,
@@ -783,7 +783,7 @@ void move_from_item_printer_to_blueberry_entrance(SingleSwitchProgramEnvironment
     ret = wait_until(env.console, context, Milliseconds(10000), { overworld });
     if (ret == 0){
         env.log("Overworld detected");
-    } else {
+    }else{
         throw OperationFailedException(
             ErrorReport::SEND_ERROR_REPORT, env.console,
             "Failed to detect overworld.",

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.h
@@ -83,7 +83,32 @@ private:
     );
 };
 
-void run_material_farmer(SingleSwitchProgramEnvironment& env, BotBaseContext& context, MaterialFarmerOptions& options);
+class MaterialFarmer_Descriptor : public SingleSwitchProgramDescriptor{
+public:
+    MaterialFarmer_Descriptor();
+
+    struct Stats : public LetsGoEncounterBotStats{
+        Stats()
+            : m_sandwiches(m_stats["Sandwiches"])
+            , m_autoheals(m_stats["Auto Heals"])
+            , m_game_resets(m_stats["Game Resets"])
+            , m_errors(m_stats["Errors"])
+        {
+            m_display_order.insert(m_display_order.begin() + 2, {"Sandwiches", HIDDEN_IF_ZERO});
+            m_display_order.insert(m_display_order.begin() + 3, {"Auto Heals", HIDDEN_IF_ZERO});
+            m_display_order.insert(m_display_order.begin() + 4, {"Game Resets", HIDDEN_IF_ZERO});
+            m_display_order.insert(m_display_order.begin() + 5, {"Errors", HIDDEN_IF_ZERO});
+        }
+        std::atomic<uint64_t>& m_sandwiches;
+        std::atomic<uint64_t>& m_autoheals;
+        std::atomic<uint64_t>& m_game_resets;
+        std::atomic<uint64_t>& m_errors;
+    };
+    virtual std::unique_ptr<StatsTracker> make_stats() const override;
+};
+
+void run_material_farmer(SingleSwitchProgramEnvironment& env, BotBaseContext& context, 
+    MaterialFarmerOptions& options, MaterialFarmer_Descriptor::Stats& stats);
 
 void run_one_sandwich_iteration(SingleSwitchProgramEnvironment& env, BotBaseContext& context, 
     LetsGoEncounterBotTracker& encounter_tracker, MaterialFarmerOptions& options);

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.h
@@ -24,6 +24,28 @@ namespace PokemonAutomation{
 namespace NintendoSwitch{
 namespace PokemonSV{
 
+
+class MaterialFarmerTools {
+public:
+    struct Stats : public LetsGoEncounterBotStats{
+        Stats()
+            : m_sandwiches(m_stats["Sandwiches"])
+            , m_autoheals(m_stats["Auto Heals"])
+            , m_game_resets(m_stats["Game Resets"])
+            , m_errors(m_stats["Errors"])
+        {
+            m_display_order.insert(m_display_order.begin() + 2, {"Sandwiches", HIDDEN_IF_ZERO});
+            m_display_order.insert(m_display_order.begin() + 3, {"Auto Heals", HIDDEN_IF_ZERO});
+            m_display_order.insert(m_display_order.begin() + 4, {"Game Resets", HIDDEN_IF_ZERO});
+            m_display_order.insert(m_display_order.begin() + 5, {"Errors", HIDDEN_IF_ZERO});
+        }
+        std::atomic<uint64_t>& m_sandwiches;
+        std::atomic<uint64_t>& m_autoheals;
+        std::atomic<uint64_t>& m_game_resets;
+        std::atomic<uint64_t>& m_errors;
+    };
+};
+
 class MaterialFarmerOptions : public GroupOption{
 public:
     MaterialFarmerOptions()
@@ -83,32 +105,10 @@ private:
     );
 };
 
-class MaterialFarmer_Descriptor : public SingleSwitchProgramDescriptor{
-public:
-    MaterialFarmer_Descriptor();
 
-    struct Stats : public LetsGoEncounterBotStats{
-        Stats()
-            : m_sandwiches(m_stats["Sandwiches"])
-            , m_autoheals(m_stats["Auto Heals"])
-            , m_game_resets(m_stats["Game Resets"])
-            , m_errors(m_stats["Errors"])
-        {
-            m_display_order.insert(m_display_order.begin() + 2, {"Sandwiches", HIDDEN_IF_ZERO});
-            m_display_order.insert(m_display_order.begin() + 3, {"Auto Heals", HIDDEN_IF_ZERO});
-            m_display_order.insert(m_display_order.begin() + 4, {"Game Resets", HIDDEN_IF_ZERO});
-            m_display_order.insert(m_display_order.begin() + 5, {"Errors", HIDDEN_IF_ZERO});
-        }
-        std::atomic<uint64_t>& m_sandwiches;
-        std::atomic<uint64_t>& m_autoheals;
-        std::atomic<uint64_t>& m_game_resets;
-        std::atomic<uint64_t>& m_errors;
-    };
-    virtual std::unique_ptr<StatsTracker> make_stats() const override;
-};
 
 void run_material_farmer(SingleSwitchProgramEnvironment& env, BotBaseContext& context, 
-    MaterialFarmerOptions& options, MaterialFarmer_Descriptor::Stats& stats);
+    MaterialFarmerOptions& options, MaterialFarmerTools::Stats& stats);
 
 void run_one_sandwich_iteration(SingleSwitchProgramEnvironment& env, BotBaseContext& context, 
     LetsGoEncounterBotTracker& encounter_tracker, MaterialFarmerOptions& options);

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.h
@@ -25,25 +25,22 @@ namespace NintendoSwitch{
 namespace PokemonSV{
 
 
-class MaterialFarmerTools {
-public:
-    struct Stats : public LetsGoEncounterBotStats{
-        Stats()
-            : m_sandwiches(m_stats["Sandwiches"])
-            , m_autoheals(m_stats["Auto Heals"])
-            , m_game_resets(m_stats["Game Resets"])
-            , m_errors(m_stats["Errors"])
-        {
-            m_display_order.insert(m_display_order.begin() + 2, {"Sandwiches", HIDDEN_IF_ZERO});
-            m_display_order.insert(m_display_order.begin() + 3, {"Auto Heals", HIDDEN_IF_ZERO});
-            m_display_order.insert(m_display_order.begin() + 4, {"Game Resets", HIDDEN_IF_ZERO});
-            m_display_order.insert(m_display_order.begin() + 5, {"Errors", HIDDEN_IF_ZERO});
-        }
-        std::atomic<uint64_t>& m_sandwiches;
-        std::atomic<uint64_t>& m_autoheals;
-        std::atomic<uint64_t>& m_game_resets;
-        std::atomic<uint64_t>& m_errors;
-    };
+struct MaterialFarmerStats : public LetsGoEncounterBotStats{
+    MaterialFarmerStats()
+        : m_sandwiches(m_stats["Sandwiches"])
+        , m_autoheals(m_stats["Auto Heals"])
+        , m_game_resets(m_stats["Game Resets"])
+        , m_errors(m_stats["Errors"])
+    {
+        m_display_order.insert(m_display_order.begin() + 2, {"Sandwiches", HIDDEN_IF_ZERO});
+        m_display_order.insert(m_display_order.begin() + 3, {"Auto Heals", HIDDEN_IF_ZERO});
+        m_display_order.insert(m_display_order.begin() + 4, {"Game Resets", HIDDEN_IF_ZERO});
+        m_display_order.insert(m_display_order.begin() + 5, {"Errors", HIDDEN_IF_ZERO});
+    }
+    std::atomic<uint64_t>& m_sandwiches;
+    std::atomic<uint64_t>& m_autoheals;
+    std::atomic<uint64_t>& m_game_resets;
+    std::atomic<uint64_t>& m_errors;
 };
 
 class MaterialFarmerOptions : public GroupOption{
@@ -108,7 +105,7 @@ private:
 
 
 void run_material_farmer(SingleSwitchProgramEnvironment& env, BotBaseContext& context, 
-    MaterialFarmerOptions& options, MaterialFarmerTools::Stats& stats);
+    MaterialFarmerOptions& options, MaterialFarmerStats& stats);
 
 void run_one_sandwich_iteration(SingleSwitchProgramEnvironment& env, BotBaseContext& context, 
     LetsGoEncounterBotTracker& encounter_tracker, MaterialFarmerOptions& options);

--- a/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.cpp
@@ -1265,7 +1265,7 @@ void ItemPrinterRNG::program(SingleSwitchProgramEnvironment& env, BotBaseContext
         audio_detector.throw_if_no_sound(std::chrono::milliseconds(1000));
 
         // Don't allow the material farmer stats to affect the Item Printer's stats.
-        MaterialFarmerTools::Stats mat_farm_stats;// = env.current_stats<MaterialFarmer_Descriptor::Stats>();
+        MaterialFarmerStats mat_farm_stats;// = env.current_stats<MaterialFarmer_Descriptor::Stats>();
         for (int i = 0; i < NUM_ROUNDS_OF_ITEM_PRINTER_TO_MATERIAL_FARM; i++){
             run_item_printer_rng(env, context, stats);
             press_Bs_to_back_to_overworld(env.program_info(), env.console, context);

--- a/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.cpp
@@ -521,7 +521,7 @@ ItemPrinterRNG::ItemPrinterRNG()
         true
     )
     , TOTAL_ROUNDS(
-         "<b>Total Rounds per item printer session:</b><br>Iterate the rounds table this many times. "
+        "<b>Total Rounds per item printer session:</b><br>Iterate the rounds table this many times. "
         "Then stop the program, or proceed to material farming (if enabled).",
         LockMode::UNLOCK_WHILE_RUNNING, 10
     )
@@ -1249,11 +1249,13 @@ void ItemPrinterRNG::program(SingleSwitchProgramEnvironment& env, BotBaseContext
         );
         audio_detector.throw_if_no_sound(std::chrono::milliseconds(1000));
 
+        // Don't allow the material farmer stats to affect the Item Printer's stats.
+        MaterialFarmer_Descriptor::Stats mat_farm_stats;// = env.current_stats<MaterialFarmer_Descriptor::Stats>();
         for (int i = 0; i < NUM_MATERIAL_FARM_ROUNDS; i++){
             run_item_printer_rng(env, context, stats);
             press_Bs_to_back_to_overworld(env.program_info(), env.console, context);
             move_from_item_printer_to_material_farming(env, context);
-            run_material_farmer(env, context, MATERIAL_FARMER_OPTIONS);
+            run_material_farmer(env, context, MATERIAL_FARMER_OPTIONS, mat_farm_stats);
             move_from_material_farming_to_item_printer(env, context);
         }
 

--- a/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.cpp
@@ -1265,7 +1265,7 @@ void ItemPrinterRNG::program(SingleSwitchProgramEnvironment& env, BotBaseContext
         audio_detector.throw_if_no_sound(std::chrono::milliseconds(1000));
 
         // Don't allow the material farmer stats to affect the Item Printer's stats.
-        MaterialFarmer_Descriptor::Stats mat_farm_stats;// = env.current_stats<MaterialFarmer_Descriptor::Stats>();
+        MaterialFarmerTools::Stats mat_farm_stats;// = env.current_stats<MaterialFarmer_Descriptor::Stats>();
         for (int i = 0; i < NUM_ROUNDS_OF_ITEM_PRINTER_TO_MATERIAL_FARM; i++){
             run_item_printer_rng(env, context, stats);
             press_Bs_to_back_to_overworld(env.program_info(), env.console, context);

--- a/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.h
@@ -106,7 +106,8 @@ private:
 
 private:
     OCR::LanguageOCROption LANGUAGE;
-    SimpleIntegerOption<uint16_t> TOTAL_ROUNDS;
+    SimpleIntegerOption<uint16_t> NUM_ITEM_PRINTER_ROUNDS;
+    StaticTextOption AFTER_ITEM_PRINTER_DONE_EXPLANATION;
 
 //    DateTimeOption DATE0;
 //    DateTimeOption DATE1;
@@ -119,11 +120,12 @@ private:
     BooleanCheckBoxOption FIX_TIME_WHEN_DONE;
 
     BooleanCheckBoxOption AUTO_MATERIAL_FARMING;
-    SimpleIntegerOption<uint16_t> NUM_MATERIAL_FARM_ROUNDS;
+    SimpleIntegerOption<uint16_t> NUM_ROUNDS_OF_ITEM_PRINTER_TO_MATERIAL_FARM;
     
     EventNotificationOption NOTIFICATION_STATUS_UPDATE;
     EventNotificationsOption NOTIFICATIONS;
     
+    StaticTextOption MATERIAL_FARMER_DISABLED_EXPLANATION;
     MaterialFarmerOptions MATERIAL_FARMER_OPTIONS;
 };
 

--- a/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.h
@@ -16,6 +16,7 @@
 #include "NintendoSwitch/NintendoSwitch_SingleSwitchProgram.h"
 #include "NintendoSwitch/Options/NintendoSwitch_GoHomeWhenDoneOption.h"
 #include "PokemonSV_ItemPrinterTools.h"
+#include "PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
@@ -64,14 +65,19 @@ public:
     virtual std::unique_ptr<StatsTracker> make_stats() const override;
 };
 
-class ItemPrinterRNG : public SingleSwitchProgramInstance{
+class ItemPrinterRNG : public SingleSwitchProgramInstance, public ConfigOption::Listener{
 public:
+    ~ItemPrinterRNG();
     ItemPrinterRNG();
 
     virtual void program(SingleSwitchProgramEnvironment& env, BotBaseContext& context) override;
 
 
 private:
+    virtual void value_changed() override;
+
+    void run_item_printer_rng(SingleSwitchProgramEnvironment& env, BotBaseContext& context, ItemPrinterRNG_Descriptor::Stats& stats);
+
     void run_print_at_date(
         SingleSwitchProgramEnvironment& env, BotBaseContext& context,
         const DateTime& date, ItemPrinterJobs jobs
@@ -112,8 +118,13 @@ private:
     GoHomeWhenDoneOption GO_HOME_WHEN_DONE;
     BooleanCheckBoxOption FIX_TIME_WHEN_DONE;
 
+    BooleanCheckBoxOption AUTO_MATERIAL_FARMING;
+    SimpleIntegerOption<uint16_t> NUM_MATERIAL_FARM_ROUNDS;
+    
     EventNotificationOption NOTIFICATION_STATUS_UPDATE;
     EventNotificationsOption NOTIFICATIONS;
+    
+    MaterialFarmerOptions MATERIAL_FARMER_OPTIONS;
 };
 
 


### PR DESCRIPTION
Adds a material farming sequence to the item printer. Will automatically fly back and forth between the material farming location and the item printer. It can potentially allow you to use the item printer for days at a time, without intervention. From my testing, the main source of failure/errors is the sandwich maker.

Includes code from #423, and #432 so I recommend merging those first. 

EDIT:
Now only #432 needs to be merged first.

EDIT 2:
#433 needs to be merged first.

EDIT 3:
Now ready for merging.