### PR TITLE
Update DialogArrowWatcher and DialogDetector

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Inference/Dialogs/PokemonSV_DialogArrowDetector.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Dialogs/PokemonSV_DialogArrowDetector.h
@@ -14,6 +14,7 @@
 #include "CommonFramework/VideoPipeline/VideoOverlayScopes.h"
 #include "CommonFramework/InferenceInfra/VisualInferenceCallback.h"
 #include "CommonFramework/Inference/VisualDetector.h"
+#include "CommonFramework/Tools/ConsoleHandle.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
@@ -29,6 +30,8 @@ public:
 
     std::vector<ImageFloatBox> detect_all(const ImageViewRGB32& screen) const;
 
+    std::pair<double, double> locate_dialog_arrow(const ImageViewRGB32& screen) const;
+
 protected:
     Color m_color;
     ImageFloatBox m_box;
@@ -39,7 +42,7 @@ protected:
 class DialogArrowWatcher : public VisualInferenceCallback{
 public:
     ~DialogArrowWatcher();
-    DialogArrowWatcher(Color color, VideoOverlay& overlay, const ImageFloatBox& box);
+    DialogArrowWatcher(Color color, VideoOverlay& overlay, const ImageFloatBox& box, const double top_line, const double bottom_line);
 
     virtual void make_overlays(VideoOverlaySet& items) const override;
     virtual bool process_frame(const ImageViewRGB32& frame, WallClock timestamp) override;
@@ -48,7 +51,12 @@ public:
 protected:
     VideoOverlay& m_overlay;
     DialogArrowDetector m_detector;
-    FixedLimitVector<OverlayBoxScope> m_arrows;
+    double m_top_line;
+    double m_bottom_line;
+    uint16_t m_num_oscillation_above_top_line;
+    uint16_t m_num_oscillation_below_bottom_line;
+    // FixedLimitVector<OverlayBoxScope> m_arrows;
+
 };
 
 

--- a/SerialPrograms/Source/PokemonSV/Inference/Dialogs/PokemonSV_DialogDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Dialogs/PokemonSV_DialogDetector.cpp
@@ -73,7 +73,7 @@ bool DialogBoxDetector::detect(const ImageViewRGB32& screen) const{
 
     ImageStats stats_border_bot = image_stats(extract_box_reference(screen, m_border_bot));
 //    cout << stats_border_bot.average << stats_border_bot.stddev << endl;
-    if (stats_border_bot.stddev.sum() < 50){
+    if (stats_border_bot.stddev.sum() < 20){
         return !m_true_if_detected;
     }
 


### PR DESCRIPTION
Note: This is used by Autostory. So, I recommend merging this first.

DialogDetector: changed the stddev threshold to deal with light backgrounds.

DialogArrowWatcher: Nothing currently uses this, so I revamped it to meet my needs.
The current ExactImageMatcher DIALOG_ARROW_WHITE() uses a template with a black background. This doesn’t work for me since I want to be able to detect the arrow on variable background colors. 
DialogArrowMatcher uses a template with no background. This does a good job of matching the arrow. But I worry about false positives with pure white templates. So, I made sure process_frame can detect the oscillation of the arrow, to reduce false positives. The way it detects the oscillations is by locating the position of the arrow, and incrementing `m_num_oscillation_above_top_line` every time the arrow is above `top_line`. Likewise for `m_num_oscillation_below_bottom_line`. We alternate between looking for the arrow being above `top_line` vs below `bottom_line`. Reset the counts whenever the dialog arrow is not detected.

For your reference, the DialogArrow that I'm trying to detect is seen in the bottom right of this screenshot.

![screenshot-20240904-180610279507](https://github.com/user-attachments/assets/c2d1eceb-f0ed-4ed4-830e-557cc46c6357)
