### PR TITLE
Add recovery routine for detecting sandwich hand

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Inference/Picnics/PokemonSV_SandwichHandDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Picnics/PokemonSV_SandwichHandDetector.cpp
@@ -80,7 +80,15 @@ void SandwichHandLocator::make_overlays(VideoOverlaySet& items) const{
 }
 
 std::pair<double, double> SandwichHandLocator::detect(const ImageViewRGB32& frame) const{
-    return locate_sandwich_hand(frame, m_box);
+    ImageFloatBox entire_screen(0.0, 0.0, 1.0, 1.0);
+    std::pair<double, double> location = locate_sandwich_hand(frame, m_box);
+    if (location.first >= 0.0){
+        return location;
+    }
+    else {
+        return locate_sandwich_hand(frame, entire_screen);
+    }
+    
 }
 
 
@@ -132,9 +140,10 @@ bool SandwichHandWatcher::process_frame(const VideoSnapshot& frame){
     return m_location.first >= 0.0;
 }
 
-std::pair<double, double> SandwichHandWatcher::search_entire_screen_for_sandwich_hand(const ImageViewRGB32& frame) const{
+bool SandwichHandWatcher::recover_sandwich_hand_position(const ImageViewRGB32& frame){
     ImageFloatBox entire_screen(0.0, 0.0, 1.0, 1.0);
-    return m_locator.locate_sandwich_hand(frame, entire_screen);
+    m_location = m_locator.locate_sandwich_hand(frame, entire_screen);
+    return m_location.first >= 0.0;
 }
 
 

--- a/SerialPrograms/Source/PokemonSV/Inference/Picnics/PokemonSV_SandwichHandDetector.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Picnics/PokemonSV_SandwichHandDetector.h
@@ -35,9 +35,10 @@ public:
 
     void make_overlays(VideoOverlaySet& items) const;
     
-    // return detected hand cetner location on screen, (x, y) where
+    // - return detected hand cetner location on screen, (x, y) where
     // x: [0, 1), 0 left-most, 1 right-most, y: [0, 1), 0 top-most 1 bottom-most
-    // If hand not detected, return (-1, -1).
+    // - first search m_box, then search the entire screen
+    // - If hand not detected, return (-1, -1).
     std::pair<double, double> detect(const ImageViewRGB32& screen) const;
 
     void change_box(const ImageFloatBox& new_box) { m_box = new_box; }
@@ -67,7 +68,10 @@ public:
 
     void change_box(const ImageFloatBox& new_box) { m_locator.change_box(new_box); }
 
-    std::pair<double, double> search_entire_screen_for_sandwich_hand(const ImageViewRGB32& frame) const;
+    // - searches the whole screen for the sandwich hand,
+    // - then updates its location
+    // - return true if hand successfully found
+    bool recover_sandwich_hand_position(const ImageViewRGB32& frame);
 
 
 private:

--- a/SerialPrograms/Source/PokemonSV/Inference/Picnics/PokemonSV_SandwichHandDetector.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Picnics/PokemonSV_SandwichHandDetector.h
@@ -42,6 +42,10 @@ public:
 
     void change_box(const ImageFloatBox& new_box) { m_box = new_box; }
 
+    // return the coordinates of the sandwich hand.
+    // search within the confines of the box area_to_search.
+    std::pair<double, double> locate_sandwich_hand(const ImageViewRGB32& frame, ImageFloatBox area_to_search) const;
+
 private:
     HandType m_type;
     ImageFloatBox m_box;
@@ -62,6 +66,9 @@ public:
     const std::pair<double, double>& location() const { return m_location; }
 
     void change_box(const ImageFloatBox& new_box) { m_locator.change_box(new_box); }
+
+    std::pair<double, double> search_entire_screen_for_sandwich_hand(const ImageViewRGB32& frame) const;
+
 
 private:
     SandwichHandLocator m_locator;

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichMaker.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichMaker.cpp
@@ -53,6 +53,14 @@ SandwichMaker::SandwichMaker()
 void SandwichMaker::program(SingleSwitchProgramEnvironment& env, BotBaseContext& context){
     assert_16_9_720p_min(env.logger(), env.console);
 
+    #if 0
+        // make unlimited sandwiches. until it errors out.
+        while (true){
+            make_sandwich_option(env, env.console, context, SANDWICH_OPTIONS);
+            enter_sandwich_recipe_list(env.program_info(), env.console, context);
+        }
+    #endif
+
     make_sandwich_option(env, env.console, context, SANDWICH_OPTIONS);
 
     GO_HOME_WHEN_DONE.run_end_of_program(context);

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
@@ -304,6 +304,20 @@ ImageFloatBox move_sandwich_hand(
     WallClock cur_time, last_time;
     VideoOverlaySet overlay_set(console.overlay());
 
+    #if 0
+        // to intentionally trigger failures in hand detection, for testing recovery
+        if (SandwichHandType::FREE == hand_type){
+            std::pair<double, double> hand_location(1.0, 1.0);
+            const ImageFloatBox hand_bb_debug = hand_location_to_box(hand_location); 
+            const ImageFloatBox expanded_hand_bb_debug = expand_box(hand_bb_debug);
+            hand_watcher.change_box(expanded_hand_bb_debug);
+            overlay_set.clear();
+            overlay_set.add(COLOR_RED, hand_bb_debug);
+            overlay_set.add(COLOR_BLUE, expanded_hand_bb_debug);
+            pbf_move_left_joystick(context, 0, 0, TICKS_PER_SECOND*5, 100);  // move hand to screen edge
+        }
+    #endif
+
     while(true){
         int ret = wait_until(console, context, std::chrono::seconds(5), {hand_watcher});
         if (ret < 0){


### PR DESCRIPTION
If the hand_watcher loses track of the sandwich hand, it searches the whole screen for the hand, instead of just its box.
If that fails, the hand may be at the screen edge. So, move the hand to the middle of the screen and re-try searching the whole screen.
If even that fails, it throws an exception.

I also added test code (commented out) so anyone can test the recovery routine.