### PR TITLE
don't heal at mesagoza pokecenter

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Programs/AutoStory/PokemonSV_AutoStory_Segment_07.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/AutoStory/PokemonSV_AutoStory_Segment_07.cpp
@@ -122,7 +122,9 @@ void checkpoint_12(
             realign_player(info, env.console, context, PlayerRealignMode::REALIGN_NEW_MARKER, 30, 0, 50);
             walk_forward_while_clear_front_path(info, env.console, context, 1000);
 
-            heal_at_pokecenter(info, env.console, context);
+            fly_to_overlapping_flypoint(info, env.console, context);
+
+            // heal_at_pokecenter(info, env.console, context);
    
         }  
         );


### PR DESCRIPTION
Healing at the pokecenter is unnecessary in Autostory, since the story automatically heals you before/after several major fights.

Also, heal_at_pokecenter(), hasn't been tested in all the languages yet. The location of the Gradient arrow changes based on the language.