### PR TITLE
Relax LetsGoKillDetector thresholds for more capture card support

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Inference/Overworld/PokemonSV_LetsGoKillDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Overworld/PokemonSV_LetsGoKillDetector.cpp
@@ -58,7 +58,7 @@ bool is_kill_icon(
 
 //    extract_box_reference(image, object).save("test.png");
 
-    if (object.width() < 20 || object.height() < 20){
+    if (object.width() < 18 || object.height() < 18){
 //        cout << "too small: " << object.width() << endl;
         return false;
     }
@@ -133,7 +133,7 @@ bool LetsGoKillDetector::detect(const ImageViewRGB32& screen) const{
             WaterfillObject object;
             while (iter->find_next(object, false)){
                 double aspect_ratio = object.aspect_ratio();
-                if (aspect_ratio < 1.5 || aspect_ratio > 2.5){
+                if (aspect_ratio < 1.5 || aspect_ratio > 2.7){
                     continue;
                 }
 //                cout << object.area << endl;


### PR DESCRIPTION
Currently only Tera Roller uses this detector (from open_recently_battled_from_pokedex). The aspect and size checks are relaxed a little to address 2 recent error reports (which are added to CommandLineTests as well).