### PR TITLE
Update EggFetcher_Core.c

### DIFF
--- a/NativePrograms/PokemonSV/Programs/EggFetcher_Core.c
+++ b/NativePrograms/PokemonSV/Programs/EggFetcher_Core.c
@@ -10,7 +10,7 @@
 
 void fly_to_gate(void) {
     pbf_press_button(BUTTON_A, 20, 500);
-    pbf_press_button(BUTTON_Y, 20, 800);
+    pbf_press_button(BUTTON_Y, 20, 1000);
     pbf_move_left_joystick(STICK_MAX, STICK_MAX, 6, 500);
     pbf_mash_button(BUTTON_A, 1000);
 };
@@ -47,6 +47,8 @@ int main(void) {
     };
     pbf_press_button(BUTTON_A, 5, 500);
 
+    fly_to_gate();
+    pbf_move_right_joystick(STICK_CENTER, STICK_MIN, 5, 0);
     open_picnic();
     move_to_basket();
 


### PR DESCRIPTION
Extended the delays in the fly to gate function to combat lag in pokemn SV introduced post the new updates. Also made it so when the program starts the program first automatically flies to the gate inorder to combat any positioning error that may have been caused due to stick drift. Also makes it simpler to launch the program as now the user just needs to be in the crater as opposed to earlier where they had to fly to it and stand on roughly the exact same spot.