### PR TITLE
Update RMSD threshold and tests for SandwichHandDetector

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Inference/Picnics/PokemonSV_SandwichHandDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Picnics/PokemonSV_SandwichHandDetector.cpp
@@ -110,7 +110,7 @@ std::pair<double, double> SandwichHandLocator::locate_sandwich_hand(const ImageV
         ((m_type == HandType::FREE) ? SandwichFreeHandMatcher::instance() : SandwichGrabbingHandMatcher::instance()),
         filters,
         {min_size, SIZE_MAX},
-        60,
+        80,
         [&](Kernels::Waterfill::WaterfillObject& object) -> bool {
             hand_location = std::make_pair(
                 (object.center_of_gravity_x() + pixel_box.min_x) / (double)frame.width(),

--- a/SerialPrograms/Source/Tests/PokemonSV_Tests.cpp
+++ b/SerialPrograms/Source/Tests/PokemonSV_Tests.cpp
@@ -196,6 +196,9 @@ int test_pokemonSV_SandwichRecipeDetector(const ImageViewRGB32& image, const std
     return 0;
 }
 
+// - the last 4 words should be the coordinates for the FloatBox, that the detector will search
+// - the 5th word from last should be the Hand type (Free or Grabbing)
+// - optional: if the image should not detect the hand, the 6th word from last should "False"
 int test_pokemonSV_SandwichHandDetector(const ImageViewRGB32& image, const std::vector<std::string>& words){
     // five words: hand_type("Free"/"Grabbing"), <image float box (four words total)>
     if (words.size() < 5){
@@ -226,10 +229,18 @@ int test_pokemonSV_SandwichHandDetector(const ImageViewRGB32& image, const std::
 
     SandwichHandLocator detector(hand_type, box);
 
+    bool hand_expected = true;
+    if (words.size() >= 6){
+        auto hand_expected_word = words[words.size() - 6];
+        if(hand_expected_word == "False"){
+            hand_expected = false;
+        }
+    }
+
     auto result = detector.detect(image);
     bool has_hand = result.first >= 0.0;
 
-    TEST_RESULT_EQUAL(has_hand, true);
+    TEST_RESULT_EQUAL(has_hand, hand_expected);
 
     return 0;
 }


### PR DESCRIPTION
- new RMSD threshold needed for the new template with the black outline. See pull request in Packages. 
- from my testing, the new template works well on my machine on both 1080p and 720p. The sandwich program can run for hours at a time. When it fails, it fails for a reason other than the SandwichHandDetector (e.g. dropping button presses in the ingredient selection page).