### PR TITLE
Legendary Hunt (Emerald)

### DIFF
--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -1339,6 +1339,8 @@ file(GLOB MAIN_SOURCES
     Source/PokemonRSE/Inference/PokemonRSE_ShinyNumberDetector.h
     Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_AudioStarterReset.cpp
     Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_AudioStarterReset.h
+    Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.cpp
+    Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.h
     Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_ShinyHunt-Deoxys.cpp
     Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_ShinyHunt-Deoxys.h
     Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_StarterReset.cpp

--- a/SerialPrograms/Source/PokemonRSE/PokemonRSE_Navigation.cpp
+++ b/SerialPrograms/Source/PokemonRSE/PokemonRSE_Navigation.cpp
@@ -21,11 +21,11 @@ namespace NintendoSwitch{
 namespace PokemonRSE{
 
 
-void soft_reset(const ProgramInfo& info, VideoStream& stream, SwitchControllerContext& context){
+void soft_reset(const ProgramInfo& info, VideoStream& stream, ProControllerContext& context){
     // A + B + Select + Start
     pbf_press_button(context, BUTTON_B | BUTTON_Y | BUTTON_MINUS | BUTTON_PLUS, 10, 180);
 
-    pbf_mash_button(context, BUTTON_PLUS, GameSettings::instance().START_BUTTON_MASH);
+    pbf_mash_button(context, BUTTON_PLUS, GameSettings::instance().START_BUTTON_MASH0);
     context.wait_for_all_requests();
 
     pbf_press_button(context, BUTTON_A, 20, 40);
@@ -34,7 +34,7 @@ void soft_reset(const ProgramInfo& info, VideoStream& stream, SwitchControllerCo
     BlackScreenOverWatcher detector(COLOR_RED, {0.282, 0.064, 0.448, 0.871});
     int ret = wait_until(
         stream, context,
-        std::chrono::milliseconds(GameSettings::instance().ENTER_GAME_WAIT * (1000 / TICKS_PER_SECOND)),
+        GameSettings::instance().ENTER_GAME_WAIT0,
         {{detector}}
     );
     if (ret == 0){
@@ -50,7 +50,7 @@ void soft_reset(const ProgramInfo& info, VideoStream& stream, SwitchControllerCo
     context.wait_for_all_requests();
 }
 
-void flee_battle(VideoStream& stream, SwitchControllerContext& context) {
+void flee_battle(VideoStream& stream, ProControllerContext& context) {
     stream.log("Navigate to Run.");
     pbf_press_dpad(context, DPAD_RIGHT, 20, 20);
     pbf_press_dpad(context, DPAD_DOWN, 20, 20);
@@ -90,7 +90,7 @@ void flee_battle(VideoStream& stream, SwitchControllerContext& context) {
     }
 }
 
-bool handle_encounter(VideoStream& stream, SwitchControllerContext& context, bool send_out_lead) {
+bool handle_encounter(VideoStream& stream, ProControllerContext& context, bool send_out_lead) {
     float shiny_coefficient = 1.0;
     ShinySoundDetector shiny_detector(stream.logger(), [&](float error_coefficient) -> bool{
         shiny_coefficient = error_coefficient;
@@ -102,9 +102,9 @@ bool handle_encounter(VideoStream& stream, SwitchControllerContext& context, boo
     pbf_mash_button(context, BUTTON_A, 540);
     context.wait_for_all_requests();
 
-    int res = run_until<SwitchControllerContext>(
+    int res = run_until<ProControllerContext>(
         stream, context,
-        [&](SwitchControllerContext& context) {
+        [&](ProControllerContext& context) {
             int ret = wait_until(
                 stream, context,
                 std::chrono::seconds(30),

--- a/SerialPrograms/Source/PokemonRSE/PokemonRSE_Navigation.cpp
+++ b/SerialPrograms/Source/PokemonRSE/PokemonRSE_Navigation.cpp
@@ -35,7 +35,7 @@ void soft_reset(const ProgramInfo& info, VideoStream& stream, ProControllerConte
     int ret = wait_until(
         stream, context,
         GameSettings::instance().ENTER_GAME_WAIT0,
-        {{detector}}
+        {detector}
     );
     if (ret == 0){
         stream.log("Entered game!");

--- a/SerialPrograms/Source/PokemonRSE/PokemonRSE_Navigation.h
+++ b/SerialPrograms/Source/PokemonRSE/PokemonRSE_Navigation.h
@@ -11,7 +11,7 @@
 
 #include "CommonFramework/Tools/VideoStream.h"
 #include "Common/NintendoSwitch/NintendoSwitch_ControllerDefs.h"
-#include "NintendoSwitch/Controllers/NintendoSwitch_ProController.h"
+#include "NintendoSwitch/Controllers/NintendoSwitch_Controller.h"
 
 namespace PokemonAutomation{
     struct ProgramInfo;
@@ -20,14 +20,15 @@ namespace PokemonRSE{
 
 // Press A+B+Select+Start at the same time to soft reset, then re-enters the game.
 // For now this assumes no dry battery.
-void soft_reset(const ProgramInfo& info, VideoStream& stream, ProControllerContext &context);
+void soft_reset(const ProgramInfo& info, VideoStream& stream, SwitchControllerContext &context);
 
 // Run from battle. Cursor must start on the FIGHT button. Assumes fleeing will always work. (Smoke Ball)
-void flee_battle(VideoStream& stream, ProControllerContext& context);
+void flee_battle(VideoStream& stream, SwitchControllerContext& context);
 
 // After press A/walking up to enter a battle, run this handle the battle start and to check if opponent is shiny.
-// Use flee_battle or soft_reset after this, depending on game.
-bool handle_encounter(VideoStream& stream, ProControllerContext& context);
+// Set send_out_lead to true and then use flee_battle() after if game is Emerald.
+// For R/S, send_out_lead as false and then soft_reset() to save time.
+bool handle_encounter(VideoStream& stream, SwitchControllerContext& context, bool send_out_lead);
 
 
 }

--- a/SerialPrograms/Source/PokemonRSE/PokemonRSE_Navigation.h
+++ b/SerialPrograms/Source/PokemonRSE/PokemonRSE_Navigation.h
@@ -11,7 +11,7 @@
 
 #include "CommonFramework/Tools/VideoStream.h"
 #include "Common/NintendoSwitch/NintendoSwitch_ControllerDefs.h"
-#include "NintendoSwitch/Controllers/NintendoSwitch_Controller.h"
+#include "NintendoSwitch/Controllers/NintendoSwitch_ProController.h"
 
 namespace PokemonAutomation{
     struct ProgramInfo;
@@ -20,15 +20,15 @@ namespace PokemonRSE{
 
 // Press A+B+Select+Start at the same time to soft reset, then re-enters the game.
 // For now this assumes no dry battery.
-void soft_reset(const ProgramInfo& info, VideoStream& stream, SwitchControllerContext &context);
+void soft_reset(const ProgramInfo& info, VideoStream& stream, ProControllerContext &context);
 
 // Run from battle. Cursor must start on the FIGHT button. Assumes fleeing will always work. (Smoke Ball)
-void flee_battle(VideoStream& stream, SwitchControllerContext& context);
+void flee_battle(VideoStream& stream, ProControllerContext& context);
 
 // After press A/walking up to enter a battle, run this handle the battle start and to check if opponent is shiny.
 // Set send_out_lead to true and then use flee_battle() after if game is Emerald.
 // For R/S, send_out_lead as false and then soft_reset() to save time.
-bool handle_encounter(VideoStream& stream, SwitchControllerContext& context, bool send_out_lead);
+bool handle_encounter(VideoStream& stream, ProControllerContext& context, bool send_out_lead);
 
 
 }

--- a/SerialPrograms/Source/PokemonRSE/PokemonRSE_Panels.cpp
+++ b/SerialPrograms/Source/PokemonRSE/PokemonRSE_Panels.cpp
@@ -11,6 +11,7 @@
 #include "PokemonRSE_Settings.h"
 
 #include "Programs/ShinyHunting/PokemonRSE_AudioStarterReset.h"
+#include "Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.h"
 #include "Programs/ShinyHunting/PokemonRSE_ShinyHunt-Deoxys.h"
 
 #include "Programs/ShinyHunting/PokemonRSE_StarterReset.h"
@@ -38,6 +39,7 @@ std::vector<PanelEntry> PanelListFactory::make_panels() const{
     ret.emplace_back(make_single_switch_program<AudioStarterReset_Descriptor, AudioStarterReset>());
 
     ret.emplace_back("---- Shiny Hunting (Emerald) ----");
+    ret.emplace_back(make_single_switch_program<LegendaryHuntEmerald_Descriptor, LegendaryHuntEmerald>());
     ret.emplace_back(make_single_switch_program<ShinyHuntDeoxys_Descriptor, ShinyHuntDeoxys>());
     
 

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.cpp
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.cpp
@@ -155,6 +155,7 @@ void LegendaryHuntEmerald::reset_groudon(SingleSwitchProgramEnvironment& env, Sw
     //Turn left. Take 4 steps.
     ssf_press_button(context, BUTTON_B, 0, 80);
     pbf_press_dpad(context, DPAD_LEFT, 80, 20);
+    context.wait_for_all_requests();
 
     //Turn down. Exit. Black screen over.
     BlackScreenOverWatcher exit_area(COLOR_RED, {0.282, 0.064, 0.448, 0.871});
@@ -222,7 +223,96 @@ void LegendaryHuntEmerald::reset_groudon(SingleSwitchProgramEnvironment& env, Sw
 }
 
 void LegendaryHuntEmerald::reset_kyogre(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context) {
+    //Turn down. Take 1 step.
+    ssf_press_button(context, BUTTON_B, 0, 20);
+    pbf_press_dpad(context, DPAD_DOWN, 20, 20);
 
+    //Turn right. Take 9 steps.
+    ssf_press_button(context, BUTTON_B, 0, 160);
+    pbf_press_dpad(context, DPAD_RIGHT, 160, 20);
+
+    //Turn up. 13 steps. Wall.
+    ssf_press_button(context, BUTTON_B, 0, 220);
+    pbf_press_dpad(context, DPAD_UP, 220, 20);
+
+    //Turn left. 4 steps. Wall.
+    ssf_press_button(context, BUTTON_B, 0, 80);
+    pbf_press_dpad(context, DPAD_LEFT, 80, 20);
+
+    //Turn up. 10 steps.
+    ssf_press_button(context, BUTTON_B, 0, 180);
+    pbf_press_dpad(context, DPAD_UP, 180, 20);
+
+    //Turn right. 6 steps.
+    ssf_press_button(context, BUTTON_B, 0, 110);
+    pbf_press_dpad(context, DPAD_RIGHT, 110, 20);
+
+    //Turn down. Exit. Black screen over.
+    BlackScreenOverWatcher exit_area(COLOR_RED, {0.282, 0.064, 0.448, 0.871});
+    int ret = run_until<SwitchControllerContext>(
+        env.console, context,
+        [](SwitchControllerContext& context){
+            ssf_press_button(context, BUTTON_B, 0, 90);
+            pbf_press_dpad(context, DPAD_DOWN, 90, 20);
+            pbf_wait(context, 300);
+        },
+        {exit_area}
+    );
+    context.wait_for_all_requests();
+    if (ret != 0){
+        env.log("Failed to exit area.", COLOR_RED);
+        OperationFailedException::fire(
+            ErrorReport::SEND_ERROR_REPORT,
+            "Failed to exit area.",
+            env.console
+        );
+    }
+    else {
+        env.log("Left area.");
+    }
+
+    BlackScreenOverWatcher enter_area(COLOR_RED, {0.282, 0.064, 0.448, 0.871});
+    int ret2 = run_until<SwitchControllerContext>(
+        env.console, context,
+        [](SwitchControllerContext& context){
+            ssf_press_button(context, BUTTON_B, 0, 90);
+            pbf_press_dpad(context, DPAD_UP, 90, 20);
+            pbf_wait(context, 300);
+        },
+        {enter_area}
+    );
+    context.wait_for_all_requests();
+    if (ret2 != 0){
+        env.log("Failed to enter area.", COLOR_RED);
+        OperationFailedException::fire(
+            ErrorReport::SEND_ERROR_REPORT,
+            "Failed to enter area.",
+            env.console
+        );
+    }
+    else {
+        env.log("Entered area.");
+    }
+
+    ssf_press_button(context, BUTTON_B, 0, 110);
+    pbf_press_dpad(context, DPAD_LEFT, 110, 20);
+
+    ssf_press_button(context, BUTTON_B, 0, 180);
+    pbf_press_dpad(context, DPAD_DOWN, 180, 20);
+
+    ssf_press_button(context, BUTTON_B, 0, 80);
+    pbf_press_dpad(context, DPAD_RIGHT, 80, 20);
+
+    ssf_press_button(context, BUTTON_B, 0, 220);
+    pbf_press_dpad(context, DPAD_DOWN, 220, 20);
+
+    ssf_press_button(context, BUTTON_B, 0, 160);
+    pbf_press_dpad(context, DPAD_LEFT, 160, 20);
+
+    ssf_press_button(context, BUTTON_B, 0, 20);
+    pbf_press_dpad(context, DPAD_UP, 20, 20);
+
+    context.wait_for_all_requests();
 }
 
 void LegendaryHuntEmerald::reset_hooh(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context) {
@@ -373,15 +463,17 @@ void LegendaryHuntEmerald::program(SingleSwitchProgramEnvironment& env, SwitchCo
     while (true) {
         switch (TARGET) {
         case Target::hooh:
+        case Target::kyogre:
+        case Target::groudon:
             //Step forward to start the encounter.
             pbf_press_dpad(context, DPAD_UP, 20, 50);
             break;
-        case Target::groudon:
-            pbf_press_dpad(context, DPAD_RIGHT, 20, 50);
-            break;
-        case Target::kyogre:
-            pbf_press_dpad(context, DPAD_LEFT, 20, 50);
-            break;
+        //case Target::groudon: //Step up is easier.
+        //    pbf_press_dpad(context, DPAD_RIGHT, 20, 50);
+        //    break;
+        //case Target::kyogre:
+        //    pbf_press_dpad(context, DPAD_LEFT, 20, 50);
+        //    break;
         }
         //handle_encounter presses A already for everything else
         
@@ -409,6 +501,7 @@ void LegendaryHuntEmerald::program(SingleSwitchProgramEnvironment& env, SwitchCo
             break;
         case Target::kyogre:
             reset_kyogre(env, context);
+            break;
         case Target::hooh:
             reset_hooh(env, context);
             break;

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.cpp
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.cpp
@@ -1,0 +1,191 @@
+/*  Legendary Hunt - Emerald
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#include "Common/Cpp/PrettyPrint.h"
+#include "CommonFramework/Exceptions/OperationFailedException.h"
+#include "CommonTools/Async/InferenceRoutines.h"
+#include "CommonTools/VisualDetectors/BlackScreenDetector.h"
+#include "CommonFramework/Notifications/ProgramNotifications.h"
+#include "CommonFramework/ProgramStats/StatsTracking.h"
+#include "CommonFramework/VideoPipeline/VideoFeed.h"
+#include "Pokemon/Pokemon_Strings.h"
+#include "NintendoSwitch/Commands/NintendoSwitch_Commands_PushButtons.h"
+#include "NintendoSwitch/Commands/NintendoSwitch_Commands_Superscalar.h"
+#include "PokemonRSE/Inference/Dialogs/PokemonRSE_DialogDetector.h"
+#include "PokemonRSE/PokemonRSE_Navigation.h"
+#include "PokemonRSE_LegendaryHunt-Emerald.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonRSE{
+
+LegendaryHuntEmerald_Descriptor::LegendaryHuntEmerald_Descriptor()
+    : SingleSwitchProgramDescriptor(
+        "PokemonRSE:LegendaryHuntEmerald",
+        Pokemon::STRING_POKEMON + " RSE", "Legendary Hunt (Emerald)",
+        "ComputerControl/blob/master/Wiki/Programs/PokemonRSE/LegendaryHuntEmerald.md",
+        "Use the Run Away method to shiny hunt legendaries in Emerald.",
+        FeedbackType::VIDEO_AUDIO,
+        AllowCommandsWhenRunning::DISABLE_COMMANDS,
+        {SerialPABotBase::OLD_NINTENDO_SWITCH_DEFAULT_REQUIREMENTS}
+    )
+{}
+
+struct LegendaryHuntEmerald_Descriptor::Stats : public StatsTracker{
+    Stats()
+        : resets(m_stats["Resets"])
+        , shinies(m_stats["Shinies"])
+    {
+        m_display_order.emplace_back("Resets");
+        m_display_order.emplace_back("Shinies");
+    }
+    std::atomic<uint64_t>& resets;
+    std::atomic<uint64_t>& shinies;
+};
+std::unique_ptr<StatsTracker> LegendaryHuntEmerald_Descriptor::make_stats() const{
+    return std::unique_ptr<StatsTracker>(new Stats());
+}
+
+LegendaryHuntEmerald::LegendaryHuntEmerald()
+    : TARGET(
+        "<b>Starter:</b><br>",
+        {
+            {Target::regis, "regis", "Regirock/Regice/Registeel"},
+            {Target::hooh, "hooh", "Ho-Oh"},
+            {Target::lugia, "lugia", "Lugia"},
+            {Target::latis, "latis", "Latias/Latios (Southern Island)"},
+        },
+        LockMode::LOCK_WHILE_RUNNING,
+        Target::hooh
+    )
+    , NOTIFICATION_SHINY(
+        "Shiny Found",
+        true, true, ImageAttachmentMode::JPG,
+        {"Notifs", "Showcase"}
+    )
+    , NOTIFICATION_STATUS_UPDATE("Status Update", true, false, std::chrono::seconds(3600))
+    , NOTIFICATIONS({
+        &NOTIFICATION_SHINY,
+        &NOTIFICATION_STATUS_UPDATE,
+        &NOTIFICATION_PROGRAM_FINISH,
+        })
+{
+    PA_ADD_OPTION(TARGET);
+    PA_ADD_OPTION(NOTIFICATIONS);
+}
+
+void LegendaryHuntEmerald::reset_room(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context) {
+    switch (TARGET) {
+    case Target::regis:
+        //turn around, walk down 4
+
+        //black screen over
+
+        //turn around, up one
+
+        //black screen over
+
+        //reverse the above
+
+        break;
+    case Target::hooh:
+        //Turn around
+
+        //10 steps down
+
+        //Turn right
+
+        //Take one step
+
+        //Wait for black screen over
+
+        //Turn left and take a step
+
+        //now turn right and take a step
+
+        //wait for black screen over
+
+        //now reverse the above, but only take 9 steps up
+        break;
+    case Target::lugia:
+        //Turn around
+
+        //5 steps down
+
+        //Turn right
+
+        //3 steps right
+
+
+        //Wait for black screen over
+
+        //turn up, take one step
+
+        //now turn back down and take a step
+
+        //wait for black screen over
+
+        //reverse above steps
+        break;
+    case Target::latis:
+
+        break;
+    default:
+        break;
+    }
+    context.wait_for_all_requests();
+}
+
+void LegendaryHuntEmerald::program(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context){
+    LegendaryHuntEmerald_Descriptor::Stats& stats = env.current_stats<LegendaryHuntEmerald_Descriptor::Stats>();
+
+    /*
+    * Text speed fast, battle animations off
+    * smoke ball or fast pokemon req.
+    * 
+    * Don't need to worry about PokeNav or random encounters for any of these targets.
+    * 
+    * Stand in front of Regis/Ho-Oh/Lugia. Save the game.
+    */
+
+    while (true) {
+        //Start battle.
+        if (TARGET == Target::hooh) {
+            //Step forward to start the encounter.
+            pbf_press_dpad(context, DPAD_UP, 10, 50);
+        }
+        else {
+            //All other legendaries.
+            pbf_press_button(context, BUTTON_A, 20, 40);
+        }
+
+        bool legendary_shiny = handle_encounter(env.console, context, true);
+        if (legendary_shiny) {
+            stats.shinies++;
+            env.update_stats();
+            send_program_notification(env, NOTIFICATION_SHINY, COLOR_YELLOW, "Shiny found!", {}, "", env.console.video().snapshot(), true);
+            break;
+        }
+        env.log("No shiny found.");
+        flee_battle(env.console, context);
+
+        //Close out dialog box
+        pbf_mash_button(context, BUTTON_B, 250);
+        context.wait_for_all_requests();
+        
+        //Exit and reenter
+        reset_room(env, context);
+
+        stats.resets++;
+        env.update_stats();
+    }
+
+    send_program_finished_notification(env, NOTIFICATION_PROGRAM_FINISH);
+}
+
+}
+}
+}

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.cpp
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.cpp
@@ -77,6 +77,73 @@ LegendaryHuntEmerald::LegendaryHuntEmerald()
     PA_ADD_OPTION(NOTIFICATIONS);
 }
 
+void LegendaryHuntEmerald::reset_hooh(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context) {
+    BlackScreenOverWatcher exit_area(COLOR_RED, {0.282, 0.064, 0.448, 0.871});
+    //Turn around, 10 steps down
+    ssf_press_button(context, BUTTON_B, 0, 180);
+    pbf_press_dpad(context, DPAD_DOWN, 180, 20);
+
+    //Turn right, take 1 step. Wait for black screen over.
+    int ret = run_until<SwitchControllerContext>(
+        env.console, context,
+        [](SwitchControllerContext& context){
+            ssf_press_button(context, BUTTON_B, 0, 30);
+            pbf_press_dpad(context, DPAD_RIGHT, 30, 20);
+            pbf_wait(context, 300);
+        },
+        {exit_area}
+    );
+    context.wait_for_all_requests();
+    if (ret != 0){
+        env.log("Failed to exit area.", COLOR_RED);
+        OperationFailedException::fire(
+            ErrorReport::SEND_ERROR_REPORT,
+            "Failed to exit area.",
+            env.console
+        );
+    }
+    else {
+        env.log("Left area.");
+    }
+
+    BlackScreenOverWatcher enter_area(COLOR_RED, {0.282, 0.064, 0.448, 0.871});
+    //turn left, take one step. now turn back right and take a step. wait for black screen over.
+    int ret2 = run_until<SwitchControllerContext>(
+        env.console, context,
+        [](SwitchControllerContext& context){
+            ssf_press_button(context, BUTTON_B, 0, 40);
+            pbf_press_dpad(context, DPAD_LEFT, 40, 20);
+
+            ssf_press_button(context, BUTTON_B, 0, 40);
+            pbf_press_dpad(context, DPAD_RIGHT, 40, 20);
+            pbf_wait(context, 300);
+        },
+        {enter_area}
+    );
+    context.wait_for_all_requests();
+    if (ret2 != 0){
+        env.log("Failed to enter area.", COLOR_RED);
+        OperationFailedException::fire(
+            ErrorReport::SEND_ERROR_REPORT,
+            "Failed to enter area.",
+            env.console
+        );
+    }
+    else {
+        env.log("Entered area.");
+    }
+
+    //reverse above steps, but only take 9 steps up
+    //doesn't really matter since we want to trigger the encounter anyway
+    ssf_press_button(context, BUTTON_B, 0, 30);
+    pbf_press_dpad(context, DPAD_LEFT, 30, 20);
+
+    ssf_press_button(context, BUTTON_B, 0, 170);
+    pbf_press_dpad(context, DPAD_UP, 170, 20);
+
+    context.wait_for_all_requests();
+}
+
 void LegendaryHuntEmerald::reset_lugia(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context) {
     BlackScreenOverWatcher exit_area(COLOR_RED, {0.282, 0.064, 0.448, 0.871});
     //Turn around, 5 steps down
@@ -195,23 +262,7 @@ void LegendaryHuntEmerald::program(SingleSwitchProgramEnvironment& env, SwitchCo
 
             break;
         case Target::hooh:
-            //Turn around
-
-            //10 steps down
-
-            //Turn right
-
-            //Take one step
-
-            //Wait for black screen over
-
-            //Turn left and take a step
-
-            //now turn right and take a step
-
-            //wait for black screen over
-
-            //now reverse the above, but only take 9 steps up
+            reset_hooh(env, context);
             break;
         case Target::lugia:
             reset_lugia(env, context);

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.cpp
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.cpp
@@ -58,7 +58,7 @@ LegendaryHuntEmerald::LegendaryHuntEmerald()
             {Target::lugia, "lugia", "Lugia"},
         },
         LockMode::LOCK_WHILE_RUNNING,
-        Target::hooh
+        Target::regis
     )
     , NOTIFICATION_SHINY(
         "Shiny Found",
@@ -269,7 +269,7 @@ void LegendaryHuntEmerald::program(SingleSwitchProgramEnvironment& env, SwitchCo
 
     /*
     * Text speed fast, battle animations off
-    * smoke ball or fast pokemon req.
+    * smoke ball or fast pokemon req. no entry effects.
     * 
     * Don't need to worry about PokeNav or random encounters for any of these targets.
     * 
@@ -277,11 +277,11 @@ void LegendaryHuntEmerald::program(SingleSwitchProgramEnvironment& env, SwitchCo
     */
 
     while (true) {
-        //Start battle.
         if (TARGET == Target::hooh) {
             //Step forward to start the encounter.
             pbf_press_dpad(context, DPAD_UP, 10, 50);
         }
+        //handle_encounter presses A already for everything else
         
         bool legendary_shiny = handle_encounter(env.console, context, true);
         if (legendary_shiny) {

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.cpp
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.cpp
@@ -54,6 +54,8 @@ LegendaryHuntEmerald::LegendaryHuntEmerald()
         "<b>Target:</b><br>",
         {
             {Target::regis, "regis", "Regirock/Regice/Registeel"},
+            {Target::groudon, "groudon", "Groudon"},
+            {Target::kyogre, "kyogre", "Kyogre"},
             {Target::hooh, "hooh", "Ho-Oh"},
             {Target::lugia, "lugia", "Lugia"},
         },
@@ -129,6 +131,98 @@ void LegendaryHuntEmerald::reset_regi(SingleSwitchProgramEnvironment& env, Switc
     //walk back up to the regi
     ssf_press_button(context, BUTTON_B, 0, 60);
     pbf_press_dpad(context, DPAD_UP, 60, 20);
+
+    context.wait_for_all_requests();
+}
+
+void LegendaryHuntEmerald::reset_groudon(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context) {
+    //Turn left. Take 10 steps.
+    ssf_press_button(context, BUTTON_B, 0, 180);
+    pbf_press_dpad(context, DPAD_LEFT, 180, 20);
+
+    //Turn up. Take 14 steps. (Bump into wall.)
+    ssf_press_button(context, BUTTON_B, 0, 240);
+    pbf_press_dpad(context, DPAD_UP, 240, 20);
+
+    //Turn right. Take 2 steps.
+    ssf_press_button(context, BUTTON_B, 0, 40);
+    pbf_press_dpad(context, DPAD_RIGHT, 40, 20);
+
+    //Turn up. Take 8 steps (Bump into wall.)
+    ssf_press_button(context, BUTTON_B, 0, 140);
+    pbf_press_dpad(context, DPAD_UP, 140, 20);
+
+    //Turn left. Take 4 steps.
+    ssf_press_button(context, BUTTON_B, 0, 80);
+    pbf_press_dpad(context, DPAD_LEFT, 80, 20);
+
+    //Turn down. Exit. Black screen over.
+    BlackScreenOverWatcher exit_area(COLOR_RED, {0.282, 0.064, 0.448, 0.871});
+    int ret = run_until<SwitchControllerContext>(
+        env.console, context,
+        [](SwitchControllerContext& context){
+            ssf_press_button(context, BUTTON_B, 0, 90);
+            pbf_press_dpad(context, DPAD_DOWN, 90, 20);
+            pbf_wait(context, 300);
+        },
+        {exit_area}
+    );
+    context.wait_for_all_requests();
+    if (ret != 0){
+        env.log("Failed to exit area.", COLOR_RED);
+        OperationFailedException::fire(
+            ErrorReport::SEND_ERROR_REPORT,
+            "Failed to exit area.",
+            env.console
+        );
+    }
+    else {
+        env.log("Left area.");
+    }
+
+    //Reverse above steps.
+    BlackScreenOverWatcher enter_area(COLOR_RED, {0.282, 0.064, 0.448, 0.871});
+    int ret2 = run_until<SwitchControllerContext>(
+        env.console, context,
+        [](SwitchControllerContext& context){
+            ssf_press_button(context, BUTTON_B, 0, 90);
+            pbf_press_dpad(context, DPAD_UP, 90, 20);
+            pbf_wait(context, 300);
+        },
+        {enter_area}
+    );
+    context.wait_for_all_requests();
+    if (ret2 != 0){
+        env.log("Failed to enter area.", COLOR_RED);
+        OperationFailedException::fire(
+            ErrorReport::SEND_ERROR_REPORT,
+            "Failed to enter area.",
+            env.console
+        );
+    }
+    else {
+        env.log("Entered area.");
+    }
+    ssf_press_button(context, BUTTON_B, 0, 80);
+    pbf_press_dpad(context, DPAD_RIGHT, 80, 20);
+
+    ssf_press_button(context, BUTTON_B, 0, 140);
+    pbf_press_dpad(context, DPAD_DOWN, 140, 20);
+
+    ssf_press_button(context, BUTTON_B, 0, 40);
+    pbf_press_dpad(context, DPAD_LEFT, 40, 20);
+
+    ssf_press_button(context, BUTTON_B, 0, 240);
+    pbf_press_dpad(context, DPAD_DOWN, 240, 20);
+
+    ssf_press_button(context, BUTTON_B, 0, 180);
+    pbf_press_dpad(context, DPAD_RIGHT, 180, 20);
+
+    context.wait_for_all_requests();
+}
+
+void LegendaryHuntEmerald::reset_kyogre(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context) {
+
 }
 
 void LegendaryHuntEmerald::reset_hooh(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context) {
@@ -277,9 +371,17 @@ void LegendaryHuntEmerald::program(SingleSwitchProgramEnvironment& env, SwitchCo
     */
 
     while (true) {
-        if (TARGET == Target::hooh) {
+        switch (TARGET) {
+        case Target::hooh:
             //Step forward to start the encounter.
-            pbf_press_dpad(context, DPAD_UP, 10, 50);
+            pbf_press_dpad(context, DPAD_UP, 20, 50);
+            break;
+        case Target::groudon:
+            pbf_press_dpad(context, DPAD_RIGHT, 20, 50);
+            break;
+        case Target::kyogre:
+            pbf_press_dpad(context, DPAD_LEFT, 20, 50);
+            break;
         }
         //handle_encounter presses A already for everything else
         
@@ -302,6 +404,11 @@ void LegendaryHuntEmerald::program(SingleSwitchProgramEnvironment& env, SwitchCo
         case Target::regis:
             reset_regi(env, context);
             break;
+        case Target::groudon:
+            reset_groudon(env, context);
+            break;
+        case Target::kyogre:
+            reset_kyogre(env, context);
         case Target::hooh:
             reset_hooh(env, context);
             break;

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.cpp
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.cpp
@@ -56,7 +56,6 @@ LegendaryHuntEmerald::LegendaryHuntEmerald()
             {Target::regis, "regis", "Regirock/Regice/Registeel"},
             {Target::hooh, "hooh", "Ho-Oh"},
             {Target::lugia, "lugia", "Lugia"},
-            {Target::latis, "latis", "Latias/Latios (Southern Island)"},
         },
         LockMode::LOCK_WHILE_RUNNING,
         Target::hooh
@@ -308,9 +307,6 @@ void LegendaryHuntEmerald::program(SingleSwitchProgramEnvironment& env, SwitchCo
             break;
         case Target::lugia:
             reset_lugia(env, context);
-            break;
-        case Target::latis:
-            //TODO
             break;
         default:
             OperationFailedException::fire(

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.cpp
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.cpp
@@ -78,13 +78,13 @@ LegendaryHuntEmerald::LegendaryHuntEmerald()
     PA_ADD_OPTION(NOTIFICATIONS);
 }
 
-void LegendaryHuntEmerald::reset_regi(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context) {
+void LegendaryHuntEmerald::reset_regi(SingleSwitchProgramEnvironment& env, ProControllerContext& context) {
     //turn around, walk down 4/until black screen over
     BlackScreenOverWatcher exit_area(COLOR_RED, {0.282, 0.064, 0.448, 0.871});
     BlackScreenOverWatcher enter_area(COLOR_RED, {0.282, 0.064, 0.448, 0.871});
-    int ret = run_until<SwitchControllerContext>(
+    int ret = run_until<ProControllerContext>(
         env.console, context,
-        [](SwitchControllerContext& context){
+        [](ProControllerContext& context){
             ssf_press_button(context, BUTTON_B, 0, 120);
             pbf_press_dpad(context, DPAD_DOWN, 120, 20);
             pbf_wait(context, 300);
@@ -107,9 +107,9 @@ void LegendaryHuntEmerald::reset_regi(SingleSwitchProgramEnvironment& env, Switc
     context.wait_for_all_requests();
 
     //turn around, up one/black screen over
-    int ret2 = run_until<SwitchControllerContext>(
+    int ret2 = run_until<ProControllerContext>(
         env.console, context,
-        [](SwitchControllerContext& context){
+        [](ProControllerContext& context){
             pbf_press_dpad(context, DPAD_UP, 120, 20);
             pbf_wait(context, 300);
         },
@@ -135,7 +135,7 @@ void LegendaryHuntEmerald::reset_regi(SingleSwitchProgramEnvironment& env, Switc
     context.wait_for_all_requests();
 }
 
-void LegendaryHuntEmerald::reset_groudon(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context) {
+void LegendaryHuntEmerald::reset_groudon(SingleSwitchProgramEnvironment& env, ProControllerContext& context) {
     //Turn left. Take 10 steps.
     ssf_press_button(context, BUTTON_B, 0, 180);
     pbf_press_dpad(context, DPAD_LEFT, 180, 20);
@@ -159,9 +159,9 @@ void LegendaryHuntEmerald::reset_groudon(SingleSwitchProgramEnvironment& env, Sw
 
     //Turn down. Exit. Black screen over.
     BlackScreenOverWatcher exit_area(COLOR_RED, {0.282, 0.064, 0.448, 0.871});
-    int ret = run_until<SwitchControllerContext>(
+    int ret = run_until<ProControllerContext>(
         env.console, context,
-        [](SwitchControllerContext& context){
+        [](ProControllerContext& context){
             ssf_press_button(context, BUTTON_B, 0, 90);
             pbf_press_dpad(context, DPAD_DOWN, 90, 20);
             pbf_wait(context, 300);
@@ -183,9 +183,9 @@ void LegendaryHuntEmerald::reset_groudon(SingleSwitchProgramEnvironment& env, Sw
 
     //Reverse above steps.
     BlackScreenOverWatcher enter_area(COLOR_RED, {0.282, 0.064, 0.448, 0.871});
-    int ret2 = run_until<SwitchControllerContext>(
+    int ret2 = run_until<ProControllerContext>(
         env.console, context,
-        [](SwitchControllerContext& context){
+        [](ProControllerContext& context){
             ssf_press_button(context, BUTTON_B, 0, 90);
             pbf_press_dpad(context, DPAD_UP, 90, 20);
             pbf_wait(context, 300);
@@ -222,7 +222,7 @@ void LegendaryHuntEmerald::reset_groudon(SingleSwitchProgramEnvironment& env, Sw
     context.wait_for_all_requests();
 }
 
-void LegendaryHuntEmerald::reset_kyogre(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context) {
+void LegendaryHuntEmerald::reset_kyogre(SingleSwitchProgramEnvironment& env, ProControllerContext& context) {
     //Turn down. Take 1 step.
     ssf_press_button(context, BUTTON_B, 0, 20);
     pbf_press_dpad(context, DPAD_DOWN, 20, 20);
@@ -249,9 +249,9 @@ void LegendaryHuntEmerald::reset_kyogre(SingleSwitchProgramEnvironment& env, Swi
 
     //Turn down. Exit. Black screen over.
     BlackScreenOverWatcher exit_area(COLOR_RED, {0.282, 0.064, 0.448, 0.871});
-    int ret = run_until<SwitchControllerContext>(
+    int ret = run_until<ProControllerContext>(
         env.console, context,
-        [](SwitchControllerContext& context){
+        [](ProControllerContext& context){
             ssf_press_button(context, BUTTON_B, 0, 90);
             pbf_press_dpad(context, DPAD_DOWN, 90, 20);
             pbf_wait(context, 300);
@@ -272,9 +272,9 @@ void LegendaryHuntEmerald::reset_kyogre(SingleSwitchProgramEnvironment& env, Swi
     }
 
     BlackScreenOverWatcher enter_area(COLOR_RED, {0.282, 0.064, 0.448, 0.871});
-    int ret2 = run_until<SwitchControllerContext>(
+    int ret2 = run_until<ProControllerContext>(
         env.console, context,
-        [](SwitchControllerContext& context){
+        [](ProControllerContext& context){
             ssf_press_button(context, BUTTON_B, 0, 90);
             pbf_press_dpad(context, DPAD_UP, 90, 20);
             pbf_wait(context, 300);
@@ -315,16 +315,16 @@ void LegendaryHuntEmerald::reset_kyogre(SingleSwitchProgramEnvironment& env, Swi
     context.wait_for_all_requests();
 }
 
-void LegendaryHuntEmerald::reset_hooh(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context) {
+void LegendaryHuntEmerald::reset_hooh(SingleSwitchProgramEnvironment& env, ProControllerContext& context) {
     BlackScreenOverWatcher exit_area(COLOR_RED, {0.282, 0.064, 0.448, 0.871});
     //Turn around, 10 steps down
     ssf_press_button(context, BUTTON_B, 0, 180);
     pbf_press_dpad(context, DPAD_DOWN, 180, 20);
 
     //Turn right, take 1 step. Wait for black screen over.
-    int ret = run_until<SwitchControllerContext>(
+    int ret = run_until<ProControllerContext>(
         env.console, context,
-        [](SwitchControllerContext& context){
+        [](ProControllerContext& context){
             ssf_press_button(context, BUTTON_B, 0, 30);
             pbf_press_dpad(context, DPAD_RIGHT, 30, 20);
             pbf_wait(context, 300);
@@ -346,9 +346,9 @@ void LegendaryHuntEmerald::reset_hooh(SingleSwitchProgramEnvironment& env, Switc
 
     BlackScreenOverWatcher enter_area(COLOR_RED, {0.282, 0.064, 0.448, 0.871});
     //turn left, take one step. now turn back right and take a step. wait for black screen over.
-    int ret2 = run_until<SwitchControllerContext>(
+    int ret2 = run_until<ProControllerContext>(
         env.console, context,
-        [](SwitchControllerContext& context){
+        [](ProControllerContext& context){
             ssf_press_button(context, BUTTON_B, 0, 40);
             pbf_press_dpad(context, DPAD_LEFT, 40, 20);
 
@@ -382,16 +382,16 @@ void LegendaryHuntEmerald::reset_hooh(SingleSwitchProgramEnvironment& env, Switc
     context.wait_for_all_requests();
 }
 
-void LegendaryHuntEmerald::reset_lugia(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context) {
+void LegendaryHuntEmerald::reset_lugia(SingleSwitchProgramEnvironment& env, ProControllerContext& context) {
     BlackScreenOverWatcher exit_area(COLOR_RED, {0.282, 0.064, 0.448, 0.871});
     //Turn around, 5 steps down
     ssf_press_button(context, BUTTON_B, 0, 90);
     pbf_press_dpad(context, DPAD_DOWN, 90, 20);
 
     //Turn right, 3 steps right. Wait for black screen over.
-    int ret = run_until<SwitchControllerContext>(
+    int ret = run_until<ProControllerContext>(
         env.console, context,
-        [](SwitchControllerContext& context){
+        [](ProControllerContext& context){
             ssf_press_button(context, BUTTON_B, 0, 90);
             pbf_press_dpad(context, DPAD_RIGHT, 90, 20);
             pbf_wait(context, 300);
@@ -413,9 +413,9 @@ void LegendaryHuntEmerald::reset_lugia(SingleSwitchProgramEnvironment& env, Swit
 
     BlackScreenOverWatcher enter_area(COLOR_RED, {0.282, 0.064, 0.448, 0.871});
     //turn up, take one step. then turn back down and take a step. wait for black screen over.
-    int ret2 = run_until<SwitchControllerContext>(
+    int ret2 = run_until<ProControllerContext>(
         env.console, context,
-        [](SwitchControllerContext& context){
+        [](ProControllerContext& context){
             ssf_press_button(context, BUTTON_B, 0, 40);
             pbf_press_dpad(context, DPAD_UP, 40, 20);
 
@@ -448,7 +448,7 @@ void LegendaryHuntEmerald::reset_lugia(SingleSwitchProgramEnvironment& env, Swit
     context.wait_for_all_requests();
 }
 
-void LegendaryHuntEmerald::program(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context){
+void LegendaryHuntEmerald::program(SingleSwitchProgramEnvironment& env, ProControllerContext& context){
     LegendaryHuntEmerald_Descriptor::Stats& stats = env.current_stats<LegendaryHuntEmerald_Descriptor::Stats>();
 
     /*

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.h
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.h
@@ -26,7 +26,7 @@ public:
 class LegendaryHuntEmerald : public SingleSwitchProgramInstance{
 public:
     LegendaryHuntEmerald();
-    virtual void program(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context) override;
+    virtual void program(SingleSwitchProgramEnvironment& env, ProControllerContext& context) override;
 
 private:
     enum class Target{
@@ -42,11 +42,11 @@ private:
     EventNotificationOption NOTIFICATION_STATUS_UPDATE;
     EventNotificationsOption NOTIFICATIONS;
 
-    void reset_regi(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context);
-    void reset_groudon(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context);
-    void reset_kyogre(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context);
-    void reset_hooh(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context);
-    void reset_lugia(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context);
+    void reset_regi(SingleSwitchProgramEnvironment& env, ProControllerContext& context);
+    void reset_groudon(SingleSwitchProgramEnvironment& env, ProControllerContext& context);
+    void reset_kyogre(SingleSwitchProgramEnvironment& env, ProControllerContext& context);
+    void reset_hooh(SingleSwitchProgramEnvironment& env, ProControllerContext& context);
+    void reset_lugia(SingleSwitchProgramEnvironment& env, ProControllerContext& context);
 };
 
 }

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.h
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.h
@@ -41,6 +41,7 @@ private:
     EventNotificationOption NOTIFICATION_STATUS_UPDATE;
     EventNotificationsOption NOTIFICATIONS;
 
+    void reset_regi(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context);
     void reset_hooh(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context);
     void reset_lugia(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context);
 };

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.h
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.h
@@ -1,0 +1,51 @@
+/*  Legendary Hunt - Emerald
+ *
+ *  From: https://github.com/PokemonAutomation/Arduino-Source
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonRSE_LegendaryHuntEmerald_H
+#define PokemonAutomation_PokemonRSE_LegendaryHuntEmerald_H
+
+#include "Common/Cpp/Options/SimpleIntegerOption.h"
+#include "Common/Cpp/Options/TimeExpressionOption.h"
+#include "CommonFramework/Notifications/EventNotificationsTable.h"
+#include "NintendoSwitch/NintendoSwitch_SingleSwitchProgram.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonRSE{
+
+class LegendaryHuntEmerald_Descriptor : public SingleSwitchProgramDescriptor{
+public:
+    LegendaryHuntEmerald_Descriptor();
+    struct Stats;
+    virtual std::unique_ptr<StatsTracker> make_stats() const override;
+};
+
+class LegendaryHuntEmerald : public SingleSwitchProgramInstance{
+public:
+    LegendaryHuntEmerald();
+    virtual void program(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context) override;
+
+private:
+    enum class Target{
+        regis,
+        hooh,
+        lugia,
+        latis,
+    };
+    EnumDropdownOption<Target> TARGET;
+
+    EventNotificationOption NOTIFICATION_SHINY;
+    EventNotificationOption NOTIFICATION_STATUS_UPDATE;
+    EventNotificationsOption NOTIFICATIONS;
+
+    void reset_room(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context);
+};
+
+}
+}
+}
+#endif
+

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.h
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.h
@@ -41,6 +41,7 @@ private:
     EventNotificationOption NOTIFICATION_STATUS_UPDATE;
     EventNotificationsOption NOTIFICATIONS;
 
+    void reset_hooh(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context);
     void reset_lugia(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context);
 };
 

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.h
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.h
@@ -33,7 +33,6 @@ private:
         regis,
         hooh,
         lugia,
-        latis,
     };
     EnumDropdownOption<Target> TARGET;
 

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.h
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.h
@@ -41,7 +41,7 @@ private:
     EventNotificationOption NOTIFICATION_STATUS_UPDATE;
     EventNotificationsOption NOTIFICATIONS;
 
-    void reset_room(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context);
+    void reset_lugia(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context);
 };
 
 }

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.h
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_LegendaryHunt-Emerald.h
@@ -31,6 +31,8 @@ public:
 private:
     enum class Target{
         regis,
+        groudon,
+        kyogre,
         hooh,
         lugia,
     };
@@ -41,6 +43,8 @@ private:
     EventNotificationsOption NOTIFICATIONS;
 
     void reset_regi(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context);
+    void reset_groudon(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context);
+    void reset_kyogre(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context);
     void reset_hooh(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context);
     void reset_lugia(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context);
 };

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_ShinyHunt-Deoxys.cpp
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_ShinyHunt-Deoxys.cpp
@@ -50,10 +50,21 @@ std::unique_ptr<StatsTracker> ShinyHuntDeoxys_Descriptor::make_stats() const{
 }
 
 ShinyHuntDeoxys::ShinyHuntDeoxys()
-    : WALK_UP_DOWN_TIME0(
+    : STARTPOS(
+        "<b>Starting Position:</b><br>",
+        {
+            {StartPos::boat, "boat", "Boat/Walk up"},
+            {StartPos::rock_unsolved, "rock_unsolved", "Triangle rock, puzzle is unsolved"},
+            {StartPos::rock_solved, "rock_solved", "Triangle rock, puzzle is already solved"},
+        },
+        LockMode::LOCK_WHILE_RUNNING,
+        StartPos::rock_unsolved
+    )
+    , WALK_UP_DOWN_TIME(
         "<b>Walk up/down time</b><br>Spend this long to run up to the triangle rock.",
         LockMode::LOCK_WHILE_RUNNING,
-        "3520 ms"
+        TICKS_PER_SECOND,
+        "440"
     )
     , NOTIFICATION_SHINY(
         "Shiny Found",
@@ -67,11 +78,12 @@ ShinyHuntDeoxys::ShinyHuntDeoxys()
         &NOTIFICATION_PROGRAM_FINISH,
         })
 {
-    PA_ADD_OPTION(WALK_UP_DOWN_TIME0);
+    PA_ADD_OPTION(STARTPOS);
+    PA_ADD_OPTION(WALK_UP_DOWN_TIME);
     PA_ADD_OPTION(NOTIFICATIONS);
 }
 
-void ShinyHuntDeoxys::solve_puzzle(SingleSwitchProgramEnvironment& env, ProControllerContext& context) {
+void ShinyHuntDeoxys::solve_puzzle(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context) {
     env.log("Step 1: Press A from below.");
     pbf_press_button(context, BUTTON_A, 20, 40);
 
@@ -175,7 +187,7 @@ void ShinyHuntDeoxys::solve_puzzle(SingleSwitchProgramEnvironment& env, ProContr
     context.wait_for_all_requests();
 }
 
-void ShinyHuntDeoxys::program(SingleSwitchProgramEnvironment& env, ProControllerContext& context){
+void ShinyHuntDeoxys::program(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context){
     ShinyHuntDeoxys_Descriptor::Stats& stats = env.current_stats<ShinyHuntDeoxys_Descriptor::Stats>();
 
     /*
@@ -195,18 +207,36 @@ void ShinyHuntDeoxys::program(SingleSwitchProgramEnvironment& env, ProController
     * Would have to handle both PokeNav and random encounters for ray/others? Why is PokeNav a thing???
     */
 
+    bool first_run = true;
+
     while (true) {
-        env.log("Walking up to Deoxys.");
-        //Walk up to the triangle rock from the ship. No bike allowed.
-        ssf_press_button(context, BUTTON_B, 0ms, WALK_UP_DOWN_TIME0);
-        pbf_press_dpad(context, DPAD_UP, WALK_UP_DOWN_TIME0, 160ms);
-        context.wait_for_all_requests();
+        if (first_run) {
+            switch (STARTPOS) {
+            case StartPos::rock_solved:
+                env.log("StartPos: Already in position.");
+                break;
+            case StartPos::boat:
+                env.log("StartPos: Walking up to Deoxys.");
+                //Walk up to the triangle rock from the ship. No bike allowed.
+                ssf_press_button(context, BUTTON_B, 0, WALK_UP_DOWN_TIME);
+                pbf_press_dpad(context, DPAD_UP, WALK_UP_DOWN_TIME, 20);
+                context.wait_for_all_requests();
+            case StartPos::rock_unsolved:
+                env.log("StartPos: Solving puzzle.");
+                solve_puzzle(env, context);
+                break;
+            default:
+                OperationFailedException::fire(
+                    ErrorReport::SEND_ERROR_REPORT,
+                    "Invalid starting position selected.",
+                    env.console
+                );
+                break;
+            }
+            first_run = false;
+        }
 
-        solve_puzzle(env, context);
-
-        //Start battle.
-        pbf_press_button(context, BUTTON_A, 20, 40);
-
+        //Start battle
         bool legendary_shiny = handle_encounter(env.console, context, true);
         if (legendary_shiny) {
             stats.shinies++;
@@ -222,9 +252,19 @@ void ShinyHuntDeoxys::program(SingleSwitchProgramEnvironment& env, ProController
         context.wait_for_all_requests();
         
         //Walk down from the triangle rock to the ship.
-        ssf_press_button(context, BUTTON_B, 0ms, WALK_UP_DOWN_TIME0);
-        pbf_press_dpad(context, DPAD_DOWN, WALK_UP_DOWN_TIME0, 160ms);
+        env.log("Walking down to ship.");
+        ssf_press_button(context, BUTTON_B, 0, WALK_UP_DOWN_TIME);
+        pbf_press_dpad(context, DPAD_DOWN, WALK_UP_DOWN_TIME, 20);
         context.wait_for_all_requests();
+
+        env.log("Walking up to Deoxys rock.");
+        //Walk up to the triangle rock from the ship. Bike is not allowed on Birth Island.
+        ssf_press_button(context, BUTTON_B, 0, WALK_UP_DOWN_TIME);
+        pbf_press_dpad(context, DPAD_UP, WALK_UP_DOWN_TIME, 20);
+        context.wait_for_all_requests();
+
+        env.log("Solving puzzle.");
+        solve_puzzle(env, context);
 
         stats.resets++;
         env.update_stats();

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_ShinyHunt-Deoxys.cpp
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_ShinyHunt-Deoxys.cpp
@@ -60,11 +60,10 @@ ShinyHuntDeoxys::ShinyHuntDeoxys()
         LockMode::LOCK_WHILE_RUNNING,
         StartPos::rock_unsolved
     )
-    , WALK_UP_DOWN_TIME(
+    , WALK_UP_DOWN_TIME0(
         "<b>Walk up/down time</b><br>Spend this long to run up to the triangle rock.",
         LockMode::LOCK_WHILE_RUNNING,
-        TICKS_PER_SECOND,
-        "440"
+        "3520 ms"
     )
     , NOTIFICATION_SHINY(
         "Shiny Found",
@@ -79,11 +78,11 @@ ShinyHuntDeoxys::ShinyHuntDeoxys()
         })
 {
     PA_ADD_OPTION(STARTPOS);
-    PA_ADD_OPTION(WALK_UP_DOWN_TIME);
+    PA_ADD_OPTION(WALK_UP_DOWN_TIME0);
     PA_ADD_OPTION(NOTIFICATIONS);
 }
 
-void ShinyHuntDeoxys::solve_puzzle(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context) {
+void ShinyHuntDeoxys::solve_puzzle(SingleSwitchProgramEnvironment& env, ProControllerContext& context) {
     env.log("Step 1: Press A from below.");
     pbf_press_button(context, BUTTON_A, 20, 40);
 
@@ -187,7 +186,7 @@ void ShinyHuntDeoxys::solve_puzzle(SingleSwitchProgramEnvironment& env, SwitchCo
     context.wait_for_all_requests();
 }
 
-void ShinyHuntDeoxys::program(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context){
+void ShinyHuntDeoxys::program(SingleSwitchProgramEnvironment& env, ProControllerContext& context){
     ShinyHuntDeoxys_Descriptor::Stats& stats = env.current_stats<ShinyHuntDeoxys_Descriptor::Stats>();
 
     /*
@@ -218,8 +217,8 @@ void ShinyHuntDeoxys::program(SingleSwitchProgramEnvironment& env, SwitchControl
             case StartPos::boat:
                 env.log("StartPos: Walking up to Deoxys.");
                 //Walk up to the triangle rock from the ship. No bike allowed.
-                ssf_press_button(context, BUTTON_B, 0, WALK_UP_DOWN_TIME);
-                pbf_press_dpad(context, DPAD_UP, WALK_UP_DOWN_TIME, 20);
+                ssf_press_button(context, BUTTON_B, 0ms, WALK_UP_DOWN_TIME0);
+                pbf_press_dpad(context, DPAD_UP, WALK_UP_DOWN_TIME0, 160ms);
                 context.wait_for_all_requests();
             case StartPos::rock_unsolved:
                 env.log("StartPos: Solving puzzle.");
@@ -253,14 +252,14 @@ void ShinyHuntDeoxys::program(SingleSwitchProgramEnvironment& env, SwitchControl
         
         //Walk down from the triangle rock to the ship.
         env.log("Walking down to ship.");
-        ssf_press_button(context, BUTTON_B, 0, WALK_UP_DOWN_TIME);
-        pbf_press_dpad(context, DPAD_DOWN, WALK_UP_DOWN_TIME, 20);
+        ssf_press_button(context, BUTTON_B, 0ms, WALK_UP_DOWN_TIME0);
+        pbf_press_dpad(context, DPAD_DOWN, WALK_UP_DOWN_TIME0, 160ms);
         context.wait_for_all_requests();
 
         env.log("Walking up to Deoxys rock.");
         //Walk up to the triangle rock from the ship. Bike is not allowed on Birth Island.
-        ssf_press_button(context, BUTTON_B, 0, WALK_UP_DOWN_TIME);
-        pbf_press_dpad(context, DPAD_UP, WALK_UP_DOWN_TIME, 20);
+        ssf_press_button(context, BUTTON_B, 0ms, WALK_UP_DOWN_TIME0);
+        pbf_press_dpad(context, DPAD_UP, WALK_UP_DOWN_TIME0, 160ms);
         context.wait_for_all_requests();
 
         env.log("Solving puzzle.");

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_ShinyHunt-Deoxys.cpp
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_ShinyHunt-Deoxys.cpp
@@ -207,7 +207,7 @@ void ShinyHuntDeoxys::program(SingleSwitchProgramEnvironment& env, ProController
         //Start battle.
         pbf_press_button(context, BUTTON_A, 20, 40);
 
-        bool legendary_shiny = handle_encounter(env.console, context);
+        bool legendary_shiny = handle_encounter(env.console, context, true);
         if (legendary_shiny) {
             stats.shinies++;
             env.update_stats();

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_ShinyHunt-Deoxys.h
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_ShinyHunt-Deoxys.h
@@ -8,7 +8,7 @@
 #define PokemonAutomation_PokemonRSE_ShinyHuntDeoxys_H
 
 #include "Common/Cpp/Options/SimpleIntegerOption.h"
-#include "Common/Cpp/Options/TimeExpressionOption.h"
+#include "Common/Cpp/Options/TimeDurationOption.h"
 #include "CommonFramework/Notifications/EventNotificationsTable.h"
 #include "NintendoSwitch/NintendoSwitch_SingleSwitchProgram.h"
 
@@ -26,7 +26,7 @@ public:
 class ShinyHuntDeoxys : public SingleSwitchProgramInstance{
 public:
     ShinyHuntDeoxys();
-    virtual void program(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context) override;
+    virtual void program(SingleSwitchProgramEnvironment& env, ProControllerContext& context) override;
 
 private:
     enum class StartPos{
@@ -36,13 +36,13 @@ private:
     };
     EnumDropdownOption<StartPos> STARTPOS;
 
-    TimeExpressionOption<uint16_t> WALK_UP_DOWN_TIME;
+    MillisecondsOption WALK_UP_DOWN_TIME0;
 
     EventNotificationOption NOTIFICATION_SHINY;
     EventNotificationOption NOTIFICATION_STATUS_UPDATE;
     EventNotificationsOption NOTIFICATIONS;
 
-    void solve_puzzle(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context);
+    void solve_puzzle(SingleSwitchProgramEnvironment& env, ProControllerContext& context);
 };
 
 }

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_ShinyHunt-Deoxys.h
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_ShinyHunt-Deoxys.h
@@ -7,7 +7,6 @@
 #ifndef PokemonAutomation_PokemonRSE_ShinyHuntDeoxys_H
 #define PokemonAutomation_PokemonRSE_ShinyHuntDeoxys_H
 
-#include "Common/Cpp/Options/SimpleIntegerOption.h"
 #include "Common/Cpp/Options/TimeDurationOption.h"
 #include "CommonFramework/Notifications/EventNotificationsTable.h"
 #include "NintendoSwitch/NintendoSwitch_SingleSwitchProgram.h"

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_ShinyHunt-Deoxys.h
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_ShinyHunt-Deoxys.h
@@ -7,7 +7,8 @@
 #ifndef PokemonAutomation_PokemonRSE_ShinyHuntDeoxys_H
 #define PokemonAutomation_PokemonRSE_ShinyHuntDeoxys_H
 
-#include "Common/Cpp/Options/TimeDurationOption.h"
+#include "Common/Cpp/Options/SimpleIntegerOption.h"
+#include "Common/Cpp/Options/TimeExpressionOption.h"
 #include "CommonFramework/Notifications/EventNotificationsTable.h"
 #include "NintendoSwitch/NintendoSwitch_SingleSwitchProgram.h"
 
@@ -25,16 +26,23 @@ public:
 class ShinyHuntDeoxys : public SingleSwitchProgramInstance{
 public:
     ShinyHuntDeoxys();
-    virtual void program(SingleSwitchProgramEnvironment& env, ProControllerContext& context) override;
+    virtual void program(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context) override;
 
 private:
-    MillisecondsOption WALK_UP_DOWN_TIME0;
+    enum class StartPos{
+        boat,
+        rock_unsolved,
+        rock_solved,
+    };
+    EnumDropdownOption<StartPos> STARTPOS;
+
+    TimeExpressionOption<uint16_t> WALK_UP_DOWN_TIME;
 
     EventNotificationOption NOTIFICATION_SHINY;
     EventNotificationOption NOTIFICATION_STATUS_UPDATE;
     EventNotificationsOption NOTIFICATIONS;
 
-    void solve_puzzle(SingleSwitchProgramEnvironment& env, ProControllerContext& context);
+    void solve_puzzle(SingleSwitchProgramEnvironment& env, SwitchControllerContext& context);
 };
 
 }


### PR DESCRIPTION
Covers all three Regis, Groudon, Kyogre, Ho-Oh, and Lugia. Program is similar to the Deoxys reset. Left both programs separate for now but can combine if needed.

Additionally, added a starting position option to Deoxys reset.

Remaining in emerald:
Mew - need to find a consistent encounter method. Cutting grass does not work. Will be a separate program since it might require Acro bike registered to select and/or calibration options.

Lati@s (non-roaming only) - Southern island can receive PokeNav calls so need would to handle that. Will also be separate program due to this. I can see random phone calls being a nightmare to handle when moving around in Emerald. And Gold/Silver/Crystal/HG/SS, I will not touching those anytime soon.

Rayquaza - Would need to handle PokeNav calls occurring at any moment on the map and random encounters on a specific tile when exiting/reentering the room. The path to the exit is long so that doesn't help when getting interrupted. Probably not doing this one anytime soon since Ruby/Sapphire soft resets are going to be easier. Also, shiny ray was a recent raid in SV so its not very rare. So poor ray is not getting a shiny hunt in its own game.