### PR TITLE
Take screenshots

### DIFF
--- a/SerialPrograms/Source/NintendoSwitch/Programs/NintendoSwitch_SnapshotDumper.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/Programs/NintendoSwitch_SnapshotDumper.cpp
@@ -69,7 +69,13 @@ void SnapshotDumper::program(SingleSwitchProgramEnvironment& env, BotBaseContext
     }
 }
 
-
+void dump_snapshot(ConsoleHandle& console, std::string folder_name){
+    std::string folder_path = USER_FILE_PATH() + folder_name + "/";
+    QDir().mkpath(folder_path.c_str());
+    VideoSnapshot last = console.video().snapshot();
+    std::string filename = folder_path + now_to_filestring() + ".png";
+    last->save(filename);
+}
 
 
 }

--- a/SerialPrograms/Source/NintendoSwitch/Programs/NintendoSwitch_SnapshotDumper.h
+++ b/SerialPrograms/Source/NintendoSwitch/Programs/NintendoSwitch_SnapshotDumper.h
@@ -37,7 +37,8 @@ private:
     EnumDropdownOption<Format> FORMAT;
 };
 
-
+// takes a snapshot of the screen and saves it to the given folder_name
+void dump_snapshot(ConsoleHandle& console, std::string folder_name = "ScreenshotDumper");
 
 }
 }


### PR DESCRIPTION
Added a function that can easily take screenshots and save the image to the specified folder. The pre-existing functions in ErrorDumper and DebugDumper do work, but I feel my new function is more straightforward to use.

I'm not sure if it's best for this function to be in `NintendoSwitch_SnapshotDumper` or another file like `DebugDumper`. 