### PR TITLE
Docile Missing From Pokemon_NatureChecker.cpp

### DIFF
--- a/SerialPrograms/Source/Pokemon/Pokemon_NatureChecker.cpp
+++ b/SerialPrograms/Source/Pokemon/Pokemon_NatureChecker.cpp
@@ -21,6 +21,7 @@ const EnumStringMap<NatureCheckerValue>& NATURE_CHECKER_VALUE_STRINGS(){
         {NatureCheckerValue::Brave,             "Brave"},
         {NatureCheckerValue::Calm,              "Calm"},
         {NatureCheckerValue::Careful,           "Careful"},
+        {NatureCheckerValue::Docile,            "Docile"},
         {NatureCheckerValue::Gentle,            "Gentle"},
         {NatureCheckerValue::Hardy,             "Hardy"},
         {NatureCheckerValue::Hasty,             "Hasty"},


### PR DESCRIPTION
The EnumStringMap for NatureChecker was missing "Docile". This causes the following error in Egg Autonomous:
![image](https://github.com/user-attachments/assets/e48eb6f3-5657-4cd5-a588-d9f769cce580)
