### PR TITLE
MaterialFarmerTools refactor

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmer.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmer.cpp
@@ -95,7 +95,7 @@ void MaterialFarmer::program(SingleSwitchProgramEnvironment& env, BotBaseContext
     MaterialFarmerStats& stats = env.current_stats<MaterialFarmerStats>();
 
     try{
-        run_material_farmer(env, context, MATERIAL_FARMER_OPTIONS, stats);
+        run_material_farmer(env, env.console, context, MATERIAL_FARMER_OPTIONS, stats);
     }catch (ProgramFinishedException&){}
 
     GO_HOME_WHEN_DONE.run_end_of_program(context);

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.cpp
@@ -610,14 +610,14 @@ void run_from_battles_and_back_to_pokecenter(
 
 
 
-void move_from_material_farming_to_item_printer(SingleSwitchProgramEnvironment& env, BotBaseContext& context){
-    env.console.log("Start moving from material farming to item printer.");
-    fly_from_paldea_to_blueberry_entrance(env, context);
-    move_from_blueberry_entrance_to_league_club(env, context);
-    move_from_league_club_entrance_to_item_printer(env, context);
+void move_from_material_farming_to_item_printer(const ProgramInfo& info, ConsoleHandle& console, BotBaseContext& context){
+    console.log("Start moving from material farming to item printer.");
+    fly_from_paldea_to_blueberry_entrance(info, console, context);
+    move_from_blueberry_entrance_to_league_club(info, console, context);
+    move_from_league_club_entrance_to_item_printer(info, console, context);
 }
 
-void fly_from_paldea_to_blueberry_entrance(SingleSwitchProgramEnvironment& env, BotBaseContext& context){
+void fly_from_paldea_to_blueberry_entrance(const ProgramInfo& info, ConsoleHandle& console, BotBaseContext& context){
     int numAttempts = 0;
     int maxAttempts = 5;
     bool isFlySuccessful = false;
@@ -628,7 +628,7 @@ void fly_from_paldea_to_blueberry_entrance(SingleSwitchProgramEnvironment& env, 
 
         numAttempts++;
 
-        open_map_from_overworld(env.program_info(), env.console, context);
+        open_map_from_overworld(info, console, context);
 
         // change from Paldea map to Blueberry map
         pbf_press_button(context, BUTTON_L, 50, 300);
@@ -640,22 +640,23 @@ void fly_from_paldea_to_blueberry_entrance(SingleSwitchProgramEnvironment& env, 
         pbf_move_left_joystick(context, 0, 0, 76, 50);
 
         // press A to fly to Blueberry academy
-        isFlySuccessful = fly_to_overworld_from_map(env.program_info(), env.console, context, true);
+        isFlySuccessful = fly_to_overworld_from_map(info, console, context, true);
         if (!isFlySuccessful){
-            env.log("Failed to fly to Blueberry academy.");
+            console.log("Failed to fly to Blueberry academy.");
+            // dump_snapshot(console);
         }
     }
 
     if (!isFlySuccessful){
         throw OperationFailedException(
-            ErrorReport::SEND_ERROR_REPORT, env.console,
+            ErrorReport::SEND_ERROR_REPORT, console,
             "Failed to fly to Blueberry academy, five times in a row.",
             true
         );
     }
 }
 
-void move_from_blueberry_entrance_to_league_club(SingleSwitchProgramEnvironment& env, BotBaseContext& context){
+void move_from_blueberry_entrance_to_league_club(const ProgramInfo& info, ConsoleHandle& console, BotBaseContext& context){
 
     int numAttempts = 0;
     int maxAttempts = 5;
@@ -664,8 +665,8 @@ void move_from_blueberry_entrance_to_league_club(SingleSwitchProgramEnvironment&
     while (!isSuccessful && numAttempts < maxAttempts){
         if (numAttempts > 0){ // failed at least once
             pbf_mash_button(context, BUTTON_B, 100);
-            open_map_from_overworld(env.program_info(), env.console, context);
-            fly_to_overworld_from_map(env.program_info(), env.console, context, false);
+            open_map_from_overworld(info, console, context);
+            fly_to_overworld_from_map(info, console, context, false);
         }
 
         numAttempts++;
@@ -678,11 +679,11 @@ void move_from_blueberry_entrance_to_league_club(SingleSwitchProgramEnvironment&
         // Wait for detection of Blueberry navigation menu
         ImageFloatBox select_entrance_box(0.031, 0.193, 0.047, 0.078);
         GradientArrowWatcher select_entrance(COLOR_RED, GradientArrowType::RIGHT, select_entrance_box);
-        int ret = wait_until(env.console, context, Milliseconds(5000), { select_entrance });
+        int ret = wait_until(console, context, Milliseconds(5000), { select_entrance });
         if (ret == 0){
-            env.log("Blueberry navigation menu detected.");
+            console.log("Blueberry navigation menu detected.");
         }else{
-            env.console.log("Failed to detect Blueberry navigation menu.");
+            console.log("Failed to detect Blueberry navigation menu.");
             continue;
         }
 
@@ -692,11 +693,11 @@ void move_from_blueberry_entrance_to_league_club(SingleSwitchProgramEnvironment&
         // Confirm to League club room is selected
         ImageFloatBox select_league_club_box(0.038, 0.785, 0.043, 0.081);
         GradientArrowWatcher select_league_club(COLOR_RED, GradientArrowType::RIGHT, select_league_club_box, Milliseconds(1000));
-        ret = wait_until(env.console, context, Milliseconds(5000), { select_league_club });
+        ret = wait_until(console, context, Milliseconds(5000), { select_league_club });
         if (ret == 0){
-            env.log("League club room selected.");
+            console.log("League club room selected.");
         }else{
-            env.console.log("Failed to select League club room in navigation menu.");
+            console.log("Failed to select League club room in navigation menu.");
             continue;            
         }
         // press A
@@ -704,11 +705,11 @@ void move_from_blueberry_entrance_to_league_club(SingleSwitchProgramEnvironment&
 
         // check for overworld
         OverworldWatcher overworld(COLOR_CYAN);  
-        ret = wait_until(env.console, context, Milliseconds(10000), { overworld });
+        ret = wait_until(console, context, Milliseconds(10000), { overworld });
         if (ret == 0){
-            env.log("Entered League club room.");
+            console.log("Entered League club room.");
         }else{
-            env.console.log("Failed to enter League club room from menu selection.");
+            console.log("Failed to enter League club room from menu selection.");
             continue;            
         }
 
@@ -717,7 +718,7 @@ void move_from_blueberry_entrance_to_league_club(SingleSwitchProgramEnvironment&
 
     if (!isSuccessful){
         throw OperationFailedException(
-            ErrorReport::SEND_ERROR_REPORT, env.console,
+            ErrorReport::SEND_ERROR_REPORT, console,
             "Failed to enter League club room, five times in a row.",
             true
         );
@@ -725,7 +726,7 @@ void move_from_blueberry_entrance_to_league_club(SingleSwitchProgramEnvironment&
 
 }
 
-void move_from_league_club_entrance_to_item_printer(SingleSwitchProgramEnvironment& env, BotBaseContext& context){
+void move_from_league_club_entrance_to_item_printer(const ProgramInfo& info, ConsoleHandle& console, BotBaseContext& context){
     context.wait_for_all_requests();
 
     // move forwards towards table next to item printer
@@ -735,14 +736,14 @@ void move_from_league_club_entrance_to_item_printer(SingleSwitchProgramEnvironme
     pbf_move_left_joystick(context, 0, 128, 10, 50);
 }
 
-void move_from_item_printer_to_material_farming(SingleSwitchProgramEnvironment& env, BotBaseContext& context){
-    env.console.log("Start moving from item printer to material farming.");
-    move_from_item_printer_to_blueberry_entrance(env, context);
-    fly_from_blueberry_to_north_province_3(env, context);
+void move_from_item_printer_to_material_farming(const ProgramInfo& info, ConsoleHandle& console, BotBaseContext& context){
+    console.log("Start moving from item printer to material farming.");
+    move_from_item_printer_to_blueberry_entrance(info, console, context);
+    fly_from_blueberry_to_north_province_3(info, console, context);
 }
 
 // assumes you start in the position in front of the item printer, as if you finished using it.
-void move_from_item_printer_to_blueberry_entrance(SingleSwitchProgramEnvironment& env, BotBaseContext& context){
+void move_from_item_printer_to_blueberry_entrance(const ProgramInfo& info, ConsoleHandle& console, BotBaseContext& context){
     context.wait_for_all_requests();
 
     // look left towards door
@@ -756,18 +757,18 @@ void move_from_item_printer_to_blueberry_entrance(SingleSwitchProgramEnvironment
 
     context.wait_for_all_requests();
 
-    env.log("Wait for detection of Blueberry navigation menu.");
+    console.log("Wait for detection of Blueberry navigation menu.");
 
     // Wait for detection of Blueberry navigation menu
     ImageFloatBox select_entrance_box(0.031, 0.193, 0.047, 0.078);
     GradientArrowWatcher select_entrance(COLOR_RED, GradientArrowType::RIGHT, select_entrance_box);
-    int ret = wait_until(env.console, context, Milliseconds(5000), { select_entrance }, Milliseconds(1000));
+    int ret = wait_until(console, context, Milliseconds(5000), { select_entrance }, Milliseconds(1000));
     if (ret == 0){
-        env.log("Blueberry navigation menu detected.");
+        console.log("Blueberry navigation menu detected.");
     }else{
-        env.console.log("Failed to detect Blueberry navigation menu.");
+        console.log("Failed to detect Blueberry navigation menu.");
         throw OperationFailedException(
-            ErrorReport::SEND_ERROR_REPORT, env.console,
+            ErrorReport::SEND_ERROR_REPORT, console,
             "Failed to find the exit from the League room.",
             true
         );
@@ -778,12 +779,12 @@ void move_from_item_printer_to_blueberry_entrance(SingleSwitchProgramEnvironment
 
     // check for overworld
     OverworldWatcher overworld(COLOR_CYAN);  
-    ret = wait_until(env.console, context, std::chrono::seconds(30), { overworld });
+    ret = wait_until(console, context, std::chrono::seconds(30), { overworld });
     if (ret == 0){
-        env.log("Overworld detected");
+        console.log("Overworld detected");
     }else{
         throw OperationFailedException(
-            ErrorReport::SEND_ERROR_REPORT, env.console,
+            ErrorReport::SEND_ERROR_REPORT, console,
             "Failed to detect overworld.",
             true
         );      
@@ -791,7 +792,7 @@ void move_from_item_printer_to_blueberry_entrance(SingleSwitchProgramEnvironment
 }
 
 
-void fly_from_blueberry_to_north_province_3(SingleSwitchProgramEnvironment& env, BotBaseContext& context){
+void fly_from_blueberry_to_north_province_3(const ProgramInfo& info, ConsoleHandle& console, BotBaseContext& context){
     int numAttempts = 0;
     int maxAttempts = 10;
     bool isFlySuccessful = false;
@@ -802,7 +803,7 @@ void fly_from_blueberry_to_north_province_3(SingleSwitchProgramEnvironment& env,
         // close all menus
         pbf_mash_button(context, BUTTON_B, 100);
 
-        open_map_from_overworld(env.program_info(), env.console, context);
+        open_map_from_overworld(info, console, context);
 
         // change from Blueberry map to Paldea map
         pbf_press_button(context, BUTTON_R, 50, 300);
@@ -814,17 +815,18 @@ void fly_from_blueberry_to_north_province_3(SingleSwitchProgramEnvironment& env,
         pbf_move_left_joystick(context, 112, 0, 171, 50);
 
         // press A to fly to North province area 3
-        isFlySuccessful = fly_to_overworld_from_map(env.program_info(), env.console, context, true);
+        isFlySuccessful = fly_to_overworld_from_map(info, console, context, true);
 
         if (!isFlySuccessful){
-            env.log("Failed to fly to North province area 3.");
+            console.log("Failed to fly to North province area 3.");
+            // dump_snapshot(console);
         }
     }
 
     if (!isFlySuccessful){
 
         throw OperationFailedException(
-            ErrorReport::SEND_ERROR_REPORT, env.console,
+            ErrorReport::SEND_ERROR_REPORT, console,
             "Failed to fly to North province area 3, ten times in a row.",
             true
         );
@@ -834,7 +836,7 @@ void fly_from_blueberry_to_north_province_3(SingleSwitchProgramEnvironment& env,
             // close all menus
             pbf_mash_button(context, BUTTON_B, 100);
 
-            open_map_from_overworld(env.program_info(), env.console, context);
+            open_map_from_overworld(info, console, context);
 
             // change from Blueberry map to Paldea map
             pbf_press_button(context, BUTTON_R, 50, 300);
@@ -848,12 +850,12 @@ void fly_from_blueberry_to_north_province_3(SingleSwitchProgramEnvironment& env,
             // zoom back in to default zoom level
             pbf_press_button(context, BUTTON_ZR, 25, 200);
 
-            fly_to_closest_pokecenter_on_map(env.program_info(), env.console, context);
+            fly_to_closest_pokecenter_on_map(info, console, context);
         }
         catch(OperationFailedException& e){
             (void)e;
             throw OperationFailedException(
-                ErrorReport::SEND_ERROR_REPORT, env.console,
+                ErrorReport::SEND_ERROR_REPORT, console,
                 "Failed to fly to North province area 3, five times in a row.",
                 true
             );

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.cpp
@@ -168,13 +168,14 @@ void MaterialFarmerOptions::value_changed(void* object){
 
 
 void run_material_farmer(
-    SingleSwitchProgramEnvironment& env,
+    ProgramEnvironment& env,
+    ConsoleHandle& console,
     BotBaseContext& context,
     MaterialFarmerOptions& options,
     MaterialFarmerStats& stats
 ){
     LetsGoEncounterBotTracker encounter_tracker(
-        env, env.console, context,
+        env, console, context,
         stats,
         options.LANGUAGE
     );
@@ -189,39 +190,39 @@ void run_material_farmer(
     while (true){
         // check time left on material farming
         auto farming_time_remaining = minutes_remaining(start_time, std::chrono::minutes(options.RUN_TIME_IN_MINUTES));
-        env.console.log(
+        console.log(
             "Time left in Material Farming: " + 
             std::to_string(farming_time_remaining.count()) + " min", 
             COLOR_PURPLE
         );
         if (farming_time_remaining < std::chrono::minutes(0)){
-            env.console.log("Time's up. Stop the Material farming program.", COLOR_RED);
+            console.log("Time's up. Stop the Material farming program.", COLOR_RED);
             break;
         }
         
         // Check time left on sandwich
         if (options.SANDWICH_OPTIONS.enabled()){
             auto sandwich_time_remaining = minutes_remaining(last_sandwich_time, std::chrono::minutes(options.TIME_PER_SANDWICH));
-            env.console.log(
+            console.log(
                 "Time left on sandwich: " + 
                 std::to_string(sandwich_time_remaining.count()) + " min", 
                 COLOR_PURPLE
             );                   
             if (sandwich_time_remaining < std::chrono::minutes(0)){
-                env.console.log("Sandwich not active. Make a sandwich.");
-                last_sandwich_time = make_sandwich_material_farm(env, context, options, stats);
-                env.console.overlay().add_log("Sandwich made.");
+                console.log("Sandwich not active. Make a sandwich.");
+                last_sandwich_time = make_sandwich_material_farm(env, console, context, options, stats);
+                console.overlay().add_log("Sandwich made.");
 
                 // Log time remaining in Material farming 
                 farming_time_remaining = minutes_remaining(start_time, std::chrono::minutes(options.RUN_TIME_IN_MINUTES));
-                env.console.log(
+                console.log(
                     "Time left in Material Farming: " + 
                     std::to_string(farming_time_remaining.count()) + " min", 
                     COLOR_PURPLE
                 );
                 // Log time remaining on Sandwich
                 sandwich_time_remaining = minutes_remaining(last_sandwich_time, std::chrono::minutes(options.TIME_PER_SANDWICH));
-                env.console.log(
+                console.log(
                     "Time left on sandwich: " + 
                     std::to_string(sandwich_time_remaining.count()) + " min", 
                     COLOR_PURPLE
@@ -230,9 +231,9 @@ void run_material_farmer(
         }
 
         // heal before starting Let's go
-        env.console.log("Heal before starting Let's go", COLOR_PURPLE);
-        env.console.log("Heal threshold: " + tostr_default(options.AUTO_HEAL_PERCENT), COLOR_PURPLE);
-        check_hp(env, context, options, hp_watcher, stats);
+        console.log("Heal before starting Let's go", COLOR_PURPLE);
+        console.log("Heal threshold: " + tostr_default(options.AUTO_HEAL_PERCENT), COLOR_PURPLE);
+        check_hp(env, console, context, options, hp_watcher, stats);
 
         /*
         - Starts from pokemon center.
@@ -240,20 +241,18 @@ void run_material_farmer(
         - Then returns to pokemon center, regardless of whether 
         it completes the action or gets caught in a battle 
         */
-        run_from_battles_and_back_to_pokecenter(env, context, stats,
-            [&](
-                SingleSwitchProgramEnvironment& env, BotBaseContext& context
-            ){
+        run_from_battles_and_back_to_pokecenter(env, console, context, stats,
+            [&](ProgramEnvironment& env, ConsoleHandle& console, BotBaseContext& context){
                 // Move to starting position for Let's Go hunting path
-                env.console.log("Move to starting position for Let's Go hunting path.", COLOR_PURPLE);
-                move_to_start_position_for_letsgo1(env, context);
+                console.log("Move to starting position for Let's Go hunting path.", COLOR_PURPLE);
+                move_to_start_position_for_letsgo1(console, context);
 
                 // run let's go while updating the HP watcher
-                env.console.log("Starting Let's Go hunting path.", COLOR_PURPLE);
+                console.log("Starting Let's Go hunting path.", COLOR_PURPLE);
                 run_until(
-                    env.console, context,
+                    console, context,
                     [&](BotBaseContext& context){
-                        run_lets_go_iteration(env, context, encounter_tracker, options.NUM_FORWARD_MOVES_PER_LETS_GO_ITERATION);
+                        run_lets_go_iteration(console, context, encounter_tracker, options.NUM_FORWARD_MOVES_PER_LETS_GO_ITERATION);
                     },
                     {hp_watcher}
                 );
@@ -267,7 +266,8 @@ void run_material_farmer(
 }
 
 void check_hp(
-    SingleSwitchProgramEnvironment& env,
+    ProgramEnvironment& env,
+    ConsoleHandle& console,
     BotBaseContext& context,
     MaterialFarmerOptions& options,
     LetsGoHpWatcher& hp_watcher,
@@ -275,12 +275,12 @@ void check_hp(
 ){
     double hp = hp_watcher.last_known_value() * 100;
     if (0 < hp){
-        env.console.log("Last Known HP: " + tostr_default(hp) + "%", COLOR_BLUE);
+        console.log("Last Known HP: " + tostr_default(hp) + "%", COLOR_BLUE);
     }else{
-        env.console.log("Last Known HP: ?", COLOR_RED);
+        console.log("Last Known HP: ?", COLOR_RED);
     }
     if (0 < hp && hp < options.AUTO_HEAL_PERCENT){
-        auto_heal_from_menu_or_overworld(env.program_info(), env.console, context, 0, true);
+        auto_heal_from_menu_or_overworld(env.program_info(), console, context, 0, true);
         stats.m_autoheals++;
         env.update_stats();
         send_program_status_notification(env, options.NOTIFICATION_STATUS_UPDATE);
@@ -292,13 +292,14 @@ void check_hp(
 // start at North Province (Area 3) Pokecenter. make sandwich then go back to Pokecenter to reset position
 // return the time that the sandwich was made
 WallClock make_sandwich_material_farm(
-    SingleSwitchProgramEnvironment& env, 
+    ProgramEnvironment& env,
+    ConsoleHandle& console,
     BotBaseContext& context, 
     MaterialFarmerOptions& options,
     MaterialFarmerStats& stats
 ){
     if (options.SANDWICH_OPTIONS.SAVE_GAME_BEFORE_SANDWICH){
-        save_game_from_overworld(env.program_info(), env.console, context);
+        save_game_from_overworld(env.program_info(), console, context);
     }
 
     WallClock last_sandwich_time;
@@ -306,7 +307,7 @@ WallClock make_sandwich_material_farm(
     size_t max_consecutive_failures = 10;  
     while (true){
         try{
-            last_sandwich_time = try_make_sandwich_material_farm(env, context, options, stats);
+            last_sandwich_time = try_make_sandwich_material_farm(env, console, context, options, stats);
             break;
         }catch(OperationFailedException& e){
             stats.m_errors++;
@@ -314,7 +315,7 @@ WallClock make_sandwich_material_farm(
             e.send_notification(env, options.NOTIFICATION_ERROR_RECOVERABLE);
 
             // save screenshot after operation failed, 
-            dump_snapshot(env.console);
+            dump_snapshot(console);
 
             if (options.SAVE_DEBUG_VIDEO){
                 // Take a video to give more context for debugging
@@ -325,14 +326,14 @@ WallClock make_sandwich_material_farm(
             consecutive_failures++;
             if (consecutive_failures >= max_consecutive_failures){
                 throw OperationFailedException(
-                    ErrorReport::SEND_ERROR_REPORT, env.console,
+                    ErrorReport::SEND_ERROR_REPORT, console,
                     "Failed to make sandwich "+ std::to_string(max_consecutive_failures) + " times in a row.",
                     true
                 );
             }
 
             env.log("Failed to make sandwich. Reset game to handle recoverable error.");
-            reset_game(env.program_info(), env.console, context);
+            reset_game(env.program_info(), console, context);
             stats.m_game_resets++;
             env.update_stats();
         }
@@ -345,15 +346,16 @@ WallClock make_sandwich_material_farm(
 // make sandwich then go back to Pokecenter to reset position
 // if gets caught up in a battle, try again.
 WallClock try_make_sandwich_material_farm(
-    SingleSwitchProgramEnvironment& env, 
+    ProgramEnvironment& env,
+    ConsoleHandle& console,
     BotBaseContext& context, 
     MaterialFarmerOptions& options,
     MaterialFarmerStats& stats
 ){
     WallClock last_sandwich_time = WallClock::min();
     while(last_sandwich_time == WallClock::min()){
-        run_from_battles_and_back_to_pokecenter(env, context, stats,
-            [&](SingleSwitchProgramEnvironment& env, BotBaseContext& context){
+        run_from_battles_and_back_to_pokecenter(env, console, context, stats,
+            [&](ProgramEnvironment& env, ConsoleHandle& console, BotBaseContext& context){
                 // Orient camera to look at same direction as player character
                 // - This is needed because when save-load the game, 
                 // the camera angle is different than when just flying to pokecenter
@@ -369,12 +371,12 @@ WallClock try_make_sandwich_material_farm(
                 pbf_move_left_joystick(context, 128, 0, 300, 0);
 
                 // make sandwich
-                picnic_from_overworld(env.program_info(), env.console, context);
+                picnic_from_overworld(env.program_info(), console, context);
                 pbf_move_left_joystick(context, 128, 0, 30, 40);
-                enter_sandwich_recipe_list(env.program_info(), env.console, context);
-                make_sandwich_option(env, env.console, context, options.SANDWICH_OPTIONS);
+                enter_sandwich_recipe_list(env.program_info(), console, context);
+                make_sandwich_option(env, console, context, options.SANDWICH_OPTIONS);
                 last_sandwich_time = current_time();
-                leave_picnic(env.program_info(), env.console, context);
+                leave_picnic(env.program_info(), console, context);
 
                 stats.m_sandwiches++;
                 env.update_stats();
@@ -393,7 +395,10 @@ std::chrono::minutes minutes_remaining(WallClock start_time, std::chrono::minute
 }
 
 // from the North Province (Area 3) pokecenter, move to start position for Happiny dust farming
-void move_to_start_position_for_letsgo0(SingleSwitchProgramEnvironment& env, BotBaseContext& context){
+void move_to_start_position_for_letsgo0(    
+    ConsoleHandle& console, 
+    BotBaseContext& context
+){
     // Orient camera to look at same direction as player character
     // - This is needed because when save-load the game, 
     // the camera angle is different than when just flying to pokecenter
@@ -437,13 +442,16 @@ void move_to_start_position_for_letsgo0(SingleSwitchProgramEnvironment& env, Bot
     pbf_move_right_joystick(context, 255, 128, 30, 10);
     pbf_move_left_joystick(context, 128, 0, 50, 10);
 
-    env.console.log("Arrived at Let's go start position", COLOR_PURPLE);
+    console.log("Arrived at Let's go start position", COLOR_PURPLE);
     
 
 }
 
 // from the North Province (Area 3) pokecenter, move to start position for Happiny dust farming
-void move_to_start_position_for_letsgo1(SingleSwitchProgramEnvironment& env, BotBaseContext& context){
+void move_to_start_position_for_letsgo1(
+    ConsoleHandle& console, 
+    BotBaseContext& context
+){
     // Orient camera to look at same direction as player character
     // - This is needed because when save-load the game, 
     // the camera angle is different than when just flying to pokecenter
@@ -494,7 +502,7 @@ void move_to_start_position_for_letsgo1(SingleSwitchProgramEnvironment& env, Bot
     // move forward slightly
     pbf_move_left_joystick(context, 128, 0, 50, 10);
 
-    env.console.log("Arrived at Let's go start position", COLOR_PURPLE);
+    console.log("Arrived at Let's go start position", COLOR_PURPLE);
 }
 
 
@@ -519,12 +527,11 @@ void lets_go_movement1(BotBaseContext& context){
 move forward again to repeat the cycle. It does this as many times as per num_forward_moves_per_lets_go_iteration.
  */
 void run_lets_go_iteration(
-    SingleSwitchProgramEnvironment& env,
+    ConsoleHandle& console, 
     BotBaseContext& context,
     LetsGoEncounterBotTracker& encounter_tracker,
     int num_forward_moves_per_lets_go_iteration
 ){
-    auto& console = env.console;
     // - Orient camera to look at same direction as player character
     // - This is needed because when save-load the game, the camera points
     // in the same direction as the player.
@@ -541,7 +548,7 @@ void run_lets_go_iteration(
     for(int i = 0; i < total_iterations; i++){
         use_lets_go_to_clear_in_front(console, context, encounter_tracker, throw_ball_if_bubble, [&](BotBaseContext& context){
             // Do the following movement while the Let's Go pokemon clearing wild pokemon.
-            env.console.log("Move-forward iteration number: " + std::to_string(i + 1) + "/" + std::to_string(total_iterations), COLOR_PURPLE);
+            console.log("Move-forward iteration number: " + std::to_string(i + 1) + "/" + std::to_string(total_iterations), COLOR_PURPLE);
 
             lets_go_movement1(context);
         });
@@ -562,11 +569,13 @@ where the action will be attempted infinite times if you keep failing. In contra
 only gives you one attempt before returning to the Pokecenter
 */
 void run_from_battles_and_back_to_pokecenter(
-    SingleSwitchProgramEnvironment& env,
+    ProgramEnvironment& env,
+    ConsoleHandle& console, 
     BotBaseContext& context,
     MaterialFarmerStats& stats,
     std::function<
-        void(SingleSwitchProgramEnvironment& env,
+        void(ProgramEnvironment& env,
+        ConsoleHandle& console,
         BotBaseContext& context)
     >&& action
 ){
@@ -576,19 +585,19 @@ void run_from_battles_and_back_to_pokecenter(
     while(returned_to_pokecenter == false){
         NormalBattleMenuWatcher battle_menu(COLOR_RED);
         int ret = run_until(
-            env.console, context,
+            console, context,
             [&](BotBaseContext& context){
                 if (!attempted_action){ // We still need to carry out `action`
                     attempted_action = true;
                     context.wait_for_all_requests();
-                    action(env, context);
+                    action(env, console, context);
                     context.wait_for_all_requests();                    
                 }
 
                 // we have already attempted the action,
                 // so reset to the Pokecenter
-                env.console.log("Go back to PokeCenter.");
-                reset_to_pokecenter(env.program_info(), env.console, context);
+                console.log("Go back to PokeCenter.");
+                reset_to_pokecenter(env.program_info(), console, context);
                 returned_to_pokecenter = true;
             },
             {battle_menu}
@@ -596,10 +605,10 @@ void run_from_battles_and_back_to_pokecenter(
         if (ret == 0){ // battle detected
             stats.m_encounters++;
             env.update_stats();
-            env.console.log("Detected battle. Now running away.", COLOR_PURPLE);
-            env.console.overlay().add_log("Detected battle. Now running away.");
+            console.log("Detected battle. Now running away.", COLOR_PURPLE);
+            console.overlay().add_log("Detected battle. Now running away.");
             try{
-                run_from_battle(env.program_info(), env.console, context);
+                run_from_battle(env.program_info(), console, context);
             }catch (OperationFailedException& e){
                 throw FatalProgramException(std::move(e));
             }

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.h
@@ -143,21 +143,21 @@ void run_from_battles_and_back_to_pokecenter(
 
 
 
-void move_from_material_farming_to_item_printer(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
+void move_from_material_farming_to_item_printer(const ProgramInfo& info, ConsoleHandle& console, BotBaseContext& context);
 
-void fly_from_paldea_to_blueberry_entrance(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
+void fly_from_paldea_to_blueberry_entrance(const ProgramInfo& info, ConsoleHandle& console, BotBaseContext& context);
 
-void move_from_blueberry_entrance_to_league_club(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
+void move_from_blueberry_entrance_to_league_club(const ProgramInfo& info, ConsoleHandle& console, BotBaseContext& context);
 
-void move_from_league_club_entrance_to_item_printer(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
+void move_from_league_club_entrance_to_item_printer(const ProgramInfo& info, ConsoleHandle& console, BotBaseContext& context);
 
 
 
-void move_from_item_printer_to_material_farming(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
+void move_from_item_printer_to_material_farming(const ProgramInfo& info, ConsoleHandle& console, BotBaseContext& context);
 
-void move_from_item_printer_to_blueberry_entrance(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
+void move_from_item_printer_to_blueberry_entrance(const ProgramInfo& info, ConsoleHandle& console, BotBaseContext& context);
 
-void fly_from_blueberry_to_north_province_3(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
+void fly_from_blueberry_to_north_province_3(const ProgramInfo& info, ConsoleHandle& console, BotBaseContext& context);
 
 
 

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.h
@@ -11,7 +11,6 @@
 #include "Common/Cpp/Options/FloatingPointOption.h"
 #include "Common/Cpp/Options/SimpleIntegerOption.h"
 #include "CommonFramework/Options/LanguageOCROption.h"
-#include "NintendoSwitch/NintendoSwitch_SingleSwitchProgram.h"
 #include "NintendoSwitch/Options/NintendoSwitch_GoHomeWhenDoneOption.h"
 #include "PokemonSV/Options/PokemonSV_SandwichMakerOption.h"
 #include "PokemonSV/Programs/ShinyHunting/PokemonSV_LetsGoTools.h"
@@ -86,14 +85,16 @@ public:
 
 
 void run_material_farmer(
-    SingleSwitchProgramEnvironment& env,
+    ProgramEnvironment& env,
+    ConsoleHandle& console,
     BotBaseContext& context,
     MaterialFarmerOptions& options,
     MaterialFarmerStats& stats
 );
 
 void check_hp(
-    SingleSwitchProgramEnvironment& env,
+    ProgramEnvironment& env,
+    ConsoleHandle& console,
     BotBaseContext& context,
     MaterialFarmerOptions& options,
     LetsGoHpWatcher& hp_watcher,
@@ -101,22 +102,24 @@ void check_hp(
 );
 
 WallClock make_sandwich_material_farm(
-    SingleSwitchProgramEnvironment& env, 
+    ProgramEnvironment& env, 
+    ConsoleHandle& console,
     BotBaseContext& context, 
     MaterialFarmerOptions& options,
     MaterialFarmerStats& stats
 );        
 
 WallClock try_make_sandwich_material_farm(
-    SingleSwitchProgramEnvironment& env, 
+    ProgramEnvironment& env, 
+    ConsoleHandle& console,
     BotBaseContext& context, 
     MaterialFarmerOptions& options,
     MaterialFarmerStats& stats
 );        
 
-void move_to_start_position_for_letsgo0(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
+void move_to_start_position_for_letsgo0(ConsoleHandle& console, BotBaseContext& context);
 
-void move_to_start_position_for_letsgo1(SingleSwitchProgramEnvironment& env, BotBaseContext& context);
+void move_to_start_position_for_letsgo1(ConsoleHandle& console, BotBaseContext& context);
 
 void lets_go_movement0(BotBaseContext& context);
 
@@ -125,18 +128,20 @@ void lets_go_movement1(BotBaseContext& context);
 std::chrono::minutes minutes_remaining(WallClock start_time, std::chrono::minutes minutes_duration);
 
 void run_lets_go_iteration(
-    SingleSwitchProgramEnvironment& env,
+    ConsoleHandle& console,
     BotBaseContext& context,
     LetsGoEncounterBotTracker& encounter_tracker,
     int num_forward_moves_per_lets_go_iteration
 );
 
 void run_from_battles_and_back_to_pokecenter(
-    SingleSwitchProgramEnvironment& env,
+    ProgramEnvironment& env, 
+    ConsoleHandle& console,
     BotBaseContext& context,
     MaterialFarmerStats& stats,
     std::function<
-        void(SingleSwitchProgramEnvironment& env,
+        void(ProgramEnvironment& env,
+        ConsoleHandle& console,
         BotBaseContext& context)
     >&& action
 );

--- a/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.cpp
@@ -610,7 +610,7 @@ void ItemPrinterRNG::run_item_printer_rng(
 
             //  Run the material farmer.
             press_Bs_to_back_to_overworld(env.program_info(), env.console, context);
-            move_from_item_printer_to_material_farming(env, context);
+            move_from_item_printer_to_material_farming(env.program_info(), env.console, context);
             {
                 //  Dummy stats since we don't use the material farmer stats.
                 MaterialFarmerStats mat_farm_stats;
@@ -618,7 +618,7 @@ void ItemPrinterRNG::run_item_printer_rng(
                 stats.material_farmer_runs++;
                 env.update_stats();
             }
-            move_from_material_farming_to_item_printer(env, context);
+            move_from_material_farming_to_item_printer(env.program_info(), env.console, context);
 
             jobs_counter -= period;
         }

--- a/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/ItemPrinter/PokemonSV_ItemPrinterRNG.cpp
@@ -614,7 +614,7 @@ void ItemPrinterRNG::run_item_printer_rng(
             {
                 //  Dummy stats since we don't use the material farmer stats.
                 MaterialFarmerStats mat_farm_stats;
-                run_material_farmer(env, context, MATERIAL_FARMER_OPTIONS, mat_farm_stats);
+                run_material_farmer(env, env.console, context, MATERIAL_FARMER_OPTIONS, mat_farm_stats);
                 stats.material_farmer_runs++;
                 env.update_stats();
             }
@@ -673,7 +673,7 @@ void ItemPrinterRNG::program(SingleSwitchProgramEnvironment& env, BotBaseContext
                 run_item_printer_rng(env, context, stats);
                 press_Bs_to_back_to_overworld(env.program_info(), env.console, context);
                 move_from_item_printer_to_material_farming(env, context);
-                run_material_farmer(env, context, MATERIAL_FARMER_OPTIONS, mat_farm_stats);
+                run_material_farmer(env, env.console, context, MATERIAL_FARMER_OPTIONS, mat_farm_stats);
                 move_from_material_farming_to_item_printer(env, context);
             }
         }


### PR DESCRIPTION
Refactored material farmer to remove env variable from some functions and change SingleSwitchProgramEnvironment to ProgramEnvironment. This allows me to more easily test with TestProgramSwitch.

I initially wanted to remove all env variables, but `make_sandwich_option` requires it and I didn't also want to refactor the functions in SandwichRoutines.