### PR TITLE
Automatically adjust delay for ItemPrinterRNG

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.cpp
@@ -116,7 +116,6 @@ ItemPrinterRngRow::ItemPrinterRngRow()
         ItemPrinterItems::NONE
     )
     , prev_desired_item(ItemPrinterItems::NONE)
-    // , prev_desired_item_is_none(true)
 {
     PA_ADD_OPTION(chain);
     PA_ADD_OPTION(date);
@@ -441,8 +440,6 @@ void ItemPrinterRngRow::value_changed(){
         prev_desired_item = desired_item;
         return;
     }
-    // std::cout << chain << std::endl;
-    // std::cout << "changed" << std::endl;
     desired_item.set(ItemPrinterItems::NONE);
 }
 
@@ -580,7 +577,7 @@ ItemPrinterRNG::ItemPrinterRNG()
 void ItemPrinterRNG::run_print_at_date(
     SingleSwitchProgramEnvironment& env, BotBaseContext& context,
     const DateTime& date, ItemPrinterJobs jobs
-) const{
+) {
     ItemPrinterRNG_Descriptor::Stats& stats = env.current_stats<ItemPrinterRNG_Descriptor::Stats>();
 
     bool printed = false;
@@ -682,7 +679,10 @@ void ItemPrinterRNG::run_print_at_date(
             stats.prints++;
             env.update_stats();
             printed = true;
-            item_printer_finish_print(env.inference_dispatcher(), env.console, context, LANGUAGE);
+            std::array<std::string, 10> print_results = item_printer_finish_print(env.inference_dispatcher(), env.console, context, LANGUAGE);
+            uint64_t seed = to_seconds_since_epoch(date);
+            adjust_delay(print_results, seed);
+
 //            pbf_press_button(context, BUTTON_B, 20, 30);
             continue;
         }
@@ -697,6 +697,370 @@ void ItemPrinterRNG::run_print_at_date(
         }
     }
 }
+
+void ItemPrinterRNG::adjust_delay(std::array<std::string, 10> print_results, uint64_t seed){
+    DistanceFromTarget distance_from_target = get_distance_from_target(print_results, seed);
+    int16_t delay_adjustment;
+    int16_t current_delay_mills = DELAY_MILLIS;
+    switch (distance_from_target){
+    case DistanceFromTarget::UNKNOWN:
+    case DistanceFromTarget::ON_TARGET:
+        delay_adjustment = 0;
+        break;
+    case DistanceFromTarget::MINUS_1:
+        delay_adjustment = -50;
+        break;
+    case DistanceFromTarget::MINUS_2:
+        delay_adjustment =  -1000;
+        break;
+    case DistanceFromTarget::PLUS_1:
+        delay_adjustment =  50;
+        break;
+    case DistanceFromTarget::PLUS_2:
+        delay_adjustment = 1000;
+        break;        
+    default:
+        delay_adjustment = 0;
+        break;
+    }
+
+    int16_t new_delay = current_delay_mills + delay_adjustment;
+    if (new_delay < 0){
+        new_delay = 0;
+    }
+
+    DELAY_MILLIS.set((uint16_t) new_delay);
+    
+}
+
+DistanceFromTarget ItemPrinterRNG::get_distance_from_target(std::array<std::string, 10> print_results, uint64_t seed){
+    DistanceFromTarget distance_from_target;
+    std::array<std::string, 10> target_result;
+    std::array<std::string, 10> target_result_plus_1;
+    std::array<std::string, 10> target_result_minus_1;
+    std::array<std::string, 10> target_result_plus_2;
+    std::array<std::string, 10> target_result_minus_2;
+    bool unknown_seed = false;
+    
+    switch (seed){
+    case 2346161588: // item bonus
+        std::cout << "Item bonus: ";
+        target_result_minus_2 = {"stardust", "", "", "", "", "", "", "", "", ""};
+        target_result_minus_1 = {"tiny-mushroom", "", "", "", "", "", "", "", "", ""};
+        target_result = {"calcium", "", "", "", "", "", "", "", "", ""};
+        target_result_plus_1 = {"max-ether", "", "", "", "", "", "", "", "", ""};
+        target_result_plus_2 = {"electric-tera-shard", "", "", "", "", "", "", "", "", ""};
+        break;
+    case 1717461428: // ball bonus
+        std::cout << "Ball bonus: ";
+        target_result_minus_2 = {"balm-mushroom", "", "", "", "", "", "", "", "", ""};
+        target_result_minus_1 = {"revive", "", "", "", "", "", "", "", "", ""};
+        target_result = {"full-restore", "", "", "", "", "", "", "", "", ""};
+        target_result_plus_1 = {"fairy-tera-shard", "", "", "", "", "", "", "", "", ""};
+        target_result_plus_2 = {"big-bamboo-shoot", "", "", "", "", "", "", "", "", ""};
+        break;        
+    case 958172368:
+        std::cout << "Ability patch: ";
+        target_result_minus_2 = {"dark-tera-shard", "revive", "reaper-cloth", "ability-patch", "poison-tera-shard", "", "", "", "", ""};
+        target_result_minus_1 = {"dark-tera-shard", "fire-tera-shard", "big-bamboo-shoot", "balm-mushroom", "super-potion", "", "", "", "", ""};
+        target_result = {"dark-tera-shard", "ability-patch", "ability-patch", "ability-patch", "ability-patch", "", "", "", "", ""};
+        target_result_plus_1 = {"dark-tera-shard", "pearl", "spell-tag", "flower-sweet", "ribbon-sweet", "", "", "", "", ""};
+        target_result_plus_2 = {"dark-tera-shard", "water-stone", "max-potion", "tiny-mushroom", "electric-tera-shard", "", "", "", "", ""};
+        break;
+    case 1991472489:
+        std::cout << "EXP_CANDY: ";
+        target_result_minus_2 = {"exp-candy-xl", "tiny-bamboo-shoot", "exp-candy-s", "iron", "tiny-bamboo-shoot", "", "", "", "", ""};
+        target_result_minus_1 = {"exp-candy-xl", "toxic-orb", "rare-bone", "silver-powder", "lucky-egg", "", "", "", "", ""};
+        target_result         = {"exp-candy-xl", "protein", "exp-candy-l", "exp-candy-xl", "exp-candy-xl", "", "", "", "", ""};
+        target_result_plus_1  = {"exp-candy-xl", "silver-powder", "dubious-disc", "mystic-water", "toxic-orb", "", "", "", "", ""};
+        target_result_plus_2  = {"exp-candy-xl", "tiny-bamboo-shoot", "toxic-orb", "ice-stone", "charcoal", "", "", "", "", ""};
+        break;
+    case 2246577010:
+        std::cout << "NORMAL_TERA: ";
+        target_result_minus_2 = {"normal-tera-shard", "exp-candy-l", "star-piece", "tiny-mushroom", "rock-tera-shard", "", "", "", "", ""};
+        target_result_minus_1 = {"normal-tera-shard", "oval-stone", "ether", "stardust", "steel-tera-shard", "", "", "", "", ""};
+        target_result         = {"normal-tera-shard", "normal-tera-shard", "normal-tera-shard", "normal-tera-shard", "normal-tera-shard", "", "", "", "", ""};
+        target_result_plus_1  = {"normal-tera-shard", "exp-candy-s", "ether", "elixir", "big-pearl", "", "", "", "", ""};
+        target_result_plus_2  = {"normal-tera-shard", "dragon-tera-shard", "ice-tera-shard", "exp-candy-xl", "black-sludge", "", "", "", "", ""};
+        break;
+    case 2669513710:
+        std::cout << "FIRE_TERA: ";
+        target_result_minus_2 = {"fire-tera-shard", "flame-orb", "steel-tera-shard", "fire-stone", "max-revive", "", "", "", "", ""};
+        target_result_minus_1 = {"fire-tera-shard", "exp-candy-xs", "miracle-seed", "sun-stone", "iron", "", "", "", "", ""};
+        target_result         = {"fire-tera-shard", "fire-tera-shard", "fire-tera-shard", "fire-tera-shard", "honey", "", "", "", "", ""};
+        target_result_plus_1  = {"fire-tera-shard", "poison-tera-shard", "love-sweet", "safety-goggles", "exp-candy-m", "", "", "", "", ""};
+        target_result_plus_2  = {"fire-tera-shard", "rare-bone", "dubious-disc", "berry-sweet", "hp-up", "", "", "", "", ""};
+        break;
+    case 2419526534:
+        std::cout << "WATER_TERA: ";
+        target_result_minus_2 = {"water-tera-shard", "exp-candy-xs", "flame-orb", "exp-candy-s", "honey", "", "", "", "", ""};
+        target_result_minus_1 = {"water-tera-shard", "never-melt-ice", "rock-tera-shard", "hp-up", "sun-stone", "", "", "", "", ""};
+        target_result         = {"water-tera-shard", "full-restore", "water-tera-shard", "flying-tera-shard", "water-tera-shard", "", "", "", "", ""};
+        target_result_plus_1  = {"water-tera-shard", "heavy-duty-boots", "moon-stone", "strawberry-sweet", "exp-candy-xs", "", "", "", "", ""};
+        target_result_plus_2  = {"water-tera-shard", "ghost-tera-shard", "max-revive", "ground-tera-shard", "exp-candy-xl", "", "", "", "", ""};
+        break;
+    case 1300121653:
+        std::cout << "ELECTRIC_TERA: ";
+        target_result_minus_2 = {"electric-tera-shard", "elixir", "full-restore", "upgrade", "toxic-orb", "", "", "", "", ""};
+        target_result_minus_1 = {"electric-tera-shard", "exp-candy-xs", "steel-tera-shard", "big-mushroom", "exp-candy-s", "", "", "", "", ""};
+        target_result         = {"electric-tera-shard", "light-clay", "electric-tera-shard", "electric-tera-shard", "electric-tera-shard", "", "", "", "", ""};
+        target_result_plus_1  = {"electric-tera-shard", "calcium", "ground-tera-shard", "water-tera-shard", "upgrade", "", "", "", "", ""};
+        target_result_plus_2  = {"electric-tera-shard", "max-potion", "charcoal", "exp-candy-xs", "grass-tera-shard", "", "", "", "", ""};
+        break;                        
+    case 1258326250:
+        std::cout << "GRASS_TERA: ";
+        target_result_minus_2 = {"grass-tera-shard", "pretty-feather", "exp-candy-m", "bug-tera-shard", "tiny-mushroom", "", "", "", "", ""};
+        target_result_minus_1 = {"grass-tera-shard", "ghost-tera-shard", "bug-tera-shard", "silver-powder", "berry-sweet", "", "", "", "", ""};
+        target_result         = {"grass-tera-shard", "tiny-mushroom", "grass-tera-shard", "grass-tera-shard", "grass-tera-shard", "", "", "", "", ""};
+        target_result_plus_1  = {"grass-tera-shard", "steel-tera-shard", "honey", "strawberry-sweet", "normal-tera-shard", "", "", "", "", ""};
+        target_result_plus_2  = {"grass-tera-shard", "exp-candy-xl", "exp-candy-xs", "zinc", "dragon-fang", "", "", "", "", ""};
+        break; 
+    case 2567326030:
+        std::cout << "ICE_TERA: ";
+        target_result_minus_2 = {"ice-tera-shard", "pearl-string", "dragon-tera-shard", "sun-stone", "water-tera-shard", "", "", "", "", ""};
+        target_result_minus_1 = {"ice-tera-shard", "scope-lens", "full-restore", "dubious-disc", "lucky-egg", "", "", "", "", ""};
+        target_result         = {"ice-tera-shard", "ice-tera-shard", "ice-tera-shard", "ice-tera-shard", "metal-alloy", "", "", "", "", ""};
+        target_result_plus_1  = {"ice-tera-shard", "poison-barb", "leaf-stone", "cracked-pot", "ghost-tera-shard", "", "", "", "", ""};
+        target_result_plus_2  = {"ice-tera-shard", "exp-candy-xs", "rock-tera-shard", "loaded-dice", "Pretty Feather", "", "", "", "", ""};
+        break;
+    case 1510682535:
+        std::cout << "FIGHTING_TERA: ";
+        target_result_minus_2 = {"fairy-feather", "normal-tera-shard", "air-balloon", "poison-tera-shard", "pearl", "", "", "", "", ""};
+        target_result_minus_1 = {"strawberry-sweet", "electric-tera-shard", "calcium", "revive", "ghost-tera-shard", "", "", "", "", ""};
+        target_result         = {"fighting-tera-shard", "fighting-tera-shard", "fighting-tera-shard", "fighting-tera-shard", "shiny-stone", "", "", "", "", ""};
+        target_result_plus_1  = {"miracle-seed", "fighting-tera-shard", "ice-tera-shard", "light-clay", "dark-tera-shard", "", "", "", "", ""};
+        target_result_plus_2  = {"rare-bone", "max-elixir", "leaf-stone", "metal-alloy", "magmarizer", "", "", "", "", ""};
+        break;
+    case 2041396572:
+        std::cout << "POISON_TERA: ";
+        target_result_minus_2 = {"electirizer", "upgrade", "zinc", "elixir", "revive", "", "", "", "", ""};
+        target_result_minus_1 = {"electirizer", "flame-orb", "magmarizer", "hp-up", "pretty-feather", "", "", "", "", ""};
+        target_result         = {"electirizer", "poison-tera-shard", "poison-tera-shard", "poison-tera-shard", "poison-tera-shard", "", "", "", "", ""};
+        target_result_plus_1  = {"electirizer", "pp-up", "rock-tera-shard", "big-mushroom", "light-clay", "", "", "", "", ""};
+        target_result_plus_2  = {"electirizer", "fire-tera-shard", "revive", "big-bamboo-shoot", "dark-tera-shard", "", "", "", "", ""};
+        break;
+    case 1463321889:
+        std::cout << "GROUND_TERA: ";
+        target_result_minus_2 = {"pp-up", "pretty-feather", "max-ether", "big-pearl", "carbos", "", "", "", "", ""};
+        target_result_minus_1 = {"pp-up", "spell-tag", "bug-tera-shard", "pearl", "fighting-tera-shard", "", "", "", "", ""};
+        target_result         = {"pp-up", "ground-tera-shard", "ground-tera-shard", "ground-tera-shard", "ground-tera-shard", "", "", "", "", ""};
+        target_result_plus_1  = {"pp-up", "metal-alloy", "full-restore", "pearl", "silver-powder", "", "", "", "", ""};
+        target_result_plus_2  = {"pp-up", "ghost-tera-shard", "nugget", "safety-goggles", "leftovers", "", "", "", "", ""};
+        break; 
+    case 1580633500:
+        std::cout << "FLYING_TERA: ";
+        target_result_minus_2 = {"black-glasses", "big-nugget", "max-revive", "pearl-string", "balm-mushroom", "", "", "", "", ""};
+        target_result_minus_1 = {"loaded-dice", "exp-candy-s", "strawberry-sweet", "never-melt-ice", "moon-stone", "", "", "", "", ""};
+        target_result         = {"flying-tera-shard", "flying-tera-shard", "flying-tera-shard", "flying-tera-shard", "flying-tera-shard", "", "", "", "", ""};
+        target_result_plus_1  = {"water-stone", "rare-bone", "max-ether", "moon-stone", "ability-patch", "", "", "", "", ""};
+        target_result_plus_2  = {"max-ether", "big-bamboo-shoot", "iron", "big-mushroom", "pearl", "", "", "", "", ""};
+        break; 
+    case 2190593713:
+        std::cout << "PSYCHIC_TERA: ";
+        target_result_minus_2 = {"psychic-tera-shard", "big-mushroom", "fairy-feather", "fairy-tera-shard", "reaper-cloth", "", "", "", "", ""};
+        target_result_minus_1 = {"psychic-tera-shard", "electric-tera-shard", "pearl", "stellar-tera-shard", "dawn-stone", "", "", "", "", ""};
+        target_result         = {"psychic-tera-shard", "never-melt-ice", "psychic-tera-shard", "psychic-tera-shard", "psychic-tera-shard", "", "", "", "", ""};
+        target_result_plus_1  = {"psychic-tera-shard", "pearl-string", "twisted-spoon", "big-pearl", "iron", "", "", "", "", ""};
+        target_result_plus_2  = {"psychic-tera-shard", "heavy-duty-boots", "water-tera-shard", "rock-tera-shard", "twisted-spoon", "", "", "", "", ""};
+        break;
+    case 2458109848:
+        std::cout << "BUG_TERA: ";
+        target_result_minus_2 = {"ether", "big-nugget", "mystic-water", "pretty-feather", "pretty-feather", "", "", "", "", ""};
+        target_result_minus_1 = {"ether", "psychic-tera-shard", "exp-candy-s", "honey", "sharp-beak", "", "", "", "", ""};
+        target_result         = {"ether", "bug-tera-shard", "bug-tera-shard", "bug-tera-shard", "bug-tera-shard", "", "", "", "", ""};
+        target_result_plus_1  = {"ether", "black-glasses", "fighting-tera-shard", "tiny-bamboo-shoot", "poison-barb", "", "", "", "", ""};
+        target_result_plus_2  = {"ether", "exp-candy-xl", "normal-tera-shard", "fairy-tera-shard", "balm-mushroom", "", "", "", "", ""};
+        break;
+    case 2801954289:
+        std::cout << "ROCK_TERA: ";
+        target_result_minus_2 = {"max-revive", "scope-lens", "razor-claw", "big-nugget", "tiny-bamboo-shoot", "", "", "", "", ""};
+        target_result_minus_1 = {"iron", "dark-tera-shard", "air-balloon", "rare-bone", "ability-patch", "", "", "", "", ""};
+        target_result         = {"rock-tera-shard", "rock-tera-shard", "pretty-feather", "rock-tera-shard", "stardust", "", "", "", "", ""};
+        target_result_plus_1  = {"normal-tera-shard", "ground-tera-shard", "honey", "upgrade", "honey", "", "", "", "", ""};
+        target_result_plus_2  = {"heavy-duty-boots", "ice-tera-shard", "sun-stone", "dubious-disc", "pearl", "", "", "", "", ""};
+        break;
+    case 1509904271:
+        std::cout << "GHOST_TERA: ";
+        target_result_minus_2 = {"ghost-tera-shard", "hyper-potion", "toxic-orb", "magmarizer", "black-glasses", "", "", "", "", ""};
+        target_result_minus_1 = {"ghost-tera-shard", "black-belt", "pp-up", "ice-tera-shard", "magmarizer", "", "", "", "", ""};
+        target_result         = {"ghost-tera-shard", "ghost-tera-shard", "ghost-tera-shard", "magnet", "ghost-tera-shard", "", "", "", "", ""};
+        target_result_plus_1  = {"ghost-tera-shard", "big-nugget", "hp-up", "gold-bottle-cap", "big-bamboo-shoot", "", "", "", "", ""};
+        target_result_plus_2  = {"ghost-tera-shard", "hp-up", "elixir", "water-tera-shard", "pp-up", "", "", "", "", ""};
+        break;                        
+    case 2155674309:
+        std::cout << "DRAGON_TERA: ";
+        target_result_minus_2 = {"comet-shard", "soft-sand", "big-mushroom", "steel-tera-shard", "metronome", "", "", "", "", ""};
+        target_result_minus_1 = {"pearl", "balm-mushroom", "moon-stone", "protein", "ability-patch", "", "", "", "", ""};
+        target_result         = {"ability-patch", "dragon-tera-shard", "dragon-tera-shard", "dragon-tera-shard", "dragon-tera-shard", "", "", "", "", ""};
+        target_result_plus_1  = {"reaper-cloth", "hp-up", "revive", "light-clay", "focus-band", "", "", "", "", ""};
+        target_result_plus_2  = {"spell-tag", "love-sweet", "fire-tera-shard", "ether", "black-belt", "", "", "", "", ""};
+        break; 
+    case 2537180413:
+        std::cout << "DARK_TERA: ";
+        target_result_minus_2 = {"dark-tera-shard", "upgrade", "big-mushroom", "normal-tera-shard", "exp-candy-m", "", "", "", "", ""};
+        target_result_minus_1 = {"dark-tera-shard", "pp-max", "calcium", "rock-tera-shard", "hard-stone", "", "", "", "", ""};
+        target_result         = {"dark-tera-shard", "dark-tera-shard", "dark-tera-shard", "dark-tera-shard", "prism-scale", "", "", "", "", ""};
+        target_result_plus_1  = {"dark-tera-shard", "leaf-stone", "big-pearl", "comet-shard", "exp-candy-m", "", "", "", "", ""};
+        target_result_plus_2  = {"dark-tera-shard", "ground-tera-shard", "fairy-tera-shard", "exp-candy-xs", "fighting-tera-shard", "", "", "", "", ""};
+        break; 
+    case 1766067369:
+        std::cout << "STEEL_TERA: ";
+        target_result_minus_2 = {"steel-tera-shard", "bug-tera-shard", "exp-candy-xl", "pretty-feather", "silk-scarf", "", "", "", "", ""};
+        target_result_minus_1 = {"steel-tera-shard", "tiny-mushroom", "super-potion", "sharp-beak", "ice-tera-shard", "", "", "", "", ""};
+        target_result         = {"steel-tera-shard", "steel-tera-shard", "steel-tera-shard", "steel-tera-shard", "berry-sweet", "", "", "", "", ""};
+        target_result_plus_1  = {"steel-tera-shard", "moon-stone", "exp-candy-xl", "iron", "exp-candy-xs", "", "", "", "", ""};
+        target_result_plus_2  = {"steel-tera-shard", "metal-alloy", "ability-patch", "pp-up", "rare-bone", "", "", "", "", ""};
+        break;
+    case 2183028974:
+        std::cout << "FAIRY_TERA: ";
+        target_result_minus_2 = {"max-elixir", "never-melt-ice", "pearl", "max-potion", "pp-up", "", "", "", "", ""};
+        target_result_minus_1 = {"full-restore", "psychic-tera-shard", "gold-bottle-cap", "dawn-stone", "never-melt-ice", "", "", "", "", ""};
+        target_result         = {"fairy-tera-shard", "fairy-tera-shard", "water-tera-shard", "tiny-bamboo-shoot", "fairy-tera-shard", "", "", "", "", ""};
+        target_result_plus_1  = {"ice-tera-shard", "twisted-spoon", "exp-candy-s", "max-elixir", "razor-fang", "", "", "", "", ""};
+        target_result_plus_2  = {"exp-candy-xl", "bug-tera-shard", "star-piece", "hp-up", "bug-tera-shard", "", "", "", "", ""};
+        break;
+    case 1165654034:
+        std::cout << "STELLAR_TERA: ";
+        target_result_minus_2 = {"stellar-tera-shard", "pp-up", "scope-lens", "electric-tera-shard", "metronome", "", "", "", "", ""};
+        target_result_minus_1 = {"stellar-tera-shard", "dragon-tera-shard", "honey", "steel-tera-shard", "max-potion", "", "", "", "", ""};
+        target_result         = {"stellar-tera-shard", "max-revive", "stellar-tera-shard", "stellar-tera-shard", "clover-sweet", "", "", "", "", ""};
+        target_result_plus_1  = {"stellar-tera-shard", "full-heal", "toxic-orb", "max-potion", "miracle-seed", "", "", "", "", ""};
+        target_result_plus_2  = {"stellar-tera-shard", "big-bamboo-shoot", "poison-tera-shard", "honey", "oval-stone", "", "", "", "", ""};
+        break;
+    case 1131363128:
+        std::cout << "MASTER_BALL: ";
+        target_result_minus_2 = {"master-ball", "great-ball", "quick-ball", "luxury-ball", "heal-ball", "", "", "", "", ""};
+        target_result_minus_1 = {"master-ball", "great-ball", "timer-ball", "fast-ball", "love-ball", "", "", "", "", ""};
+        target_result         = {"master-ball", "master-ball", "great-ball", "master-ball", "master-ball", "", "", "", "", ""};
+        target_result_plus_1  = {"master-ball", "premier-ball", "great-ball", "luxury-ball", "heal-ball", "", "", "", "", ""};
+        target_result_plus_2  = {"master-ball", "quick-ball", "poke-ball", "premier-ball", "poke-ball", "", "", "", "", ""};
+        break;                        
+    case 2493163222:
+        std::cout << "SAFARI_BALL: ";
+        target_result_minus_2 = {"premier-ball", "great-ball", "lure-ball", "ultra-ball", "safari-ball", "", "", "", "", ""};
+        target_result_minus_1 = {"premier-ball", "great-ball", "poke-ball", "poke-ball", "poke-ball", "", "", "", "", ""};
+        target_result         = {"safari-ball", "safari-ball", "safari-ball", "safari-ball", "safari-ball", "", "", "", "", ""};
+        target_result_plus_1  = {"poke-ball", "poke-ball", "poke-ball", "premier-ball", "great-ball", "", "", "", "", ""};
+        target_result_plus_2  = {"great-ball", "great-ball", "level-ball", "poke-ball", "safari-ball", "", "", "", "", ""};
+        break;       
+    case 2040690819:
+        std::cout << "FAST_BALL: ";
+        target_result_minus_2 = {"fast-ball", "lure-ball", "dream-ball", "friend-ball", "level-ball", "", "", "", "", ""};
+        target_result_minus_1 = {"fast-ball", "great-ball", "quick-ball", "great-ball", "heal-ball", "", "", "", "", ""};
+        target_result         = {"fast-ball", "fast-ball", "fast-ball", "fast-ball", "fast-ball", "", "", "", "", ""};
+        target_result_plus_1  = {"fast-ball", "dream-ball", "luxury-ball", "luxury-ball", "premier-ball", "", "", "", "", ""};
+        target_result_plus_2  = {"fast-ball", "luxury-ball", "great-ball", "poke-ball", "premier-ball", "", "", "", "", ""};
+        break;  
+    case 2373357938:
+        std::cout << "LEVEL_BALL: ";
+        target_result_minus_2 = {"dusk-ball", "heal-ball", "luxury-ball", "premier-ball", "poke-ball", "", "", "", "", ""};
+        target_result_minus_1 = {"great-ball", "dive-ball", "dream-ball", "luxury-ball", "luxury-ball", "", "", "", "", ""};
+        target_result         = {"level-ball", "level-ball", "level-ball", "level-ball", "level-ball", "", "", "", "", ""};
+        target_result_plus_1  = {"repeat-ball", "heal-ball", "heal-ball", "luxury-ball", "dive-ball", "", "", "", "", ""};
+        target_result_plus_2  = {"luxury-ball", "master-ball", "premier-ball", "ultra-ball", "heal-ball", "", "", "", "", ""};
+        break;  
+    case 2773542517:
+        std::cout << "LURE_BALL: ";
+        target_result_minus_2 = {"lure-ball", "premier-ball", "premier-ball", "great-ball", "poke-ball", "", "", "", "", ""};
+        target_result_minus_1 = {"dream-ball", "poke-ball", "poke-ball", "luxury-ball", "poke-ball", "", "", "", "", ""};
+        target_result         = {"lure-ball", "lure-ball", "lure-ball", "lure-ball", "lure-ball", "", "", "", "", ""};
+        target_result_plus_1  = {"luxury-ball", "premier-ball", "great-ball", "luxury-ball", "fast-ball", "", "", "", "", ""};
+        target_result_plus_2  = {"timer-ball", "safari-ball", "dive-ball", "poke-ball", "premier-ball", "", "", "", "", ""};
+        break;       
+    case 1879588391:
+        std::cout << "HEAVY_BALL: ";
+        target_result_minus_2 = {"heavy-ball", "nest-ball", "nest-ball", "heal-ball", "luxury-ball", "", "", "", "", ""};
+        target_result_minus_1 = {"heavy-ball", "poke-ball", "premier-ball", "premier-ball", "heal-ball", "", "", "", "", ""};
+        target_result         = {"heavy-ball", "heavy-ball", "heavy-ball", "heavy-ball", "heavy-ball", "", "", "", "", ""};
+        target_result_plus_1  = {"heavy-ball", "heal-ball", "premier-ball", "timer-ball", "premier-ball", "", "", "", "", ""};
+        target_result_plus_2  = {"heavy-ball", "ultra-ball", "heal-ball", "quick-ball", "beast-ball", "", "", "", "", ""};
+        break;  
+    case 1684733771:
+        std::cout << "LOVE_BALL: ";
+        target_result_minus_2 = {"love-ball", "sport-ball", "great-ball", "poke-ball", "poke-ball", "", "", "", "", ""};
+        target_result_minus_1 = {"love-ball", "poke-ball", "great-ball", "luxury-ball", "master-ball", "", "", "", "", ""};
+        target_result         = {"love-ball", "love-ball", "love-ball", "love-ball", "love-ball", "", "", "", "", ""};
+        target_result_plus_1  = {"love-ball", "great-ball", "luxury-ball", "luxury-ball", "poke-ball", "", "", "", "", ""};
+        target_result_plus_2  = {"love-ball", "luxury-ball", "premier-ball", "poke-ball", "quick-ball", "", "", "", "", ""};
+        break; 
+    case 2428107797:
+        std::cout << "FRIEND_BALL: ";
+        target_result_minus_2 = {"friend-ball", "great-ball", "sport-ball", "great-ball", "great-ball", "", "", "", "", ""};
+        target_result_minus_1 = {"friend-ball", "premier-ball", "heal-ball", "repeat-ball", "nest-ball", "", "", "", "", ""};
+        target_result         = {"friend-ball", "friend-ball", "friend-ball", "friend-ball", "friend-ball", "", "", "", "", ""};
+        target_result_plus_1  = {"friend-ball", "premier-ball", "heavy-ball", "timer-ball", "friend-ball", "", "", "", "", ""};
+        target_result_plus_2  = {"friend-ball", "heal-ball", "great-ball", "beast-ball", "moon-ball", "", "", "", "", ""};
+        break;       
+    case 2296878993:
+        std::cout << "MOON_BALL: ";
+        target_result_minus_2 = {"luxury-ball", "timer-ball", "premier-ball", "luxury-ball", "poke-ball", "", "", "", "", ""};
+        target_result_minus_1 = {"nest-ball", "poke-ball", "heal-ball", "premier-ball", "premier-ball", "", "", "", "", ""};
+        target_result         = {"moon-ball", "moon-ball", "moon-ball", "moon-ball", "moon-ball", "", "", "", "", ""};
+        target_result_plus_1  = {"fast-ball", "heal-ball", "poke-ball", "dusk-ball", "luxury-ball", "", "", "", "", ""};
+        target_result_plus_2  = {"lure-ball", "heavy-ball", "luxury-ball", "heal-ball", "poke-ball", "", "", "", "", ""};
+        break;  
+    case 1244233031:
+        std::cout << "SPORT_BALL: ";
+        target_result_minus_2 = {"sport-ball", "heal-ball", "luxury-ball", "great-ball", "heal-ball", "", "", "", "", ""};
+        target_result_minus_1 = {"sport-ball", "dream-ball", "level-ball", "poke-ball", "luxury-ball", "", "", "", "", ""};
+        target_result         = {"sport-ball", "sport-ball", "sport-ball", "sport-ball", "sport-ball", "", "", "", "", ""};
+        target_result_plus_1  = {"moon-ball", "heal-ball", "poke-ball", "poke-ball", "heal-ball", "", "", "", "", ""};
+        target_result_plus_2  = {"moon-ball", "poke-ball", "ultra-ball", "poke-ball", "great-ball", "", "", "", "", ""};
+        break;    
+    case 2657784681:
+        std::cout << "DREAM_BALL: ";
+        target_result_minus_2 = {"master-ball", "poke-ball", "luxury-ball", "level-ball", "dream-ball", "", "", "", "", ""};
+        target_result_minus_1 = {"timer-ball", "beast-ball", "poke-ball", "premier-ball", "heal-ball", "", "", "", "", ""};
+        target_result         = {"dream-ball", "dream-ball", "dream-ball", "dream-ball", "dream-ball", "", "", "", "", ""};
+        target_result_plus_1  = {"heavy-ball", "poke-ball", "friend-ball", "fast-ball", "heavy-ball", "", "", "", "", ""};
+        target_result_plus_2  = {"luxury-ball", "poke-ball", "luxury-ball", "quick-ball", "friend-ball", "", "", "", "", ""};
+        break;  
+    case 2117201835:
+        std::cout << "BEAST_BALL: ";
+        target_result_minus_2 = {"luxury-ball", "poke-ball", "lure-ball", "master-ball", "dive-ball", "", "", "", "", ""};
+        target_result_minus_1 = {"heavy-ball", "premier-ball", "premier-ball", "poke-ball", "level-ball", "", "", "", "", ""};
+        target_result         = {"beast-ball", "beast-ball", "beast-ball", "beast-ball", "beast-ball", "", "", "", "", ""};
+        target_result_plus_1  = {"heal-ball", "great-ball", "luxury-ball", "heavy-ball", "great-ball", "", "", "", "", ""};
+        target_result_plus_2  = {"poke-ball", "premier-ball", "great-ball", "poke-ball", "dive-ball", "", "", "", "", ""};
+        break;       
+    default:
+        unknown_seed = true;
+        std::cout << "Unknown seed. can't calculate distance from target." << std::endl;
+        break;
+    }
+
+    if (unknown_seed){
+        return DistanceFromTarget::UNKNOWN;
+    }
+
+    if (print_results == target_result){
+        distance_from_target = DistanceFromTarget::ON_TARGET;
+        std::cout << "on target." << std::endl;
+    }
+    else if (print_results == target_result_plus_1){
+        distance_from_target = DistanceFromTarget::PLUS_1;
+        std::cout << "target +1." << std::endl;
+    }
+    else if (print_results == target_result_minus_1){
+        distance_from_target = DistanceFromTarget::MINUS_1;
+        std::cout << "target -1." << std::endl;
+    }
+    else if (print_results == target_result_plus_2){
+        distance_from_target = DistanceFromTarget::PLUS_2;
+        std::cout << "target +2." << std::endl;
+    }
+    else if (print_results == target_result_minus_2){
+        distance_from_target = DistanceFromTarget::MINUS_2;
+        std::cout << "target -2." << std::endl;
+    }
+    else {
+        distance_from_target = DistanceFromTarget::UNKNOWN;
+        std::cout << "unknown distance from target." << std::endl;
+    }
+
+    return distance_from_target;
+}
+
 void ItemPrinterRNG::print_again(
     SingleSwitchProgramEnvironment& env, BotBaseContext& context,
     ItemPrinterJobs jobs

--- a/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.h
@@ -75,13 +75,16 @@ private:
     void run_print_at_date(
         SingleSwitchProgramEnvironment& env, BotBaseContext& context,
         const DateTime& date, ItemPrinterJobs jobs
-    ) const;
+    );
 
     void print_again(
         SingleSwitchProgramEnvironment& env, BotBaseContext& context,
         ItemPrinterJobs jobs
     ) const;
 
+    void adjust_delay(std::array<std::string, 10> print_results, uint64_t seed);
+
+    DistanceFromTarget get_distance_from_target(std::array<std::string, 10> print_results, uint64_t seed);
 
 private:
     OCR::LanguageOCROption LANGUAGE;

--- a/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.h
@@ -82,9 +82,15 @@ private:
         ItemPrinterJobs jobs
     ) const;
 
-    void adjust_delay(std::array<std::string, 10> print_results, uint64_t seed);
+    void adjust_delay(
+        std::array<std::string, 10> print_results, 
+        uint64_t seed, ConsoleHandle& console
+    );
 
-    DistanceFromTarget get_distance_from_target(std::array<std::string, 10> print_results, uint64_t seed);
+    DistanceFromTarget get_distance_from_target(
+        std::array<std::string, 10> print_results, 
+        uint64_t seed, ConsoleHandle& console
+    );
 
 private:
     OCR::LanguageOCROption LANGUAGE;
@@ -95,6 +101,7 @@ private:
     ItemPrinterRngTable TABLE;
 
     SimpleIntegerOption<uint16_t> DELAY_MILLIS;
+    BooleanCheckBoxOption ADJUST_DELAY;
 
     GoHomeWhenDoneOption GO_HOME_WHEN_DONE;
     BooleanCheckBoxOption FIX_TIME_WHEN_DONE;

--- a/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.h
@@ -83,13 +83,19 @@ private:
     ) const;
 
     void adjust_delay(
-        std::array<std::string, 10> print_results, 
+        const std::array<std::string, 10>& print_results, 
         uint64_t seed, ConsoleHandle& console
     );
 
     DistanceFromTarget get_distance_from_target(
-        std::array<std::string, 10> print_results, 
+        const std::array<std::string, 10>& print_results, 
         uint64_t seed, ConsoleHandle& console
+    );
+
+    bool check_print_results_match(
+        const std::array<std::string, 10>& print_results, 
+        const std::array<std::string, 10>& expected_result, 
+        uint8_t max_number_of_mismatches
     );
 
 private:

--- a/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterTools.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterTools.h
@@ -66,6 +66,15 @@ enum class ItemPrinterItems{
     SPORT_BALL,
 };
 
+enum class DistanceFromTarget{
+    UNKNOWN,
+    ON_TARGET,
+    MINUS_1,
+    MINUS_2,
+    PLUS_1,
+    PLUS_2,
+};
+
 
 void item_printer_start_print(
     ConsoleHandle& console, BotBaseContext& context,


### PR DESCRIPTION
- added ability to automatically adjust the delay for ItemPrinterRNG, by comparing the desired item with the actual print results
- I did not port in Kurt's program. So, this only works for the pre-determined "Desired items". 
- I confirmed empirically that the program is able to correctly detect when it hits the seed, target plus 1, and target minus 1 for all the pre-determined "Desired Items". I didn't do this for the plus 2 or minus 2 cases.