### PR TITLE
Fix egg detection on dark images

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxEggDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxEggDetector.cpp
@@ -76,7 +76,9 @@ void BoxEggDetector::make_overlays(VideoOverlaySet& items) const{
 
 bool BoxEggDetector::detect(const ImageViewRGB32& frame) const{
     const std::vector<std::pair<uint32_t, uint32_t>> filters = {
-        {combine_rgb(200, 200, 200), combine_rgb(255, 255, 255)}
+        {combine_rgb(200, 200, 200), combine_rgb(255, 255, 255)},
+        {combine_rgb(180, 180, 180), combine_rgb(255, 255, 255)} // for darker capture cards
+
     };
 
     const double screen_rel_size = (frame.height() / 1080.0);


### PR DESCRIPTION
Added a broader color filter to handle darker capture cards.
I didn't just replace the old filter in case it the narrower filter was needed for capture cards with bright settings. I also noticed that the RMSD did get worse for some of the test images when I only used the broader color filter.