### PR TITLE
Fix pokecenter detector for dark capture cards

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Inference/Map/PokemonSV_MapPokeCenterIconDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Map/PokemonSV_MapPokeCenterIconDetector.cpp
@@ -56,7 +56,8 @@ bool MapPokeCenterIconDetector::detect(const ImageViewRGB32& screen) const{
 
 std::vector<ImageFloatBox> MapPokeCenterIconDetector::detect_all(const ImageViewRGB32& screen) const{
     const std::vector<std::pair<uint32_t, uint32_t>> filters = {
-        {combine_rgb(150, 0, 0), combine_rgb(255, 120, 120)}
+        // {combine_rgb(150, 0, 0), combine_rgb(255, 120, 120)},
+        {combine_rgb(100, 0, 0), combine_rgb(255, 100, 100)}
     };
 
     const double min_object_size = 350.0;


### PR DESCRIPTION
- It should work for your bad capture card now. It still works with all other test cases
- I'm wondering if we should also try running the detector on your bad capture card in 720p.