### PR TITLE
Direction detector to check for locked minimap

### DIFF
--- a/SerialPrograms/Source/NintendoSwitch/DevPrograms/TestProgramSwitch.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/DevPrograms/TestProgramSwitch.cpp
@@ -278,7 +278,7 @@ void TestProgram::program(MultiSwitchProgramEnvironment& env, CancellableScope& 
 
     // std::pair<double, double> north_location = detector.locate_north(image);
     // detector.current_direction(image);
-    detector.change_direction(console, context, 3.14);
+    detector.change_direction(env.program_info(), console, context, 3.14);
 
 #endif
 

--- a/SerialPrograms/Source/PokemonSV/Inference/Overworld/PokemonSV_DirectionDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Overworld/PokemonSV_DirectionDetector.cpp
@@ -223,9 +223,9 @@ void DirectionDetector::change_direction(
 
         uint8_t scale_factor = 80;
 
-        uint16_t push_duration = std::max(uint16_t(std::abs(diff * scale_factor)), uint16_t(3));
+        uint16_t push_duration = std::max(uint16_t(std::abs(diff * scale_factor)), uint16_t(8));
         int16_t push_direction = (diff > 0) ? -1 : 1;
-        double push_magnitude = (128 / (i + 1)); // push less with each iteration/attempt
+        double push_magnitude = std::max(double(128 / (i + 1)), double(20)); // push less with each iteration/attempt
         uint8_t push_x = uint8_t(std::max(std::min(int(128 + (push_direction * push_magnitude)), 255), 0));
         console.log("push magnitude: " + std::to_string(push_x) + ", push duration: " +  std::to_string(push_duration));
         pbf_move_right_joystick(context, push_x, 128, push_duration, 100);

--- a/SerialPrograms/Source/PokemonSV/Inference/Overworld/PokemonSV_DirectionDetector.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Overworld/PokemonSV_DirectionDetector.h
@@ -45,13 +45,9 @@ public:
     // return -1 if unable to locate the N symbol
     double get_current_direction(ConsoleHandle& console, const ImageViewRGB32& screen) const;
 
-    bool is_minimap_possibly_locked(
-        double initial_diff, 
-        double current_diff, 
-        double curr_direction
-    ) const;
+    bool is_minimap_possibly_locked(double current_direction) const;
 
-    bool is_minimap_definitely_locked(ConsoleHandle& console, BotBaseContext& context, double curr_direction) const;
+    bool is_minimap_definitely_locked(ConsoleHandle& console, BotBaseContext& context, double current_direction) const;
 
     // given direction in radians (North-clockwise), rotate the camera so N is pointing in the desired direction.
     // mini-map must be unlocked.

--- a/SerialPrograms/Source/PokemonSV/Inference/Overworld/PokemonSV_DirectionDetector.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Overworld/PokemonSV_DirectionDetector.h
@@ -43,7 +43,15 @@ public:
 
     // return the direction of the N symbol, in radians, using North-clockwise convention. [0, 2pi)
     // return -1 if unable to locate the N symbol
-    double current_direction(ConsoleHandle& console, const ImageViewRGB32& screen) const;
+    double get_current_direction(ConsoleHandle& console, const ImageViewRGB32& screen) const;
+
+    bool is_minimap_possibly_locked(
+        double initial_diff, 
+        double current_diff, 
+        double curr_direction
+    ) const;
+
+    bool is_minimap_definitely_locked(ConsoleHandle& console, BotBaseContext& context, double curr_direction) const;
 
     // given direction in radians (North-clockwise), rotate the camera so N is pointing in the desired direction.
     // mini-map must be unlocked.

--- a/SerialPrograms/Source/PokemonSV/Inference/Overworld/PokemonSV_DirectionDetector.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Overworld/PokemonSV_DirectionDetector.h
@@ -12,6 +12,7 @@
 #include "Common/Cpp/Containers/FixedLimitVector.h"
 #include "ClientSource/Connection/BotBase.h"
 #include "CommonFramework/Tools/ConsoleHandle.h"
+#include "CommonFramework/Notifications/ProgramInfo.h"
 #include "CommonFramework/ImageTools/ImageBoxes.h"
 #include "CommonFramework/VideoPipeline/VideoOverlayScopes.h"
 #include "CommonFramework/InferenceInfra/VisualInferenceCallback.h"
@@ -47,6 +48,7 @@ public:
     // given direction in radians (North-clockwise), rotate the camera so N is pointing in the desired direction.
     // mini-map must be unlocked.
     void change_direction(
+        const ProgramInfo& info,
         ConsoleHandle& console, 
         BotBaseContext& context,
         double direction

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.cpp
@@ -500,7 +500,7 @@ void move_to_start_position_for_letsgo1(
 
     // look right
     // pbf_move_right_joystick(context, 255, 128, 20, 10);
-    direction.change_direction(info, console, context, 5.46); // 5.3
+    direction.change_direction(info, console, context, 5.3);
 
     // move forward slightly
     pbf_move_left_joystick(context, 128, 0, 50, 10);

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.cpp
@@ -263,7 +263,7 @@ void run_material_farmer(
                 [&](ProgramEnvironment& env, ConsoleHandle& console, BotBaseContext& context){
                     // Move to starting position for Let's Go hunting path
                     console.log("Move to starting position for Let's Go hunting path.", COLOR_PURPLE);
-                    move_to_start_position_for_letsgo1(console, context);
+                    move_to_start_position_for_letsgo1(env.program_info(), console, context);
 
                     // run let's go while updating the HP watcher
                     console.log("Starting Let's Go hunting path.", COLOR_PURPLE);
@@ -448,6 +448,7 @@ void move_to_start_position_for_letsgo0(
 
 // from the North Province (Area 3) pokecenter, move to start position for Happiny dust farming
 void move_to_start_position_for_letsgo1(
+    const ProgramInfo& info,
     ConsoleHandle& console, 
     BotBaseContext& context
 ){
@@ -467,7 +468,7 @@ void move_to_start_position_for_letsgo1(
 
     // look right, towards the start position
     DirectionDetector direction;
-    direction.change_direction(console, context, 5.76);
+    direction.change_direction(info, console, context, 5.76);
     // pbf_move_right_joystick(context, 255, 128, 130, 10);
     pbf_move_left_joystick(context, 128, 0, 10, 10);
 
@@ -499,7 +500,7 @@ void move_to_start_position_for_letsgo1(
 
     // look right
     // pbf_move_right_joystick(context, 255, 128, 20, 10);
-    direction.change_direction(console, context, 5.46);
+    direction.change_direction(info, console, context, 5.46); // 5.3
 
     // move forward slightly
     pbf_move_left_joystick(context, 128, 0, 50, 10);

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_MaterialFarmerTools.h
@@ -111,7 +111,7 @@ WallClock make_sandwich_material_farm(
 
 void move_to_start_position_for_letsgo0(ConsoleHandle& console, BotBaseContext& context);
 
-void move_to_start_position_for_letsgo1(ConsoleHandle& console, BotBaseContext& context);
+void move_to_start_position_for_letsgo1(const ProgramInfo& info, ConsoleHandle& console, BotBaseContext& context);
 
 void lets_go_movement0(BotBaseContext& context);
 


### PR DESCRIPTION
- when changing player direction with the Direction detector, it will also check if the minimap is locked and try to unlock it
- also a minor update to MaterialFarmer when aligning player direction