### PR TITLE
Added Normal Encounter (non-shiny) sandwich to Sandwich Maker

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Options/PokemonSV_SandwichMakerOption.cpp
+++ b/SerialPrograms/Source/PokemonSV/Options/PokemonSV_SandwichMakerOption.cpp
@@ -18,6 +18,7 @@ namespace PokemonSV{
 //  Map for standard+type recipes taking Base + Type to find SandwichRecipe
 const std::map<std::pair<BaseRecipe, PokemonType>, SandwichRecipe>& PREMADE_SANDWICH_TYPE(){
     static const std::map<std::pair<BaseRecipe, PokemonType>, SandwichRecipe> map{
+        {{BaseRecipe::non_shiny, PokemonType::normal},  SandwichRecipe::non_shiny_normal},
         {{BaseRecipe::shiny, PokemonType::normal},  SandwichRecipe::shiny_normal},
         {{BaseRecipe::shiny, PokemonType::fire},    SandwichRecipe::shiny_fire},
         {{BaseRecipe::shiny, PokemonType::water},   SandwichRecipe::shiny_water},
@@ -134,6 +135,7 @@ const std::map<ParadoxRecipe, SandwichRecipe>& PREMADE_SANDWICH_OTHER(){
 //  Remember the ingredient limits: Six fillings, four condiments. Two condiment slots will be taken by the Herba.
 const std::map<SandwichRecipe, std::vector<std::string>>& PREMADE_SANDWICH_INGREDIENTS(){
     static const std::map<SandwichRecipe, std::vector<std::string>> map{
+        {SandwichRecipe::non_shiny_normal,      {"chorizo", "chorizo", "chorizo", "chorizo", "banana", "banana", "mayonnaise", "mayonnaise", "mayonnaise", "whipped-cream"}},
         {SandwichRecipe::shiny_normal,          {"cucumber", "pickle", "tofu", "tofu", "tofu", "curry-powder", "curry-powder"}},
         {SandwichRecipe::shiny_fire,            {"cucumber", "pickle", "red-bell-pepper", "red-bell-pepper","curry-powder","curry-powder", "red-bell-pepper"}},
         {SandwichRecipe::shiny_water,           {"cucumber", "pickle", "cucumber", "cucumber", "cucumber","curry-powder","curry-powder"}},
@@ -313,6 +315,7 @@ SandwichMakerOption::SandwichMakerOption(
         "<b>Sandwich Recipe:</b><br>Select a recipe to make a sandwich with preset ingredients, or select Custom Sandwich to make a sandwich using the table below. "
         "Refer to the documentation for recipe ingredients and valid Herba Mystica combinations.",
         {
+            {BaseRecipe::non_shiny,  "non-shiny",    "Normal Encounter (non-shiny)"},
             {BaseRecipe::shiny,     "shiny",    "Sparkling + Title + Encounter"},
             {BaseRecipe::huge,      "huge",     "Sparkling + Title + Humungo"},
             {BaseRecipe::tiny,      "tiny",     "Sparkling + Title + Teensy"},
@@ -320,7 +323,7 @@ SandwichMakerOption::SandwichMakerOption(
             {BaseRecipe::custom,    "custom",   "Custom Sandwich"},
         },
         LockMode::LOCK_WHILE_RUNNING,
-        BaseRecipe::shiny
+        BaseRecipe::non_shiny
         )
     , TYPE(
         "",
@@ -451,6 +454,13 @@ SandwichMakerOption::SandwichMakerOption(
 void SandwichMakerOption::value_changed(){
     if (BASE_RECIPE == BaseRecipe::custom){
         SANDWICH_INGREDIENTS.set_visibility(ConfigOptionState::ENABLED);
+        HERBA_ONE.set_visibility(ConfigOptionState::DISABLED);
+        HERBA_TWO.set_visibility(ConfigOptionState::DISABLED);
+        HERB_INCOMPATIBILITY_WARNING.set_visibility(ConfigOptionState::HIDDEN);
+        TYPE.set_visibility(ConfigOptionState::DISABLED); //to prevent the options moving around
+        PARADOX.set_visibility(ConfigOptionState::HIDDEN);
+    }else if (BASE_RECIPE == BaseRecipe::non_shiny){
+        SANDWICH_INGREDIENTS.set_visibility(ConfigOptionState::DISABLED);
         HERBA_ONE.set_visibility(ConfigOptionState::DISABLED);
         HERBA_TWO.set_visibility(ConfigOptionState::DISABLED);
         HERB_INCOMPATIBILITY_WARNING.set_visibility(ConfigOptionState::HIDDEN);

--- a/SerialPrograms/Source/PokemonSV/Options/PokemonSV_SandwichMakerOption.cpp
+++ b/SerialPrograms/Source/PokemonSV/Options/PokemonSV_SandwichMakerOption.cpp
@@ -293,6 +293,7 @@ SandwichMakerOption::~SandwichMakerOption(){
 
 SandwichMakerOption::SandwichMakerOption(
     OCR::LanguageOCROption* language_option,
+    BaseRecipe base_recipe,
     bool toggleable,
     bool enabled
 )
@@ -323,7 +324,7 @@ SandwichMakerOption::SandwichMakerOption(
             {BaseRecipe::custom,    "custom",   "Custom Sandwich"},
         },
         LockMode::LOCK_WHILE_RUNNING,
-        BaseRecipe::non_shiny
+        base_recipe
         )
     , TYPE(
         "",

--- a/SerialPrograms/Source/PokemonSV/Options/PokemonSV_SandwichMakerOption.h
+++ b/SerialPrograms/Source/PokemonSV/Options/PokemonSV_SandwichMakerOption.h
@@ -224,19 +224,21 @@ public:
 
     //  Include the language option in the box.
     SandwichMakerOption(
+        BaseRecipe base_recipe = BaseRecipe::non_shiny,
         bool toggleable = false,
         bool enabled = true
     )
-        : SandwichMakerOption(nullptr, toggleable, enabled)
+        : SandwichMakerOption(nullptr, base_recipe, toggleable, enabled)
     {}
 
     //  Don't include language option. Give it one instead.
     SandwichMakerOption(
         OCR::LanguageOCROption& language_option,
+        BaseRecipe base_recipe = BaseRecipe::non_shiny,
         bool toggleable = false,
         bool enabled = true
     )
-        : SandwichMakerOption(&language_option, toggleable, enabled)
+        : SandwichMakerOption(&language_option, base_recipe, toggleable, enabled)
     {}
 
 public:
@@ -261,6 +263,7 @@ public:
 private:
     SandwichMakerOption(
         OCR::LanguageOCROption* language_option,
+        BaseRecipe base_recipe,
         bool toggleable,
         bool enabled
     );

--- a/SerialPrograms/Source/PokemonSV/Options/PokemonSV_SandwichMakerOption.h
+++ b/SerialPrograms/Source/PokemonSV/Options/PokemonSV_SandwichMakerOption.h
@@ -30,6 +30,7 @@ enum class HerbaSelection{
 };
 
 enum class BaseRecipe{
+    non_shiny,
     shiny,
     huge,
     tiny,
@@ -109,6 +110,7 @@ enum class ParadoxRecipe{
 };
 
 enum class SandwichRecipe{
+    non_shiny_normal,
     shiny_normal,
     shiny_fire,
     shiny_water,

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
@@ -787,6 +787,26 @@ void make_sandwich_option(ProgramEnvironment& env, ConsoleHandle& console, BotBa
         console.log("Ingredients validated.", COLOR_BLACK);
         console.overlay().add_log("Ingredients validated.", COLOR_WHITE);
     }
+    else if(SANDWICH_OPTIONS.BASE_RECIPE == BaseRecipe::non_shiny){
+        console.log("Preset sandwich selected.", COLOR_BLACK);
+        console.overlay().add_log("Preset sandwich selected.");
+
+        // std::vector<std::string> table = SANDWICH_OPTIONS.get_premade_ingredients(
+        //     SANDWICH_OPTIONS.get_premade_sandwich_recipe(SANDWICH_OPTIONS.BASE_RECIPE, SANDWICH_OPTIONS.TYPE, SANDWICH_OPTIONS.PARADOX));
+
+        // The only non-shiny sandwich added at this time is Normal Encounter.
+        std::vector<std::string> table = SANDWICH_OPTIONS.get_premade_ingredients(SandwichRecipe::non_shiny_normal);
+
+        for (auto&& s : table){
+            if (std::find(ALL_SANDWICH_FILLINGS_SLUGS().begin(), ALL_SANDWICH_FILLINGS_SLUGS().end(), s) != ALL_SANDWICH_FILLINGS_SLUGS().end()){
+                fillings[s]++;
+                num_fillings++;
+            }else{
+                condiments[s]++;
+                num_condiments++;
+            }
+        }
+    }
     //Otherwise get the preset ingredients
     else{
         console.log("Preset sandwich selected.", COLOR_BLACK);

--- a/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-AreaZeroPlatform.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-AreaZeroPlatform.cpp
@@ -125,7 +125,7 @@ ShinyHuntAreaZeroPlatform::ShinyHuntAreaZeroPlatform()
         LockMode::UNLOCK_WHILE_RUNNING,
         35
     )
-    , SANDWICH_OPTIONS(LANGUAGE)
+    , SANDWICH_OPTIONS(LANGUAGE, BaseRecipe::paradox)
     , GO_HOME_WHEN_DONE(true)
     , AUTO_HEAL_PERCENT(
         "<b>Auto-Heal %</b><br>Auto-heal if your HP drops below this percentage.",

--- a/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-Scatterbug.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ShinyHunting/PokemonSV_ShinyHunt-Scatterbug.cpp
@@ -88,7 +88,7 @@ ShinyHuntScatterbug::ShinyHuntScatterbug()
         LockMode::UNLOCK_WHILE_RUNNING,
         true
     )
-    , SANDWICH_OPTIONS(LANGUAGE)
+    , SANDWICH_OPTIONS(LANGUAGE, BaseRecipe::shiny)
     , GO_HOME_WHEN_DONE(true)
     , AUTO_HEAL_PERCENT(
         "<b>Auto-Heal %</b><br>Auto-heal if your HP drops below this percentage.",


### PR DESCRIPTION
- this is mainly helpful for the Material farmer for farming Happiny dust.
- changed the default sandwich to the normal (non-shiny) sandwich, so users don't accidentally use up Herba Mystica when they weren't intending to shiny hunt.
- if there is a need for to add non-shiny encounter sandwiches for the rest of the types, I can add them later. But I don't see a use for them at this time. So, right now, the BaseRecipe::non_shiny is basically hard-coded to SandwichRecipe::non_shiny_normal.