### PR TITLE
Update sandwich hand detector so it can also check for the black outline

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Inference/Picnics/PokemonSV_SandwichHandDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Picnics/PokemonSV_SandwichHandDetector.cpp
@@ -6,9 +6,13 @@
 
 #include "Common/Cpp/Exceptions.h"
 #include "CommonFramework/Globals.h"
+#include "CommonFramework/GlobalSettingsPanel.h"
+#include "CommonFramework/Logging/Logger.h"
 #include "CommonFramework/VideoPipeline/VideoOverlayScopes.h"
 #include "CommonFramework/ImageMatch/WaterfillTemplateMatcher.h"
 #include "CommonFramework/ImageTools/WaterfillUtilities.h"
+#include "CommonFramework/ImageTools/BinaryImage_FilterRgb32.h"
+#include "CommonFramework/Tools/DebugDumper.h"
 #include "Kernels/Waterfill/Kernels_Waterfill_Types.h"
 #include "PokemonSV_SandwichHandDetector.h"
 
@@ -58,6 +62,41 @@ public:
     }
 };
 
+class SandwichFreeHandMatcher2 : public ImageMatch::WaterfillTemplateMatcher{
+public:
+    SandwichFreeHandMatcher2() : WaterfillTemplateMatcher(
+        "PokemonSV/Picnic/SandwichHand-Template.png", Color(100,100,100), Color(255, 255, 255), 50
+    ){
+        m_aspect_ratio_lower = 0.9;
+        m_aspect_ratio_upper = 1.2;
+        m_area_ratio_lower = 0.9;
+        m_area_ratio_upper = 1.2;
+    }
+
+    static const ImageMatch::WaterfillTemplateMatcher& instance(){
+        static SandwichFreeHandMatcher2 matcher;
+        return matcher;
+    }
+};
+
+
+class SandwichGrabbingHandMatcher2 : public ImageMatch::WaterfillTemplateMatcher{
+public:
+    SandwichGrabbingHandMatcher2() : WaterfillTemplateMatcher(
+        "PokemonSV/Picnic/SandwichGrab-Template.png", Color(100,100,100), Color(255, 255, 255), 50
+    ){
+        m_aspect_ratio_lower = 0.9;
+        m_aspect_ratio_upper = 1.2;
+        m_area_ratio_lower = 0.9;
+        m_area_ratio_upper = 1.2;
+    }
+
+    static const ImageMatch::WaterfillTemplateMatcher& instance(){
+        static SandwichGrabbingHandMatcher2 matcher;
+        return matcher;
+    }
+};
+
 } // anonymous namespace
 
 std::string SANDWICH_HAND_TYPE_NAMES(SandwichHandType type){
@@ -80,11 +119,13 @@ void SandwichHandLocator::make_overlays(VideoOverlaySet& items) const{
 }
 
 std::pair<double, double> SandwichHandLocator::detect(const ImageViewRGB32& frame) const{
-    return locate_sandwich_hand(frame, m_box);
+    return locate_sandwich_hand(frame, m_box, false);
 }
 
 
-std::pair<double, double> SandwichHandLocator::locate_sandwich_hand(const ImageViewRGB32& frame, ImageFloatBox area_to_search) const{
+std::pair<double, double> SandwichHandLocator::locate_sandwich_hand(
+    const ImageViewRGB32& frame, ImageFloatBox area_to_search, bool check_outline) const
+{
     const std::vector<std::pair<uint32_t, uint32_t>> filters = {
         {combine_rgb(150, 150, 150), combine_rgb(255, 255, 255)}
     };
@@ -97,6 +138,12 @@ std::pair<double, double> SandwichHandLocator::locate_sandwich_hand(const ImageV
     std::pair<double, double> hand_location(-1.0, -1.0);
 
     ImagePixelBox pixel_box = floatbox_to_pixelbox(frame.width(), frame.height(), area_to_search);
+    
+    const std::vector<std::pair<uint32_t, uint32_t>> black_filters = {
+        // {combine_rgb(0, 0, 0), combine_rgb(80, 80, 80)}
+        {combine_rgb(0, 0, 0), combine_rgb(150, 150, 150)}
+    };
+
     match_template_by_waterfill(
         extract_box_reference(frame, area_to_search), 
         ((m_type == HandType::FREE) ? SandwichFreeHandMatcher::instance() : SandwichGrabbingHandMatcher::instance()),
@@ -104,14 +151,53 @@ std::pair<double, double> SandwichHandLocator::locate_sandwich_hand(const ImageV
         {min_size, SIZE_MAX},
         60,
         [&](Kernels::Waterfill::WaterfillObject& object) -> bool {
-            hand_location = std::make_pair(
-                (object.center_of_gravity_x() + pixel_box.min_x) / (double)frame.width(),
-                (object.center_of_gravity_y() + pixel_box.min_y) / (double)frame.height()
-            );
-            return true;
+            if (!check_outline){
+                hand_location = std::make_pair(
+                    (object.center_of_gravity_x() + pixel_box.min_x) / (double)frame.width(),
+                    (object.center_of_gravity_y() + pixel_box.min_y) / (double)frame.height()
+                );
+                return true;
+            }
+            else {
+                /* 
+                - this checks that the matched waterfill object contains the black outline
+                - for matching waterfill objects, apply a mask filter to retain all black components
+                - if this is a true positive, waterfill_sub_binary_image should be a black outline of the hand. 
+                - if false positive, it will be a pure white image
+                - then apply the waterfill+template match algorithm on the resulting waterfill_sub_binary_image
+                - this helps to remove false positives (e.g. lettuce)
+                */
+                ImageRGB32 waterfill_sub_binary_image = extract_box_reference(extract_box_reference(frame, area_to_search), object).copy();
+                auto matrices = compress_rgb32_to_binary_range(waterfill_sub_binary_image, black_filters);
+                filter_by_mask(matrices[0], waterfill_sub_binary_image, Color(COLOR_WHITE), true);
+
+                if (PreloadSettings::debug().IMAGE_TEMPLATE_MATCHING){
+                    dump_debug_image(
+                        global_logger_command_line(), 
+                        "CommonFramework/SandwichHandDetector", 
+                        "waterfill_sub_binary_image", 
+                        waterfill_sub_binary_image);
+                }
+                
+                match_template_by_waterfill(
+                    waterfill_sub_binary_image, 
+                    ((m_type == HandType::FREE) ? SandwichFreeHandMatcher2::instance() : SandwichGrabbingHandMatcher2::instance()),
+                    filters,
+                    {min_size, SIZE_MAX},
+                    60,
+                    [&](Kernels::Waterfill::WaterfillObject& object2) -> bool {
+                        hand_location = std::make_pair(
+                            (object.center_of_gravity_x() + pixel_box.min_x) / (double)frame.width(),
+                            (object.center_of_gravity_y() + pixel_box.min_y) / (double)frame.height()
+                        );
+                        return true;
+                    }
+                );
+                return false;
+            }
+
         }
     );
-
     return hand_location;
 }
 
@@ -134,7 +220,7 @@ bool SandwichHandWatcher::process_frame(const VideoSnapshot& frame){
 
 std::pair<double, double> SandwichHandWatcher::search_entire_screen_for_sandwich_hand(const ImageViewRGB32& frame) const{
     ImageFloatBox entire_screen(0.0, 0.0, 1.0, 1.0);
-    return m_locator.locate_sandwich_hand(frame, entire_screen);
+    return m_locator.locate_sandwich_hand(frame, entire_screen, true);
 }
 
 

--- a/SerialPrograms/Source/PokemonSV/Inference/Picnics/PokemonSV_SandwichHandDetector.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Picnics/PokemonSV_SandwichHandDetector.h
@@ -42,6 +42,10 @@ public:
 
     void change_box(const ImageFloatBox& new_box) { m_box = new_box; }
 
+    // return the coordinates of the sandwich hand.
+    // search within the confines of the box area_to_search.
+    std::pair<double, double> locate_sandwich_hand(const ImageViewRGB32& frame, ImageFloatBox area_to_search) const;
+
 private:
     HandType m_type;
     ImageFloatBox m_box;
@@ -62,6 +66,9 @@ public:
     const std::pair<double, double>& location() const { return m_location; }
 
     void change_box(const ImageFloatBox& new_box) { m_locator.change_box(new_box); }
+
+    std::pair<double, double> search_entire_screen_for_sandwich_hand(const ImageViewRGB32& frame) const;
+
 
 private:
     SandwichHandLocator m_locator;

--- a/SerialPrograms/Source/PokemonSV/Inference/Picnics/PokemonSV_SandwichHandDetector.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Picnics/PokemonSV_SandwichHandDetector.h
@@ -44,7 +44,7 @@ public:
 
     // return the coordinates of the sandwich hand.
     // search within the confines of the box area_to_search.
-    std::pair<double, double> locate_sandwich_hand(const ImageViewRGB32& frame, ImageFloatBox area_to_search) const;
+    std::pair<double, double> locate_sandwich_hand(const ImageViewRGB32& frame, ImageFloatBox area_to_search, bool check_outline) const;
 
 private:
     HandType m_type;

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichMaker.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichMaker.cpp
@@ -53,6 +53,14 @@ SandwichMaker::SandwichMaker()
 void SandwichMaker::program(SingleSwitchProgramEnvironment& env, BotBaseContext& context){
     assert_16_9_720p_min(env.logger(), env.console);
 
+    #if 0
+        // make unlimited sandwiches. until it errors out.
+        while (true){
+            make_sandwich_option(env, env.console, context, SANDWICH_OPTIONS);
+            enter_sandwich_recipe_list(env.program_info(), env.console, context);
+        }
+    #endif
+
     make_sandwich_option(env, env.console, context, SANDWICH_OPTIONS);
 
     GO_HOME_WHEN_DONE.run_end_of_program(context);

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
@@ -304,6 +304,20 @@ ImageFloatBox move_sandwich_hand(
     WallClock cur_time, last_time;
     VideoOverlaySet overlay_set(console.overlay());
 
+    #if 0
+        // to intentionally trigger failures in hand detection, for testing recovery
+        if (SandwichHandType::FREE == hand_type){
+            std::pair<double, double> hand_location(1.0, 1.0);
+            const ImageFloatBox hand_bb_debug = hand_location_to_box(hand_location); 
+            const ImageFloatBox expanded_hand_bb_debug = expand_box(hand_bb_debug);
+            hand_watcher.change_box(expanded_hand_bb_debug);
+            overlay_set.clear();
+            overlay_set.add(COLOR_RED, hand_bb_debug);
+            overlay_set.add(COLOR_BLUE, expanded_hand_bb_debug);
+            pbf_move_left_joystick(context, 0, 0, TICKS_PER_SECOND*5, 100);  // move hand to screen edge
+        }
+    #endif
+
     while(true){
         int ret = wait_until(console, context, std::chrono::seconds(5), {hand_watcher});
         if (ret < 0){

--- a/SerialPrograms/Source/Tests/PokemonSV_Tests.cpp
+++ b/SerialPrograms/Source/Tests/PokemonSV_Tests.cpp
@@ -196,6 +196,11 @@ int test_pokemonSV_SandwichRecipeDetector(const ImageViewRGB32& image, const std
     return 0;
 }
 
+/* 
+- the last 4 words should be the coordinates for the FloatBox, that the detector will search
+- the 5th word from last should be the Hand type (Free or Grabbing)
+- if the image should not detect the hand, the 6th word from last should "False"
+ */
 int test_pokemonSV_SandwichHandDetector(const ImageViewRGB32& image, const std::vector<std::string>& words){
     // five words: hand_type("Free"/"Grabbing"), <image float box (four words total)>
     if (words.size() < 5){
@@ -225,6 +230,25 @@ int test_pokemonSV_SandwichHandDetector(const ImageViewRGB32& image, const std::
     ImageFloatBox box(box_values[0], box_values[1], box_values[2], box_values[3]);
 
     SandwichHandLocator detector(hand_type, box);
+
+    // for testing locate_sandwich_hand(), which does a second check to ensure the 
+    // hand has a black outline around it.
+    auto hand_expected_word = words[words.size() - 6];
+    if(hand_expected_word == "False"){
+        auto result = detector.locate_sandwich_hand(image, box, true);
+        bool has_hand = result.first >= 0.0;
+
+        TEST_RESULT_EQUAL(has_hand, false);
+        return 0;
+    }
+    else if (hand_expected_word == "True"){
+        auto result = detector.locate_sandwich_hand(image, box, true);
+        bool has_hand = result.first >= 0.0;
+
+        TEST_RESULT_EQUAL(has_hand, true);
+        return 0;
+    }
+    
 
     auto result = detector.detect(image);
     bool has_hand = result.first >= 0.0;


### PR DESCRIPTION
Updated the detector to reduce false positives on lettuce. It checks that the matched waterfill object contains the black outline.
- for waterfill objects that matched the hand template, apply a mask filter to retain all black components
- if this is a true positive, waterfill_sub_binary_image should be a black outline of the hand. 
- if false positive, it will be a pure white image
- then apply the waterfill+template match algorithm on the resulting waterfill_sub_binary_image
- this helps to remove false positives (e.g. lettuce)

SandwichHandLocator::detect will still use the old method of detection, for performance reasons (I didn't test it, but I imagine that adding an extra round of waterfill matching will worsen the lag in an already laggy program).
So, I think that detecting the black outline should only be done for recovery routines.

I recommend merging #428 first.