### PR TITLE
Make VideoSnapshot more safe against immediate conversion to ImageView.

### DIFF
--- a/SerialPrograms/Source/CommonFramework/Inference/VisualDetector.h
+++ b/SerialPrograms/Source/CommonFramework/Inference/VisualDetector.h
@@ -7,6 +7,7 @@
 #ifndef PokemonAutomation_CommonFramework_VisualDetector_H
 #define PokemonAutomation_CommonFramework_VisualDetector_H
 
+#include "CommonFramework/VideoPipeline/VideoFeed.h"
 #include "CommonFramework/InferenceInfra/VisualInferenceCallback.h"
 
 namespace PokemonAutomation{
@@ -20,6 +21,9 @@ public:
     virtual ~StaticScreenDetector() = default;
     virtual void make_overlays(VideoOverlaySet& items) const = 0;
     virtual bool detect(const ImageViewRGB32& screen) const = 0;
+    virtual bool detect(const VideoSnapshot& snapshot) const{
+        return detect((ImageViewRGB32)snapshot);
+    }
 };
 
 

--- a/SerialPrograms/Source/CommonFramework/Tools/ErrorDumper.cpp
+++ b/SerialPrograms/Source/CommonFramework/Tools/ErrorDumper.cpp
@@ -54,6 +54,14 @@ std::string dump_image(
     );
     return name;
 }
+std::string dump_image(
+    const ProgramInfo& program_info,
+    ConsoleHandle& console,
+    const std::string& label
+){
+    auto snapshot = console.video().snapshot();
+    return dump_image(console, program_info, label, snapshot);
+}
 
 #if 0
 void dump_image_and_throw_recoverable_exception(

--- a/SerialPrograms/Source/CommonFramework/Tools/ErrorDumper.h
+++ b/SerialPrograms/Source/CommonFramework/Tools/ErrorDumper.h
@@ -16,6 +16,7 @@ class ConsoleHandle;
 class EventNotificationOption;
 class ImageViewRGB32;
 class Logger;
+struct VideoSnapshot;
 class ProgramEnvironment;
 struct ProgramInfo;
 
@@ -30,6 +31,11 @@ std::string dump_image(
     Logger& logger,
     const ProgramInfo& program_info, const std::string& label,
     const ImageViewRGB32& image
+);
+std::string dump_image(
+    const ProgramInfo& program_info,
+    ConsoleHandle& console,
+    const std::string& label
 );
 
 #if 0

--- a/SerialPrograms/Source/CommonFramework/Tools/VideoResolutionCheck.cpp
+++ b/SerialPrograms/Source/CommonFramework/Tools/VideoResolutionCheck.cpp
@@ -26,7 +26,8 @@ void assert_16_9_720p_min(Logger& logger, const ImageViewRGB32& frame){
     }
 }
 void assert_16_9_720p_min(Logger& logger, ConsoleHandle& console){
-    assert_16_9_720p_min(logger, console.video().snapshot());
+    auto snapshot = console.video().snapshot();
+    assert_16_9_720p_min(logger, snapshot);
 }
 
 void assert_16_9_1080p_min(Logger& logger, const ImageViewRGB32& frame){
@@ -42,7 +43,8 @@ void assert_16_9_1080p_min(Logger& logger, const ImageViewRGB32& frame){
     }
 }
 void assert_16_9_1080p_min(Logger& logger, ConsoleHandle& console){
-    assert_16_9_1080p_min(logger, console.video().snapshot());
+    auto snapshot = console.video().snapshot();
+    assert_16_9_1080p_min(logger, snapshot);
 }
 
 

--- a/SerialPrograms/Source/CommonFramework/VideoPipeline/VideoFeed.h
+++ b/SerialPrograms/Source/CommonFramework/VideoPipeline/VideoFeed.h
@@ -37,7 +37,8 @@ struct VideoSnapshot{
     const ImageRGB32* operator->() const{ return frame.get(); }
 
     operator std::shared_ptr<const ImageRGB32>() const{ return frame; }
-    operator ImageViewRGB32() const{ return *frame; }
+    operator ImageViewRGB32() const&{ return *frame; }
+    operator ImageViewRGB32() && = delete;
 
     void clear(){
         frame.reset();

--- a/SerialPrograms/Source/NintendoSwitch/Inference/NintendoSwitch_DetectHome.h
+++ b/SerialPrograms/Source/NintendoSwitch/Inference/NintendoSwitch_DetectHome.h
@@ -22,6 +22,7 @@ public:
 
     virtual void make_overlays(VideoOverlaySet& items) const override;
     virtual bool detect(const ImageViewRGB32& screen) const override;
+    using StaticScreenDetector::detect;
 
 private:
     ImageFloatBox m_bottom_row;

--- a/SerialPrograms/Source/PokemonBDSP/Inference/PokemonBDSP_DialogDetector.h
+++ b/SerialPrograms/Source/PokemonBDSP/Inference/PokemonBDSP_DialogDetector.h
@@ -24,6 +24,7 @@ public:
 
     virtual void make_overlays(VideoOverlaySet& items) const override;
     virtual bool detect(const ImageViewRGB32& screen) const override;
+    using StaticScreenDetector::detect;
 
 private:
     Color m_color;

--- a/SerialPrograms/Source/PokemonBDSP/Programs/Glitches/PokemonBDSP_CloneItemsBoxCopy2.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/Glitches/PokemonBDSP_CloneItemsBoxCopy2.cpp
@@ -173,7 +173,8 @@ void CloneItemsBoxCopy2::program(SingleSwitchProgramEnvironment& env, BotBaseCon
 
         context.wait_for_all_requests();
         context.wait_for(std::chrono::milliseconds(500));
-        if (!matcher.detect(env.console.video().snapshot())){
+        auto snapshot = env.console.video().snapshot();
+        if (!matcher.detect(snapshot)){
             stats.m_errors++;
             throw OperationFailedException(
                 ErrorReport::SEND_ERROR_REPORT, env.console,

--- a/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_BasicCatcher.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_BasicCatcher.cpp
@@ -28,7 +28,11 @@ int move_to_ball(
     const std::string& ball_slug,
     bool forward, int attempts, uint16_t delay
 ){
-    std::string first_ball = reader.read_ball(console.video().snapshot());
+    std::string first_ball;
+    {
+        auto snapshot = console.video().snapshot();
+        first_ball = reader.read_ball(snapshot);
+    }
     if (first_ball == ball_slug){
         return 0;
     }
@@ -37,7 +41,8 @@ int move_to_ball(
     for (int c = 1; c < attempts; c++){
         pbf_press_dpad(context, forward ? DPAD_RIGHT : DPAD_LEFT, 10, delay);
         context.wait_for_all_requests();
-        std::string current_ball = reader.read_ball(console.video().snapshot());
+        auto snapshot = console.video().snapshot();
+        std::string current_ball = reader.read_ball(snapshot);
         if (current_ball == ball_slug){
             return c;
         }
@@ -65,7 +70,8 @@ int16_t move_to_ball(
         return 0;
     }
     if (ret == 0){
-        uint16_t quantity = reader.read_quantity(console.video().snapshot());
+        auto snapshot = console.video().snapshot();
+        uint16_t quantity = reader.read_quantity(snapshot);
         return quantity == 0 ? -1 : quantity;
     }
 
@@ -80,10 +86,13 @@ int16_t move_to_ball(
         return 0;
     }
     if (ret > 0){
-        console.log("BasicCatcher: Fast ball scrolling overshot by " +
-            std::to_string(ret) + " slot(s).", COLOR_RED);
+        console.log(
+            "BasicCatcher: Fast ball scrolling overshot by " +
+            std::to_string(ret) + " slot(s).", COLOR_RED
+        );
     }
-    uint16_t quantity = reader.read_quantity(console.video().snapshot());
+    auto snapshot = console.video().snapshot();
+    uint16_t quantity = reader.read_quantity(snapshot);
     return quantity == 0 ? -1 : quantity;
 }
 

--- a/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_GameEntry.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/PokemonBDSP_GameEntry.cpp
@@ -58,7 +58,7 @@ bool openedgame_to_ingame(
     ok &= openedgame_to_gamemenu(console, context, load_game_timeout);
     ok &= gamemenu_to_ingame(console, context, mash_duration, enter_game_timeout);
     if (!ok){
-        dump_image(console.logger(), env.program_info(), "StartGame", console.video().snapshot());
+        dump_image(env.program_info(), console, "StartGame");
     }
     console.log("Entered game! Waiting out grace period.");
     pbf_wait(context, post_wait_time);

--- a/SerialPrograms/Source/PokemonBDSP/Programs/ShinyHunting/PokemonBDSP_StarterReset.cpp
+++ b/SerialPrograms/Source/PokemonBDSP/Programs/ShinyHunting/PokemonBDSP_StarterReset.cpp
@@ -151,7 +151,7 @@ void StarterReset::program(SingleSwitchProgramEnvironment& env, BotBaseContext& 
             env.log("Timed out waiting for briefcase.", COLOR_RED);
             stats.add_error();
             consecutive_failures++;
-            dump_image(env.logger(), env.program_info(), "Briefcase", env.console.video().snapshot());
+            dump_image(env.program_info(), env.console, "Briefcase");
             continue;
         }
 
@@ -212,7 +212,7 @@ void StarterReset::program(SingleSwitchProgramEnvironment& env, BotBaseContext& 
         if (result_own.shiny_type == ShinyType::UNKNOWN){
             stats.add_error();
             consecutive_failures++;
-            dump_image(env.logger(), env.program_info(), "UnknownShinyDetection", env.console.video().snapshot());
+            dump_image(env.program_info(), env.console, "UnknownShinyDetection");
         }else{
             consecutive_failures = 0;
         }

--- a/SerialPrograms/Source/PokemonLA/Inference/Map/PokemonLA_OutbreakReader.cpp
+++ b/SerialPrograms/Source/PokemonLA/Inference/Map/PokemonLA_OutbreakReader.cpp
@@ -7,6 +7,7 @@
 #include "CommonFramework/Notifications/ProgramNotifications.h"
 #include "CommonFramework/ImageTypes/ImageViewRGB32.h"
 #include "CommonFramework/ImageTools/ImageStats.h"
+#include "CommonFramework/VideoPipeline/VideoFeed.h"
 //#include "CommonFramework/Tools/ErrorDumper.h"
 #include "Pokemon/Inference/Pokemon_NameReader.h"
 #include "PokemonLA_OutbreakReader.h"
@@ -45,6 +46,10 @@ OCR::StringMatchResult OutbreakReader::read(const ImageViewRGB32& screen) const{
 //    }
 
     return result;
+}
+
+OCR::StringMatchResult OutbreakReader::read(const VideoSnapshot& snapshot) const{
+    return read((ImageViewRGB32)snapshot);
 }
 
 

--- a/SerialPrograms/Source/PokemonLA/Inference/Map/PokemonLA_OutbreakReader.h
+++ b/SerialPrograms/Source/PokemonLA/Inference/Map/PokemonLA_OutbreakReader.h
@@ -15,6 +15,7 @@
 #include "CommonFramework/OCR/OCR_StringMatchResult.h"
 
 namespace PokemonAutomation{
+    struct VideoSnapshot;
 namespace NintendoSwitch{
 namespace PokemonLA{
 
@@ -24,6 +25,7 @@ public:
     OutbreakReader(Logger& logger, Language language, VideoOverlay& overlay);
 
     OCR::StringMatchResult read(const ImageViewRGB32& screen) const;
+    OCR::StringMatchResult read(const VideoSnapshot& snapshot) const;
 
 
 private:

--- a/SerialPrograms/Source/PokemonLA/Options/PokemonLA_ShinyDetectedAction.cpp
+++ b/SerialPrograms/Source/PokemonLA/Options/PokemonLA_ShinyDetectedAction.cpp
@@ -105,12 +105,13 @@ bool on_shiny_callback(
     ss << "Error Coefficient: " << error_coefficient << "\n(Shiny may not be visible on the screen.)";
     embeds.emplace_back("Detection Results:", ss.str());
 
+    auto snapshot = console.video().snapshot();
     send_program_notification(
         env, options.NOTIFICATIONS,
         Pokemon::COLOR_STAR_SHINY,
         "Detected Shiny Sound",
         embeds, "",
-        console.video().snapshot(), true
+        snapshot, true
     );
     return false;
 }
@@ -131,12 +132,13 @@ void on_shiny_sound(
     pbf_mash_button(context, BUTTON_ZL, options.SCREENSHOT_DELAY);
     context.wait_for_all_requests();
 
+    auto snapshot = console.video().snapshot();
     send_program_notification(
         env, options.NOTIFICATIONS,
         Pokemon::COLOR_STAR_SHINY,
         "Detected Shiny Sound",
         embeds, "",
-        console.video().snapshot(), true
+        snapshot, true
     );
 
     ShinyDetectedAction action = options.ACTION;
@@ -158,13 +160,16 @@ void on_match_found(
     pbf_mash_button(context, BUTTON_ZL, options.SCREENSHOT_DELAY);
     context.wait_for_all_requests();
 
-    send_program_notification(
-        env, options.NOTIFICATIONS,
-        Pokemon::COLOR_STAR_SHINY,
-        "Match Found",
-        embeds, "",
-        console.video().snapshot(), true
-    );
+    {
+        auto snapshot = console.video().snapshot();
+        send_program_notification(
+            env, options.NOTIFICATIONS,
+            Pokemon::COLOR_STAR_SHINY,
+            "Match Found",
+            embeds, "",
+            snapshot, true
+        );
+    }
 
     ShinyDetectedAction action = options.ACTION;
     if (action == ShinyDetectedAction::TAKE_VIDEO_STOP_PROGRAM){

--- a/SerialPrograms/Source/PokemonLA/Programs/Farming/PokemonLA_IngoBattleGrinder.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/Farming/PokemonLA_IngoBattleGrinder.cpp
@@ -245,11 +245,12 @@ bool IngoBattleGrinder::run_iteration(SingleSwitchProgramEnvironment& env, BotBa
         );
         if (ret < 0){
             env.console.log("Error: Failed to find battle menu after 2 minutes.");
-            dump_image(env.logger(), env.program_info(), "BattleMenuNotFound", env.console.video().snapshot());
+            auto snapshot = env.console.video().snapshot();
+            dump_image(env.logger(), env.program_info(), "BattleMenuNotFound", snapshot);
             throw OperationFailedException(
                 ErrorReport::SEND_ERROR_REPORT, env.console,
                 "Failed to find battle menu after 2 minutes.",
-                true
+                std::move(snapshot)
             );
         }
 

--- a/SerialPrograms/Source/PokemonLA/Programs/Farming/PokemonLA_IngoMoveGrinder.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/Farming/PokemonLA_IngoMoveGrinder.cpp
@@ -211,11 +211,12 @@ bool IngoMoveGrinder::run_iteration(SingleSwitchProgramEnvironment& env, BotBase
         );
         if (ret < 0){
             env.console.log("Error: Failed to find battle menu after 2 minutes.");
-            dump_image(env.logger(), env.program_info(), "BattleMenuNotFound", env.console.video().snapshot());
+            auto snapshot = env.console.video().snapshot();
+            dump_image(env.logger(), env.program_info(), "BattleMenuNotFound", snapshot);
             throw OperationFailedException(
                 ErrorReport::SEND_ERROR_REPORT, env.console,
                 "Failed to find battle menu after 2 minutes.",
-                true
+                std::move(snapshot)
             );
         }
 

--- a/SerialPrograms/Source/PokemonLA/Programs/Farming/PokemonLA_LeapGrinder.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/Farming/PokemonLA_LeapGrinder.cpp
@@ -148,7 +148,8 @@ bool LeapGrinder::run_iteration(SingleSwitchProgramEnvironment& env, BotBaseCont
 
     for (size_t c = 0; true; c++){
         context.wait_for_all_requests();
-        if (is_pokemon_selection(env.console, env.console.video().snapshot())){
+        auto snapshot = env.console.video().snapshot();
+        if (is_pokemon_selection(env.console, snapshot)){
             break;
         }
         if (c >= 5){

--- a/SerialPrograms/Source/PokemonLA/Programs/Farming/PokemonLA_MagikarpMoveGrinder.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/Farming/PokemonLA_MagikarpMoveGrinder.cpp
@@ -106,11 +106,12 @@ void MagikarpMoveGrinder::grind_mimic(SingleSwitchProgramEnvironment& env, BotBa
         );
         if (ret < 0){
             env.console.log("Error: Failed to find battle menu after 2 minutes.");
-            dump_image(env.logger(), env.program_info(), "BattleMenuNotFound", env.console.video().snapshot());
+            auto snapshot = env.console.video().snapshot();
+            dump_image(env.logger(), env.program_info(), "BattleMenuNotFound", snapshot);
             throw OperationFailedException(
                 ErrorReport::SEND_ERROR_REPORT, env.console,
                 "Failed to find battle menu after 2 minutes.",
-                true
+                std::move(snapshot)
             );
         }
 
@@ -176,11 +177,12 @@ void MagikarpMoveGrinder::battle_magikarp(SingleSwitchProgramEnvironment& env, B
         );
         if (ret < 0){
             env.console.log("Error: Failed to find battle menu after 2 minutes.");
-            dump_image(env.logger(), env.program_info(), "BattleMenuNotFound", env.console.video().snapshot());
+            auto snapshot = env.console.video().snapshot();
+            dump_image(env.logger(), env.program_info(), "BattleMenuNotFound", snapshot);
             throw OperationFailedException(
                 ErrorReport::SEND_ERROR_REPORT, env.console,
                 "Failed to find battle menu after 2 minutes.",
-                true
+                std::move(snapshot)
             );
         }
 

--- a/SerialPrograms/Source/PokemonLA/Programs/General/PokemonLA_DistortionWaiter.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/General/PokemonLA_DistortionWaiter.cpp
@@ -140,12 +140,13 @@ void DistortionWaiter::program(SingleSwitchProgramEnvironment& env, BotBaseConte
 
     env.update_stats();
 
+    auto snapshot = env.console.video().snapshot();
     send_program_notification(
         env, NOTIFICATION_DISTORTION,
         COLOR_GREEN,
         "Found Distortion",
         {}, "",
-        env.console.video().snapshot()
+        snapshot
     );
     pbf_press_button(context, BUTTON_HOME, 20, GameSettings::instance().GAME_TO_HOME_DELAY);
 }

--- a/SerialPrograms/Source/PokemonLA/Programs/General/PokemonLA_OutbreakFinder.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/General/PokemonLA_OutbreakFinder.cpp
@@ -245,7 +245,11 @@ std::set<std::string> OutbreakFinder::read_travel_map_outbreaks(
 
     MMOQuestionMarkDetector question_mark_detector(env.logger());
     VideoOverlaySet mmo_overlay_set(env.console);
-    std::array<bool, 5> mmo_appears = question_mark_detector.detect_MMO_on_hisui_map(env.console.video().snapshot());
+    std::array<bool, 5> mmo_appears;
+    {
+        auto snapshot = env.console.video().snapshot();
+        mmo_appears = question_mark_detector.detect_MMO_on_hisui_map(snapshot);
+    }
     add_hisui_MMO_detection_to_overlay(mmo_appears, mmo_overlay_set);
 
     // If the current region is a wild area, the yellow cursor may overlap with the MMO question marker, causing
@@ -255,7 +259,8 @@ std::set<std::string> OutbreakFinder::read_travel_map_outbreaks(
         size_t current_wild_area_index = (int)current_region - 2;
         pbf_press_dpad(context, DPAD_RIGHT, 20, 40);
         context.wait_for_all_requests();
-        auto new_mmo_read = question_mark_detector.detect_MMO_on_hisui_map(env.console.video().snapshot());
+        auto snapshot = env.console.video().snapshot();
+        auto new_mmo_read = question_mark_detector.detect_MMO_on_hisui_map(snapshot);
         mmo_appears[current_wild_area_index] = new_mmo_read[current_wild_area_index];
         if (new_mmo_read[current_wild_area_index]){
             add_hisui_MMO_detection_to_overlay(mmo_appears, mmo_overlay_set);
@@ -358,11 +363,12 @@ void OutbreakFinder::goto_region_and_return(SingleSwitchProgramEnvironment& env,
         context.wait_for_all_requests();
     }
     if (is_wild_land(current_region) == false){
-        dump_image(env.console.logger(), env.program_info(), "FindRegion", env.console.video().snapshot());
+        auto snapshot = env.console.video().snapshot();
+        dump_image(env.console.logger(), env.program_info(), "FindRegion", snapshot);
         throw OperationFailedException(
             ErrorReport::SEND_ERROR_REPORT, env.console,
             "Unable to find a wild land.",
-            true
+            std::move(snapshot)
         );
     }
 
@@ -822,12 +828,13 @@ void OutbreakFinder::program(SingleSwitchProgramEnvironment& env, BotBaseContext
 
     env.update_stats();
 
+    auto snapshot = env.console.video().snapshot();
     send_program_notification(
         env, NOTIFICATION_MATCHED,
         COLOR_GREEN,
         "Found Outbreak",
         {}, "",
-        env.console.video().snapshot()
+        snapshot
     );
 
     GO_HOME_WHEN_DONE.run_end_of_program(context);

--- a/SerialPrograms/Source/PokemonLA/Programs/General/PokemonLA_PokedexTasksReader.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/General/PokemonLA_PokedexTasksReader.cpp
@@ -78,14 +78,12 @@ void PokedexTasksReader::program(SingleSwitchProgramEnvironment& env, BotBaseCon
 
     std::ofstream output_file("output.txt");
 
-    for (int i = 0; i < 242; ++i)
-    {
+    for (int i = 0; i < 242; ++i){
         PokemonTasksReader reader(env.console);
-        std::array<int, 9> tasks = reader.read_tasks(env.console.video().snapshot());
-        for (auto task : tasks)
-        {
-            if (task != -1)
-            {
+        auto snapshot = env.console.video().snapshot();
+        std::array<int, 9> tasks = reader.read_tasks(snapshot);
+        for (auto task : tasks){
+            if (task != -1){
                 output_file << task << "\n";
             }
         }

--- a/SerialPrograms/Source/PokemonLA/Programs/General/PokemonLA_RamanasIslandCombee.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/General/PokemonLA_RamanasIslandCombee.cpp
@@ -251,7 +251,8 @@ void RamanasCombeeFinder::run_iteration(SingleSwitchProgramEnvironment& env, Bot
 
     for (size_t c = 0; true; c++){
         context.wait_for_all_requests();
-        if (is_pokemon_selection(env.console, env.console.video().snapshot())){
+        auto snapshot = env.console.video().snapshot();
+        if (is_pokemon_selection(env.console, snapshot)){
             break;
         }
         if (c >= 5){

--- a/SerialPrograms/Source/PokemonLA/Programs/General/PokemonLA_SkipToFullMoon.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/General/PokemonLA_SkipToFullMoon.cpp
@@ -54,7 +54,11 @@ void SkipToFullMoon::program(SingleSwitchProgramEnvironment& env, BotBaseContext
         pbf_press_dpad(context, DPAD_UP, 20, 120);
         context.wait_for_all_requests();
 
-        const auto compatibility = detect_item_compatibility(env.console.video().snapshot());
+        ItemCompatibility compatibility;
+        {
+            auto snapshot = env.console.video().snapshot();
+            compatibility = detect_item_compatibility(snapshot);
+        }
 
         if (compatibility == ItemCompatibility::NONE){
             throw OperationFailedException(

--- a/SerialPrograms/Source/PokemonLA/Programs/PokemonLA_GameEntry.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/PokemonLA_GameEntry.cpp
@@ -84,7 +84,8 @@ bool reset_game_from_home(
     ok &= reset_game_to_gamemenu(console, context, tolerate_update_menu);
     ok &= gamemenu_to_ingame(console, context, GameSettings::instance().ENTER_GAME_MASH, GameSettings::instance().ENTER_GAME_WAIT);
     if (!ok){
-        dump_image(console.logger(), env.program_info(), "StartGame", console.video().snapshot());
+        auto snapshot = console.video().snapshot();
+        dump_image(env.program_info(), console, "StartGame");
     }
     console.log("Entered game! Waiting out grace period.");
     pbf_wait(context, post_wait_time);

--- a/SerialPrograms/Source/PokemonLA/Programs/PokemonLA_MountChange.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/PokemonLA_MountChange.cpp
@@ -60,7 +60,11 @@ void change_mount(ConsoleHandle& console, BotBaseContext& context, MountState mo
     for (size_t c = 0; c < 20; c++){
         context.wait_for_all_requests();
 
-        MountState current = mount_detector.detect(console.video().snapshot());
+        MountState current;
+        {
+            auto snapshot = console.video().snapshot();
+            current = mount_detector.detect(snapshot);
+        }
         if (mount == current){
             return;
         }
@@ -113,7 +117,8 @@ void dismount(ConsoleHandle& console, BotBaseContext& context){
     for (size_t c = 0; c < 10; c++){
         context.wait_for_all_requests();
 
-        MountState current = mount_detector.detect(console.video().snapshot());
+        auto snapshot = console.video().snapshot();
+        MountState current = mount_detector.detect(snapshot);
         switch (current){
         case MountState::WYRDEER_OFF:
         case MountState::URSALUNA_OFF:

--- a/SerialPrograms/Source/PokemonLA/Programs/PokemonLA_RegionNavigation.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/PokemonLA_RegionNavigation.cpp
@@ -279,11 +279,12 @@ void goto_camp_from_jubilife(
             {{detector}}
         );
         if (ret < 0){
-            dump_image(env.logger(), env.program_info(), "MapNotFound", console.video().snapshot());
+            auto snapshot = console.video().snapshot();
+            dump_image(env.logger(), env.program_info(), "MapNotFound", snapshot);
             throw OperationFailedException(
                 ErrorReport::SEND_ERROR_REPORT, console,
                 "Map not detected after 5 seconds.",
-                true
+                std::move(snapshot)
             );
         }
         console.log("Found map!");
@@ -424,11 +425,12 @@ void goto_camp_from_overworld(
         {{black_screen}}
     );
     if (ret < 0){
-        dump_image(console.logger(), env.program_info(), "FlyToCamp", console.video().snapshot());
+        auto snapshot = console.video().snapshot();
+        dump_image(console.logger(), env.program_info(), "FlyToCamp", snapshot);
         throw OperationFailedException(
             ErrorReport::SEND_ERROR_REPORT, console,
             "Failed to fly to camp after 20 seconds.",
-            true
+            std::move(snapshot)
         );
     }
     console.log("Arrived at camp...");

--- a/SerialPrograms/Source/PokemonLA/Programs/ShinyHunting/PokemonLA_AutoMultiSpawn.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/ShinyHunting/PokemonLA_AutoMultiSpawn.cpp
@@ -333,14 +333,15 @@ void AutoMultiSpawn::advance_one_path_step(
     // Switch to pokemon selection so that we can press X to throw a pokemon out to start a battle
     for (size_t c = 0; true; c++){
         context.wait_for_all_requests();
-        if (is_pokemon_selection(env.console, env.console.video().snapshot())){
+        auto snapshot = env.console.video().snapshot();
+        if (is_pokemon_selection(env.console, snapshot)){
             break;
         }
         if (c >= 5){
             throw OperationFailedException(
                 ErrorReport::SEND_ERROR_REPORT, env.console,
                 "Failed to switch to Pokemon selection after 5 attempts.",
-                true
+                std::move(snapshot)
             );
         }
         env.console.log("Not on Pokemon selection. Attempting to switch to it...", COLOR_ORANGE);

--- a/SerialPrograms/Source/PokemonLA/Programs/ShinyHunting/PokemonLA_BurmyFinder.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/ShinyHunting/PokemonLA_BurmyFinder.cpp
@@ -707,14 +707,15 @@ void BurmyFinder::run_iteration(SingleSwitchProgramEnvironment& env, BotBaseCont
 
     for (size_t c = 0; true; c++){
         context.wait_for_all_requests();
-        if (is_pokemon_selection(env.console, env.console.video().snapshot())){
+        auto snapshot = env.console.video().snapshot();
+        if (is_pokemon_selection(env.console, snapshot)){
             break;
         }
         if (c >= 5){
             throw OperationFailedException(
                 ErrorReport::SEND_ERROR_REPORT, env.console,
                 "Failed to switch to Pokemon selection after 5 attempts.",
-                true
+                std::move(snapshot)
             );
         }
         env.console.log("Not on Pokemon selection. Attempting to switch to it...", COLOR_ORANGE);

--- a/SerialPrograms/Source/PokemonLA/Programs/ShinyHunting/PokemonLA_CrobatFinder.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/ShinyHunting/PokemonLA_CrobatFinder.cpp
@@ -105,7 +105,8 @@ void CrobatFinder::run_iteration(SingleSwitchProgramEnvironment& env, BotBaseCon
     bool error = true;
     MountDetector mount_detector;
     for (size_t c = 0; c < 10; c++){
-        MountState mount = mount_detector.detect(env.console.video().snapshot());
+        auto snapshot = env.console.video().snapshot();
+        MountState mount = mount_detector.detect(snapshot);
         if (mount == MountState::WYRDEER_OFF){
             pbf_press_button(context, BUTTON_PLUS, 20, 105);
             error = false;

--- a/SerialPrograms/Source/PokemonLA/Programs/Trading/PokemonLA_SelfBoxTrade.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/Trading/PokemonLA_SelfBoxTrade.cpp
@@ -133,7 +133,8 @@ void SelfBoxTrade::program(MultiSwitchProgramEnvironment& env, CancellableScope&
         TradeNameReader name_reader0(env.consoles[0], env.consoles[0], LANGUAGE_LEFT);
         TradeNameReader name_reader1(env.consoles[1], env.consoles[1], LANGUAGE_RIGHT);
         env.run_in_parallel(scope, [&](ConsoleHandle& console, BotBaseContext& context){
-            ImageStats stats = image_stats(extract_box_reference(console.video().snapshot(), box0));
+            auto snapshot = console.video().snapshot();
+            ImageStats stats = image_stats(extract_box_reference(snapshot, box0));
             bool is_ok = is_white(stats);
             if (!is_ok){
                 console.log("Skipping empty slot.", COLOR_ORANGE);
@@ -141,8 +142,7 @@ void SelfBoxTrade::program(MultiSwitchProgramEnvironment& env, CancellableScope&
                 return;
             }
 
-            VideoSnapshot image1 = console.video().snapshot();
-            std::string slug = (console.index() == 0 ? name_reader0 : name_reader1).read(image1);
+            std::string slug = (console.index() == 0 ? name_reader0 : name_reader1).read(snapshot);
             if (slug == "machoke" || slug == "haunter" || slug == "graveler" || slug == "kadabra"){
                 console.log("Skipping trade evolution: " + slug, COLOR_RED);
                 ok.store(false, std::memory_order_release);

--- a/SerialPrograms/Source/PokemonLA/Programs/Trading/PokemonLA_SelfTouchTrade.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/Trading/PokemonLA_SelfTouchTrade.cpp
@@ -181,7 +181,8 @@ void SelfTouchTrade::program(MultiSwitchProgramEnvironment& env, CancellableScop
         OverlayBoxScope box0(host, {0.925, 0.100, 0.014, 0.030});
         OverlayBoxScope box1(recv, {0.925, 0.100, 0.014, 0.030});
         env.run_in_parallel(scope, [&](ConsoleHandle& console, BotBaseContext& context){
-            ImageStats stats = image_stats(extract_box_reference(console.video().snapshot(), box0));
+            auto snapshot = console.video().snapshot();
+            ImageStats stats = image_stats(extract_box_reference(snapshot, box0));
             bool ok = is_white(stats);
             if (host.index() == console.index()){
                 host_ok = ok;

--- a/SerialPrograms/Source/PokemonSV/Inference/Battles/PokemonSV_NormalBattleMenus.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Battles/PokemonSV_NormalBattleMenus.h
@@ -80,6 +80,7 @@ public:
 
     virtual void make_overlays(VideoOverlaySet& items) const override;
     virtual bool detect(const ImageViewRGB32& screen) const override;
+    using StaticScreenDetector::detect;
 
 private:
     Color m_color;

--- a/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxDetection.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxDetection.h
@@ -28,6 +28,7 @@ public:
 
     virtual void make_overlays(VideoOverlaySet& items) const override;
     virtual bool detect(const ImageViewRGB32& screen) const override;
+    using StaticScreenDetector::detect;
 
 private:
     bool m_true_if_exists;

--- a/SerialPrograms/Source/PokemonSV/Inference/Dialogs/PokemonSV_DialogDetector.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Dialogs/PokemonSV_DialogDetector.h
@@ -90,6 +90,7 @@ public:
 
     virtual void make_overlays(VideoOverlaySet& items) const override;
     virtual bool detect(const ImageViewRGB32& screen) const override;
+    using StaticScreenDetector::detect;
 
 private:
     DialogBoxDetector m_box;

--- a/SerialPrograms/Source/PokemonSV/Inference/PokemonSV_PokemonSummaryReader.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/PokemonSV_PokemonSummaryReader.h
@@ -28,6 +28,7 @@ public:
 
     virtual void make_overlays(VideoOverlaySet& items) const override;
     virtual bool detect(const ImageViewRGB32& screen) const override;
+    using StaticScreenDetector::detect;
 
     bool is_shiny(const ImageViewRGB32& screen) const;
 

--- a/SerialPrograms/Source/PokemonSV/Inference/Tera/PokemonSV_TeraCardDetector.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Tera/PokemonSV_TeraCardDetector.h
@@ -35,6 +35,7 @@ public:
 
     virtual void make_overlays(VideoOverlaySet& items) const override;
     virtual bool detect(const ImageViewRGB32& screen) const override;
+    using StaticScreenDetector::detect;
 
     uint8_t stars(
         Logger& logger, const ProgramInfo& info, const ImageViewRGB32& screen

--- a/SerialPrograms/Source/PokemonSV/Programs/Battles/PokemonSV_BasicCatcher.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Battles/PokemonSV_BasicCatcher.cpp
@@ -72,7 +72,8 @@ int16_t move_to_ball(
         return 0;
     }
     if (ret == 0){
-        uint16_t quantity = reader.read_quantity(console.video().snapshot());
+        auto snapshot = console.video().snapshot();
+        uint16_t quantity = reader.read_quantity(snapshot);
         return quantity == 0 ? -1 : quantity;
     }
 
@@ -89,7 +90,8 @@ int16_t move_to_ball(
     if (ret > 0){
         console.log("Fast ball scrolling overshot by " + std::to_string(ret) + " slot(s).", COLOR_RED);
     }
-    uint16_t quantity = reader.read_quantity(console.video().snapshot());
+    auto snapshot = console.video().snapshot();
+    uint16_t quantity = reader.read_quantity(snapshot);
     return quantity == 0 ? -1 : quantity;
 }
 

--- a/SerialPrograms/Source/PokemonSV/Programs/Boxes/PokemonSV_BoxAttach.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Boxes/PokemonSV_BoxAttach.cpp
@@ -159,8 +159,7 @@ void attach_item_from_box(
                 errors++;
             }
 
-            auto screenshot = console.video().snapshot();
-            if (exists.detect(screenshot)){
+            if (exists.detect(console.video().snapshot())){
                 if (attach_attempted){
                     return;
                 }

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
@@ -523,12 +523,13 @@ void EggAutonomous::process_one_baby(SingleSwitchProgramEnvironment& env, BotBas
         env.console.overlay().add_log("Shiny " + std::to_string(egg_index+1) + "/" + std::to_string(num_eggs_in_party), COLOR_GREEN);
         stats.m_shinies++;
         env.update_stats();
+        auto snapshot = env.console.video().snapshot();
         send_encounter_notification(
             env,
             m_notification_noop,
             NOTIFICATION_SHINY,
             false, true, {{{}, ShinyType::UNKNOWN_SHINY}}, std::nan(""),
-            env.console.video().snapshot()
+            snapshot
         );
     }else{
         env.console.overlay().add_log("Not shiny " + std::to_string(egg_index+1) + "/" + std::to_string(num_eggs_in_party), COLOR_WHITE);
@@ -536,12 +537,13 @@ void EggAutonomous::process_one_baby(SingleSwitchProgramEnvironment& env, BotBas
 
     auto send_keep_notification = [&](){
         if (!found_shiny){
+            auto snapshot = env.console.video().snapshot();
             send_encounter_notification(
                 env,
                 NOTIFICATION_NONSHINY_KEEP,
                 NOTIFICATION_SHINY,
                 false, false, {}, std::nan(""),
-                env.console.video().snapshot()
+                snapshot
             );
         }
     };
@@ -606,7 +608,12 @@ bool EggAutonomous::move_pokemon_to_keep(SingleSwitchProgramEnvironment& env, Bo
             move_box_cursor(env.program_info(), env.console, context, BoxCursorLocation::SLOTS, row, col);
             context.wait_for_all_requests();
             // If no pokemon in the slot:
-            if (!sth_in_box_detector.detect(env.console.video().snapshot())){
+            bool something_in_box;
+            {
+                auto snapshot = env.console.video().snapshot();
+                something_in_box = sth_in_box_detector.detect(snapshot);
+            }
+            if (!something_in_box){
 
                 // Move the to-keep pokemon in party to the empty slot.
                 swap_two_box_slots(env.program_info(), env.console, context,

--- a/SerialPrograms/Source/PokemonSV/Programs/FastCodeEntry/PokemonSV_VideoFastCodeEntry.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/FastCodeEntry/PokemonSV_VideoFastCodeEntry.cpp
@@ -171,7 +171,11 @@ void VideoFastCodeEntry::program(MultiSwitchProgramEnvironment& env, Cancellable
     FastCodeEntrySettings settings(FCE_SETTINGS);
 
     if (MODE == Mode::MANUAL){
-        std::string code = read_raid_code(env.logger(), env.realtime_dispatcher(), SCREEN_WATCHER.screenshot());
+        std::string code;
+        {
+            auto snapshot = SCREEN_WATCHER.screenshot();
+            code = read_raid_code(env.logger(), env.realtime_dispatcher(), snapshot);
+        }
         const char* error = enter_code(env, scope, settings, code, !SKIP_CONNECT_TO_CONTROLLER);
         if (error){
             env.log("No valid code found: " + std::string(error), COLOR_RED);

--- a/SerialPrograms/Source/PokemonSV/Programs/Glitches/PokemonSV_RideCloner-1.0.1.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Glitches/PokemonSV_RideCloner-1.0.1.cpp
@@ -350,7 +350,7 @@ bool RideCloner101::run_post_win(
                 success = true;
             }
             continue;
-        case 1:
+        case 1:{
             //  Next button detector is unreliable. Check if the summary is
             //  open. If so, fall-through to that.
             if (!summary.detect(console.video().snapshot())){
@@ -360,6 +360,7 @@ bool RideCloner101::run_post_win(
                 continue;
             }
             console.log("Detected false positive (A) Next button.", COLOR_RED);
+        }
         case 5:
             console.log("Detected summary.");
             if (result == TeraResult::NO_DETECTION){

--- a/SerialPrograms/Source/PokemonSV/Programs/PokemonSV_GameEntry.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/PokemonSV_GameEntry.cpp
@@ -137,7 +137,7 @@ bool reset_game_from_home(
     ok &= reset_game_to_gamemenu(console, context);
     ok &= gamemenu_to_ingame(console, context);
     if (!ok){
-        dump_image(console.logger(), info, "StartGame", console.video().snapshot());
+        dump_image(info, console, "StartGame");
     }
     console.log("Entered game! Waiting out grace period.");
     pbf_wait(context, post_wait_time);

--- a/SerialPrograms/Source/PokemonSV/Programs/TeraRaids/PokemonSV_TeraMultiFarmer.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/TeraRaids/PokemonSV_TeraMultiFarmer.cpp
@@ -419,7 +419,11 @@ bool TeraMultiFarmer::run_raid(
                 : HostingMode::LOCAL
         );
         lobby_start_time = current_time();
-        std::string code = lobby_reader.raid_code(env.logger(), env.realtime_dispatcher(), host_console.video().snapshot());
+        std::string code;
+        {
+            auto snapshot = host_console.video().snapshot();
+            code = lobby_reader.raid_code(env.logger(), env.realtime_dispatcher(), snapshot);
+        }
         const char* error = normalize_code(lobby_code, code);
         if (error){
             throw OperationFailedException(

--- a/SerialPrograms/Source/PokemonSV/Programs/TeraRaids/PokemonSV_TeraRoller.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/TeraRaids/PokemonSV_TeraRoller.cpp
@@ -208,13 +208,17 @@ void TeraRoller::program(SingleSwitchProgramEnvironment& env, BotBaseContext& co
 
                 pbf_wait(context, 500); // Wait enough time for the Pokemon sprite to load
                 context.wait_for_all_requests();
-                send_encounter_notification(
-                    env,
-                    m_notification_noop,
-                    NOTIFICATION_SHINY,
-                    false, true, {{{}, ShinyType::UNKNOWN_SHINY}}, std::nan(""),
-                    env.console.video().snapshot()
-                );
+
+                {
+                    auto snapshot = env.console.video().snapshot();
+                    send_encounter_notification(
+                        env,
+                        m_notification_noop,
+                        NOTIFICATION_SHINY,
+                        false, true, {{{}, ShinyType::UNKNOWN_SHINY}}, std::nan(""),
+                        snapshot
+                    );
+                }
 
                 leave_phone_to_overworld(env.program_info(), env.console, context);
                 save_game_from_overworld(env.program_info(), env.console, context);

--- a/SerialPrograms/Source/PokemonSV/Programs/TeraRaids/PokemonSV_TeraRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/TeraRaids/PokemonSV_TeraRoutines.cpp
@@ -559,10 +559,15 @@ TeraResult exit_tera_win_by_catching(
             console.log("Detected nickname prompt.");
             pbf_press_button(context, BUTTON_B, 20, 105);
             continue;
-        case 1:
+        case 1:{
             //  Next button detector is unreliable. Check if the summary is
             //  open. If so, fall-through to that.
-            if (!summary.detect(console.video().snapshot())){
+            bool detected;
+            {
+                auto snapshot = console.video().snapshot();
+                detected = summary.detect(snapshot);
+            }
+            if (!detected){
                 console.log("Detected possible (A) Next button.");
                 stop_if_enough_rare_items(console, context, stop_on_sparkly_items);
                 pbf_press_button(context, BUTTON_A, 20, 105);
@@ -570,6 +575,7 @@ TeraResult exit_tera_win_by_catching(
                 break;
             }
             console.log("Detected false positive (A) Next button.", COLOR_RED);
+        }
         case 6:
             console.log("Detected summary.");
             if (result == TeraResult::NO_DETECTION){

--- a/SerialPrograms/Source/PokemonSV/Programs/Trading/PokemonSV_TradeRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Trading/PokemonSV_TradeRoutines.cpp
@@ -122,7 +122,8 @@ void trade_current_pokemon(
     //  Make sure there is something to trade.
     {
         SomethingInBoxSlotDetector detector(COLOR_CYAN, true);
-        if (!detector.detect(console.video().snapshot())){
+        auto snapshot = console.video().snapshot();
+        if (!detector.detect(snapshot)){
             stats.m_errors++;
             tracker.report_unrecoverable_error(console, "Box slot is empty.");
         }

--- a/SerialPrograms/Source/PokemonSwSh/Inference/PokemonSwSh_SummaryShinySymbolDetector.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Inference/PokemonSwSh_SummaryShinySymbolDetector.cpp
@@ -72,7 +72,8 @@ SummaryShinySymbolDetector::Detection SummaryShinySymbolDetector::wait_for_detec
     while (true){
         scope.throw_if_cancelled();
 
-        Detection detection = detect(feed.snapshot());
+        auto snapshot = feed.snapshot();
+        Detection detection = detect(snapshot);
         if (detection == last_detection){
             confirmations++;
         }else{

--- a/SerialPrograms/Source/PokemonSwSh/MaxLair/Framework/PokemonSwSh_MaxLair_CatchScreenTracker.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/MaxLair/Framework/PokemonSwSh_MaxLair_CatchScreenTracker.cpp
@@ -86,11 +86,12 @@ void CaughtPokemonScreen::leave_summary(){
         m_context.wait_for_all_requests();
         break;
     default:
-        dump_image(m_console, m_env.program_info(), "CaughtMenu", m_console.video().snapshot());
+        auto snapshot = m_console.video().snapshot();
+        dump_image(m_console, m_env.program_info(), "CaughtMenu", snapshot);
         throw OperationFailedException(
             ErrorReport::SEND_ERROR_REPORT, m_console,
             "Failed to detect caught menu.",
-            true
+            std::move(snapshot)
         );
     }
 

--- a/SerialPrograms/Source/PokemonSwSh/MaxLair/Framework/PokemonSwSh_MaxLair_StateMachine.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/MaxLair/Framework/PokemonSwSh_MaxLair_StateMachine.cpp
@@ -147,7 +147,7 @@ StateMachineAction run_state_iteration(
         return StateMachineAction::RESET_RECOVER;
     default:
         console.log("Program hang. No state detected after 5 minutes.", COLOR_RED);
-        dump_image(console, MODULE_NAME, "ProgramHang", console.video().snapshot());
+        dump_image(MODULE_NAME, console, "ProgramHang");
         global_state.mark_as_dead(console_index);
         return StateMachineAction::RESET_RECOVER;
     }

--- a/SerialPrograms/Source/PokemonSwSh/MaxLair/Inference/PokemonSwSh_MaxLair_Detect_EndBattle.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/MaxLair/Inference/PokemonSwSh_MaxLair_Detect_EndBattle.cpp
@@ -6,6 +6,7 @@
 
 #include "Common/Compiler.h"
 #include "CommonFramework/ImageTools/SolidColorTest.h"
+#include "CommonFramework/VideoPipeline/VideoFeed.h"
 #include "CommonFramework/VideoPipeline/VideoOverlayScopes.h"
 #include "PokemonSwSh_MaxLair_Detect_EndBattle.h"
 
@@ -110,6 +111,9 @@ size_t count_catches(VideoOverlay& overlay, const ImageViewRGB32& screen){
     }
 
     return count;
+}
+size_t count_catches(VideoOverlay& overlay, const VideoSnapshot& snapshot){
+    return count_catches(overlay, (ImageViewRGB32)snapshot);
 }
 
 

--- a/SerialPrograms/Source/PokemonSwSh/MaxLair/Inference/PokemonSwSh_MaxLair_Detect_EndBattle.h
+++ b/SerialPrograms/Source/PokemonSwSh/MaxLair/Inference/PokemonSwSh_MaxLair_Detect_EndBattle.h
@@ -42,6 +42,7 @@ private:
 
 
 size_t count_catches(VideoOverlay& overlay, const ImageViewRGB32& screen);
+size_t count_catches(VideoOverlay& overlay, const VideoSnapshot& snapshot);
 
 
 

--- a/SerialPrograms/Source/PokemonSwSh/MaxLair/Inference/PokemonSwSh_MaxLair_Detect_PokemonReader.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/MaxLair/Inference/PokemonSwSh_MaxLair_Detect_PokemonReader.cpp
@@ -77,7 +77,11 @@ struct SpeciesReadDatabase{
 
 std::string read_boss_sprite(ConsoleHandle& console){
     DenMonReader reader(console, console);
-    DenMonReadResults results = reader.read(console.video().snapshot());
+    DenMonReadResults results;
+    {
+        auto snapshot = console.video().snapshot();
+        results = reader.read(snapshot);
+    }
 
     std::string sprite_slug;
     {

--- a/SerialPrograms/Source/PokemonSwSh/MaxLair/Program/PokemonSwSh_MaxLair_Run_Battle.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/MaxLair/Program/PokemonSwSh_MaxLair_Run_Battle.cpp
@@ -61,7 +61,10 @@ bool read_battle_menu(
         pbf_press_dpad(context, DPAD_UP, 10, 50);
         pbf_press_button(context, BUTTON_A, 10, 2 * TICKS_PER_SECOND);
         context.wait_for_all_requests();
-        mon = reader.read_opponent_in_summary(console, console.video().snapshot());
+        {
+            auto snapshot = console.video().snapshot();
+            mon = reader.read_opponent_in_summary(console, snapshot);
+        }
         pbf_mash_button(context, BUTTON_B, 3 * TICKS_PER_SECOND);
         state.opponent = std::move(mon);
 
@@ -81,7 +84,7 @@ bool read_battle_menu(
 
     if (state.wins != 3 && is_boss(opponent)){
         console.log("Boss found before 3 wins. Something is seriously out-of-sync.", COLOR_RED);
-        dump_image(console, MODULE_NAME, "BossBeforeEnd", console.video().snapshot());
+        dump_image(MODULE_NAME, console, "BossBeforeEnd");
 //        send_program_telemetry(
 //            env.logger(), true, COLOR_RED, MODULE_NAME,
 //            "Error",

--- a/SerialPrograms/Source/PokemonSwSh/MaxLair/Program/PokemonSwSh_MaxLair_Run_CaughtScreen.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/MaxLair/Program/PokemonSwSh_MaxLair_Run_CaughtScreen.cpp
@@ -52,7 +52,7 @@ StateMachineAction mash_A_to_entrance(
     if (result < 0){
         console.log("Failed to detect entrance.", COLOR_RED);
         runtime.session_stats.add_error();
-        dump_image(console, MODULE_NAME, "FailedToDetectEntrance", console.video().snapshot());
+        dump_image(MODULE_NAME, console, "FailedToDetectEntrance");
         return StateMachineAction::RESET_RECOVER;
     }
     return StateMachineAction::KEEP_GOING;

--- a/SerialPrograms/Source/PokemonSwSh/MaxLair/Program/PokemonSwSh_MaxLair_Run_PokemonSwap.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/MaxLair/Program/PokemonSwSh_MaxLair_Run_PokemonSwap.cpp
@@ -112,8 +112,9 @@ void run_swap_pokemon(
     context.wait_for(std::chrono::milliseconds(100));
 
     PathReader path_reader(console, player_index);
-    path_reader.read_sprites(console, state, console.video().snapshot());
-    path_reader.read_hp(console, state, console.video().snapshot());
+    auto snapshot = console.video().snapshot();
+    path_reader.read_sprites(console, state, snapshot);
+    path_reader.read_hp(console, state, snapshot);
 }
 
 

--- a/SerialPrograms/Source/PokemonSwSh/MaxLair/Program/PokemonSwSh_MaxLair_Run_StartSolo.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/MaxLair/Program/PokemonSwSh_MaxLair_Run_StartSolo.cpp
@@ -97,9 +97,12 @@ bool start_adventure(
     size_t consoles
 ){
     LobbyMinReadyDetector ready_detector(consoles, true);
-    if (ready_detector.ready_players(console.video().snapshot()) < consoles){
-        console.log("Number of players less than expected. Did someone join the wrong lobby?", COLOR_RED);
-        return false;
+    {
+        auto snapshot = console.video().snapshot();
+        if (ready_detector.ready_players(snapshot) < consoles){
+            console.log("Number of players less than expected. Did someone join the wrong lobby?", COLOR_RED);
+            return false;
+        }
     }
 
     //  Press A until you're not in the lobby anymore.

--- a/SerialPrograms/Source/PokemonSwSh/Programs/DenHunting/PokemonSwSh_PurpleBeamFinder.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/DenHunting/PokemonSwSh_PurpleBeamFinder.cpp
@@ -229,11 +229,14 @@ void PurpleBeamFinder::program(SingleSwitchProgramEnvironment& env, BotBaseConte
     }
 
     context.wait_for(std::chrono::seconds(2));
-    send_program_finished_notification(
-        env, NOTIFICATION_PURPLE_BEAM,
-        "Found a purple beam!",
-        env.console.video().snapshot()
-    );
+    {
+        auto snapshot = env.console.video().snapshot();
+        send_program_finished_notification(
+            env, NOTIFICATION_PURPLE_BEAM,
+            "Found a purple beam!",
+            snapshot
+        );
+    }
     while (true){
         pbf_press_button(context, BUTTON_B, 20, 20);
         pbf_press_button(context, BUTTON_LCLICK, 20, 20);

--- a/SerialPrograms/Source/PokemonSwSh/Programs/EggPrograms/PokemonSwSh_EggAutonomous.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/EggPrograms/PokemonSwSh_EggAutonomous.cpp
@@ -755,7 +755,8 @@ bool EggAutonomous::process_hatched_pokemon(SingleSwitchProgramEnvironment& env,
                 const size_t max_dialog_count = 6;
                 for (; dialog_count < max_dialog_count; dialog_count++){
                     context.wait_for_all_requests();
-                    if (!dialog_detector.process_frame(env.console.video().snapshot(), current_time())){
+                    auto snapshot = env.console.video().snapshot();
+                    if (!dialog_detector.process_frame(snapshot, current_time())){
                         break;
                     }
                     pbf_press_button(context, BUTTON_A, 20, 100);

--- a/SerialPrograms/Source/PokemonSwSh/Programs/General/PokemonSwSh_DexRecFinder.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/General/PokemonSwSh_DexRecFinder.cpp
@@ -234,10 +234,11 @@ void DexRecFinder::program(SingleSwitchProgramEnvironment& env, BotBaseContext& 
     }
 
     env.update_stats();
+    auto snapshot = env.console.video().snapshot();
     send_program_finished_notification(
         env, NOTIFICATION_PROGRAM_FINISH,
         "Found a match!",
-        env.console.video().snapshot(), false
+        snapshot, false
     );
     GO_HOME_WHEN_DONE.run_end_of_program(context);
 }

--- a/SerialPrograms/Source/PokemonSwSh/Programs/Hosting/PokemonSwSh_AutoHost.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/Hosting/PokemonSwSh_AutoHost.cpp
@@ -228,7 +228,8 @@ void run_autohost(
         BlackScreenOverWatcher black_screen;
         uint32_t now = start;
         while (true){
-            if (black_screen.black_is_over(console.video().snapshot())){
+            auto snapshot = console.video().snapshot();
+            if (black_screen.black_is_over(snapshot)){
                 env.log("Raid has Started!", COLOR_BLUE);
                 stats.add_raid(raid_state.raiders());
                 break;

--- a/SerialPrograms/Source/PokemonSwSh/Programs/Hosting/PokemonSwSh_LobbyWait.h
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/Hosting/PokemonSwSh_LobbyWait.h
@@ -50,7 +50,10 @@ static RaidLobbyState raid_lobby_wait(
         uint32_t delay = time_elapsed;
 
         while (true){
-            state = inference.read(console.video().snapshot());
+            {
+                auto snapshot = console.video().snapshot();
+                state = inference.read(snapshot);
+            }
             if (state.valid && state.raid_is_full() && state.raiders_are_ready()){
                 return state;
             }
@@ -70,7 +73,10 @@ static RaidLobbyState raid_lobby_wait(
     }
 
     while (true){
-        state = inference.read(console.video().snapshot());
+        {
+            auto snapshot = console.video().snapshot();
+            state = inference.read(snapshot);
+        }
         if (state.valid && state.raid_is_full() && state.raiders_are_ready()){
             return state;
         }
@@ -106,7 +112,8 @@ static RaidLobbyState raid_lobby_wait(
             )
         );
         context.wait_for_all_requests();
-        state = inference.read(console.video().snapshot());
+        auto snapshot = console.video().snapshot();
+        state = inference.read(snapshot);
     }
 }
 

--- a/SerialPrograms/Source/PokemonSwSh/Programs/NonShinyHunting/PokemonSwSh_StatsReset-Calyrex.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/NonShinyHunting/PokemonSwSh_StatsReset-Calyrex.cpp
@@ -249,7 +249,8 @@ void StatsResetCalyrex::program(SingleSwitchProgramEnvironment& env, BotBaseCont
         if (CHECK_HORSE_STATS){
             context.wait_for_all_requests();
             IvJudgeReaderScope reader(env.console, LANGUAGE);
-            IvJudgeReader::Results results = reader.read(env.console, env.console.video().snapshot());
+            auto snapshot = env.console.video().snapshot();
+            IvJudgeReader::Results results = reader.read(env.console, snapshot);
             bool horse_ok = true;
             horse_ok &= HORSE_HP.matches(stats.errors, results.hp);
             horse_ok &= HORSE_ATTACK.matches(stats.errors, results.attack);
@@ -266,7 +267,8 @@ void StatsResetCalyrex::program(SingleSwitchProgramEnvironment& env, BotBaseCont
             context.wait_for_all_requests();
             
             IvJudgeReaderScope reader(env.console, LANGUAGE);
-            IvJudgeReader::Results results = reader.read(env.console, env.console.video().snapshot());
+            auto snapshot = env.console.video().snapshot();
+            IvJudgeReader::Results results = reader.read(env.console, snapshot);
             bool calyrex_ok = true;
             calyrex_ok &= CALYREX_HP.matches(stats.errors, results.hp);
             calyrex_ok &= CALYREX_ATTACK.matches(stats.errors, results.attack);

--- a/SerialPrograms/Source/PokemonSwSh/Programs/NonShinyHunting/PokemonSwSh_StatsReset-Moltres.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/NonShinyHunting/PokemonSwSh_StatsReset-Moltres.cpp
@@ -152,7 +152,11 @@ void StatsResetMoltres::program(SingleSwitchProgramEnvironment& env, BotBaseCont
 
         context.wait_for_all_requests();
         IvJudgeReaderScope reader(env.console, LANGUAGE);
-        IvJudgeReader::Results results = reader.read(env.console, env.console.video().snapshot());
+        IvJudgeReader::Results results;
+        {
+            auto snapshot = env.console.video().snapshot();
+            results = reader.read(env.console, snapshot);
+        }
         bool ok = true;
         ok &= HP.matches(stats.errors, results.hp);
         ok &= ATTACK.matches(stats.errors, results.attack);

--- a/SerialPrograms/Source/PokemonSwSh/Programs/NonShinyHunting/PokemonSwSh_StatsReset-Regi.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/NonShinyHunting/PokemonSwSh_StatsReset-Regi.cpp
@@ -204,7 +204,11 @@ void StatsResetRegi::program(SingleSwitchProgramEnvironment& env, BotBaseContext
 
         context.wait_for_all_requests();
         IvJudgeReaderScope reader(env.console, LANGUAGE);
-        IvJudgeReader::Results results = reader.read(env.console, env.console.video().snapshot());
+        IvJudgeReader::Results results;
+        {
+            auto snapshot = env.console.video().snapshot();
+            results = reader.read(env.console, snapshot);
+        }
         bool ok = true;
         ok &= HP.matches(stats.errors, results.hp);
         ok &= ATTACK.matches(stats.errors, results.attack);

--- a/SerialPrograms/Source/PokemonSwSh/Programs/PokemonSwSh_BasicCatcher.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/PokemonSwSh_BasicCatcher.cpp
@@ -62,7 +62,8 @@ int16_t move_to_ball(
         return 0;
     }
     if (ret == 0){
-        uint16_t quantity = reader.read_quantity(console.video().snapshot());
+        auto snapshot = console.video().snapshot();
+        uint16_t quantity = reader.read_quantity(snapshot);
         return quantity == 0 ? -1 : quantity;
     }
 
@@ -79,7 +80,8 @@ int16_t move_to_ball(
     if (ret > 0){
         console.log("Fast ball scrolling overshot by " + std::to_string(ret) + " slot(s).", COLOR_RED);
     }
-    uint16_t quantity = reader.read_quantity(console.video().snapshot());
+    auto snapshot = console.video().snapshot();
+    uint16_t quantity = reader.read_quantity(snapshot);
     return quantity == 0 ? -1 : quantity;
 }
 

--- a/SerialPrograms/Source/PokemonSwSh/Programs/PokemonSwSh_Internet.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/PokemonSwSh_Internet.cpp
@@ -29,7 +29,12 @@ bool connect_to_internet_with_inference(
 //    cout << "Waiting for Y-COMM to open..." << endl;
     {
         YCommMenuDetector detector(true);
-        if (!detector.detect(console.video().snapshot())){
+        bool detected;
+        {
+            auto snapshot = console.video().snapshot();
+            detected = detector.detect(snapshot);
+        }
+        if (!detected){
             pbf_press_button(context, BUTTON_Y, 10, TICKS_PER_SECOND);
             context.wait_for_all_requests();
         }
@@ -42,7 +47,7 @@ bool connect_to_internet_with_inference(
             console.log("Y-COMM detected.");
         }else{
             console.log("Failed to detect Y-COMM after timeout.", COLOR_RED);
-            dump_image(console, ProgramInfo(), "connect_to_internet_with_inference", console.video().snapshot());
+            dump_image(ProgramInfo(), console, "connect_to_internet_with_inference");
             ok = false;
         }
     }

--- a/SerialPrograms/Source/PokemonSwSh/Programs/PokemonSwSh_MenuNavigation.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/PokemonSwSh_MenuNavigation.cpp
@@ -29,12 +29,13 @@ void navigate_to_menu_app(
 ){
     context.wait_for_all_requests();
     RotomPhoneMenuArrowFinder menu_arrow_detector(console);
-    const int cur_app_index = menu_arrow_detector.detect(console.video().snapshot());
+    auto snapshot = console.video().snapshot();
+    const int cur_app_index = menu_arrow_detector.detect(snapshot);
     if (cur_app_index < 0){
         throw OperationFailedException(
             ErrorReport::SEND_ERROR_REPORT, console,
             "Cannot detect Rotom phone menu.",
-            true
+            std::move(snapshot)
         );
     }
     console.log("Detect menu cursor at " + std::to_string(cur_app_index) + ".");

--- a/SerialPrograms/Source/PokemonSwSh/Programs/ShinyHuntAutonomous/PokemonSwSh_ShinyHuntAutonomous-Fishing.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/ShinyHuntAutonomous/PokemonSwSh_ShinyHuntAutonomous-Fishing.cpp
@@ -170,7 +170,8 @@ void ShinyHuntAutonomousFishing::program(SingleSwitchProgramEnvironment& env, Bo
                 continue;
             }
             context.wait_for(std::chrono::seconds(3));
-            if (miss_detector.detect(env.console.video().snapshot())){
+            auto snapshot = env.console.video().snapshot();
+            if (miss_detector.detect(snapshot)){
                 env.log("False alarm! We actually missed.", COLOR_RED);
                 stats.m_misses++;
                 pbf_mash_button(context, BUTTON_B, 2 * TICKS_PER_SECOND);

--- a/SerialPrograms/Source/PokemonSwSh/Programs/ShinyHuntAutonomous/PokemonSwSh_ShinyHuntAutonomous-IoATrade.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/ShinyHuntAutonomous/PokemonSwSh_ShinyHuntAutonomous-IoATrade.cpp
@@ -146,12 +146,13 @@ void ShinyHuntAutonomousIoATrade::program(SingleSwitchProgramEnvironment& env, B
             break;
         case SummaryShinySymbolDetector::SHINY:
             stats.add_unknown_shiny();
+            auto snapshot = env.console.video().snapshot();
             send_encounter_notification(
                 env,
                 NOTIFICATION_NONSHINY,
                 NOTIFICATION_SHINY,
                 false, true, {{{}, ShinyType::UNKNOWN_SHINY}}, std::nan(""),
-                env.console.video().snapshot()
+                snapshot
             );
             if (VIDEO_ON_SHINY){
                 pbf_wait(context, 1 * TICKS_PER_SECOND);


### PR DESCRIPTION
The following line of code is a fairly common mistake that I've also done before (though was easy to catch).
`const ImageViewRGB32 frame = console.video().snapshot();`

I'm debating on whether to prevent this at the syntactic level by disallowing conversion of rvalue-ref `VideoSnapshot` to `ImageViewRGB32` because that will lead to a dangling ImageView.

The problem is that there is one legitimate use for this:
`bool detected = detector.detect(console.video().snapshot());`

Where the VideoSnapshot is inlined into where the ImageView is needed. This is fine because C++ extends the lifetime of intermediates to the end of the statement.

And if you look at the change, there's quite a few place where we do this.

Thoughts?