### PR TITLE
IV Checker Exit Condition

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Programs/Boxes/PokemonSV_BoxRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Boxes/PokemonSV_BoxRoutines.cpp
@@ -123,6 +123,8 @@ void change_view_to_judge(
         //  If less than 4 of the IVs are read, assume we're not on the judge screen.
         if (detected < 4){
             pbf_press_button(context, BUTTON_PLUS, 20, 230);
+        }else if (detected == 6){
+            break;
         }
     }
 }

--- a/SerialPrograms/Source/PokemonSV/Programs/Boxes/PokemonSV_BoxRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Boxes/PokemonSV_BoxRoutines.cpp
@@ -123,7 +123,7 @@ void change_view_to_judge(
         //  If less than 4 of the IVs are read, assume we're not on the judge screen.
         if (detected < 4){
             pbf_press_button(context, BUTTON_PLUS, 20, 230);
-        }else if (detected == 6){
+        }else{
             break;
         }
     }


### PR DESCRIPTION
[This commit](https://github.com/PokemonAutomation/Arduino-Source/commit/fb237b64c0fd8d767cf243e9aaad3a92facb520e) removed the break that was stopping the IV checker from retrying after one attempt but I'm having issues now where an exception is being thrown every time the IV checker is called.

```
if (attempts == 10){
    throw OperationFailedException(
        ErrorReport::SEND_ERROR_REPORT, console,
        "Unable to change Pokemon view to judge after 10 tries. Have you unlocked it?",
        true
    );
}
```
10 retry attempts are being made regardless of whether or not all the stats were detected.