### PR TITLE
fix dateskip, improve dailyfarmer, alolantrade favs

### DIFF
--- a/SerialPrograms/Source/NintendoSwitch/Programs/NintendoSwitch_Navigation.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/Programs/NintendoSwitch_Navigation.cpp
@@ -167,7 +167,7 @@ void home_to_date_time(ProControllerContext& context, bool to_date_change, bool 
 
 void home_to_date_time(JoyconContext& context, bool to_date_change){
     Milliseconds tv = context->timing_variation();
-    Milliseconds unit = 32ms + tv;
+    Milliseconds unit = 50ms + tv;
 
     //From ControllerPerformanceClass::SerialPABotBase_Wireless_ESP32
     //as Joycon will only have that controller type
@@ -206,7 +206,6 @@ void home_to_date_time(JoyconContext& context, bool to_date_change){
     pbf_move_joystick(context, 128, 255, 4*unit, unit);
     pbf_move_joystick(context, 128, 255, 360ms, 304ms);
     pbf_move_joystick(context, 128, 255, 2*unit, unit);
-    //pbf_move_joystick(context, 128, 255, 2*unit, unit);
     
     if (!to_date_change){
         ssf_press_button(context, BUTTON_A, 360ms, 2*unit, unit);

--- a/SerialPrograms/Source/PokemonLGPE/Programs/Farming/PokemonLGPE_DailyItemFarmer.cpp
+++ b/SerialPrograms/Source/PokemonLGPE/Programs/Farming/PokemonLGPE_DailyItemFarmer.cpp
@@ -93,6 +93,69 @@ DailyItemFarmer::DailyItemFarmer()
     PA_ADD_OPTION(NOTIFICATIONS);
 }
 
+void DailyItemFarmer::start_local_trade(SingleSwitchProgramEnvironment& env, JoyconContext& context){
+    env.log("Starting local trade.");
+    //Open Menu -> Communication -> Nearby player -> Local Trade
+    pbf_press_button(context, BUTTON_X, 200ms, 500ms);
+    pbf_move_joystick(context, 255, 128, 100ms, 100ms);
+    pbf_press_button(context, BUTTON_A, 200ms, 1000ms);
+    pbf_press_button(context, BUTTON_A, 200ms, 1000ms);
+    pbf_wait(context, 1000ms); //Black screen
+    context.wait_for_all_requests();
+    pbf_press_button(context, BUTTON_A, 200ms, 1000ms);
+    pbf_press_button(context, BUTTON_A, 200ms, 1000ms);
+
+    //Enter link code
+    switch(LINK_CODE) {
+    case LinkCode::Pikachu:
+        break;
+    case LinkCode::Eevee:
+        pbf_move_joystick(context, 255, 128, 100ms, 100ms);
+        break;
+    case LinkCode::Bulbasaur:
+        pbf_move_joystick(context, 255, 128, 100ms, 100ms);
+        pbf_move_joystick(context, 255, 128, 100ms, 100ms);
+        break;
+    case LinkCode::Charmander:
+        pbf_move_joystick(context, 0, 128, 100ms, 100ms);
+        pbf_move_joystick(context, 0, 128, 100ms, 100ms);
+        break;
+    case LinkCode::Squirtle:
+        pbf_move_joystick(context, 0, 128, 100ms, 100ms);
+        break;
+    case LinkCode::Pidgey:
+        pbf_move_joystick(context, 128, 255, 100ms, 100ms);
+        break;
+    case LinkCode::Caterpie:
+        pbf_move_joystick(context, 128, 255, 100ms, 100ms);
+        pbf_move_joystick(context, 255, 128, 100ms, 100ms);
+        break;
+    case LinkCode::Rattata:
+        pbf_move_joystick(context, 128, 255, 100ms, 100ms);
+        pbf_move_joystick(context, 0, 128, 100ms, 100ms);
+        pbf_move_joystick(context, 0, 128, 100ms, 100ms);
+        break;
+    case LinkCode::Jigglypuff:
+        pbf_move_joystick(context, 128, 255, 100ms, 100ms);
+        pbf_move_joystick(context, 0, 128, 100ms, 100ms);
+        pbf_move_joystick(context, 0, 128, 100ms, 100ms);
+        break;
+    case LinkCode::Diglett:
+        pbf_move_joystick(context, 128, 255, 100ms, 100ms);
+        pbf_move_joystick(context, 0, 128, 100ms, 100ms);
+        break;
+    default:
+        env.log("Invalid link code selection. Defaulting to Pikachu.");
+        break;
+    }
+    //Select symbol three times, then enter link search
+    pbf_press_button(context, BUTTON_A, 200ms, 100ms);
+    pbf_press_button(context, BUTTON_A, 200ms, 100ms);
+    pbf_press_button(context, BUTTON_A, 200ms, 100ms);
+    pbf_wait(context, 1000ms); //let search start
+    context.wait_for_all_requests();
+}
+
 void DailyItemFarmer::program(SingleSwitchProgramEnvironment& env, CancellableScope& scope){
     JoyconContext context(scope, env.console.controller<JoyconController>());
     assert_16_9_720p_min(env.logger(), env.console);
@@ -108,78 +171,35 @@ void DailyItemFarmer::program(SingleSwitchProgramEnvironment& env, CancellableSc
 
     uint8_t year = MAX_YEAR;
 
+    //Roll the date back before doing anything else.
+    start_local_trade(env, context);
+    pbf_press_button(context, BUTTON_HOME, 160ms, 1000ms);
+    home_to_date_time(context, true);
+    env.log("Rolling date back.");
+    roll_date_backward_N(context, MAX_YEAR);
+    year = 0;
+    pbf_press_button(context, BUTTON_HOME, 160ms, ConsoleSettings::instance().SETTINGS_TO_HOME_DELAY0);
+    pbf_press_button(context, BUTTON_HOME, 160ms, ConsoleSettings::instance().SETTINGS_TO_HOME_DELAY0);
+    pbf_mash_button(context, BUTTON_B, 5000ms);
+    context.wait_for_all_requests();
+
+    env.log("Starting pickup loop.");
     for (uint32_t count = 0; count < ATTEMPTS; count++) {
-        //Pick up item
+        env.log("Pick up item.");
         pbf_mash_button(context, BUTTON_A, 4000ms);
         context.wait_for_all_requests();
 
-        //Open Menu -> Communication -> Nearby player -> Local Trade
-        pbf_press_button(context, BUTTON_X, 200ms, 500ms);
-        pbf_move_joystick(context, 255, 128, 100ms, 100ms);
-        pbf_press_button(context, BUTTON_A, 200ms, 1000ms);
-        pbf_press_button(context, BUTTON_A, 200ms, 1000ms);
-        pbf_wait(context, 1000ms); //Black screen
-        context.wait_for_all_requests();
-        pbf_press_button(context, BUTTON_A, 200ms, 1000ms);
-        pbf_press_button(context, BUTTON_A, 200ms, 1000ms);
-
-        //Enter link code
-        switch(LINK_CODE) {
-        case LinkCode::Pikachu:
-            break;
-        case LinkCode::Eevee:
-            pbf_move_joystick(context, 255, 128, 100ms, 100ms);
-            break;
-        case LinkCode::Bulbasaur:
-            pbf_move_joystick(context, 255, 128, 100ms, 100ms);
-            pbf_move_joystick(context, 255, 128, 100ms, 100ms);
-            break;
-        case LinkCode::Charmander:
-            pbf_move_joystick(context, 0, 128, 100ms, 100ms);
-            pbf_move_joystick(context, 0, 128, 100ms, 100ms);
-            break;
-        case LinkCode::Squirtle:
-            pbf_move_joystick(context, 0, 128, 100ms, 100ms);
-            break;
-        case LinkCode::Pidgey:
-            pbf_move_joystick(context, 128, 255, 100ms, 100ms);
-            break;
-        case LinkCode::Caterpie:
-            pbf_move_joystick(context, 128, 255, 100ms, 100ms);
-            pbf_move_joystick(context, 255, 128, 100ms, 100ms);
-            break;
-        case LinkCode::Rattata:
-            pbf_move_joystick(context, 128, 255, 100ms, 100ms);
-            pbf_move_joystick(context, 0, 128, 100ms, 100ms);
-            pbf_move_joystick(context, 0, 128, 100ms, 100ms);
-            break;
-        case LinkCode::Jigglypuff:
-            pbf_move_joystick(context, 128, 255, 100ms, 100ms);
-            pbf_move_joystick(context, 0, 128, 100ms, 100ms);
-            pbf_move_joystick(context, 0, 128, 100ms, 100ms);
-            break;
-        case LinkCode::Diglett:
-            pbf_move_joystick(context, 128, 255, 100ms, 100ms);
-            pbf_move_joystick(context, 0, 128, 100ms, 100ms);
-            break;
-        default:
-            env.log("Invalid link code selection. Defaulting to Pikachu.");
-            break;
-        }
-        //Select symbol three times, then enter link search
-        pbf_press_button(context, BUTTON_A, 200ms, 100ms);
-        pbf_press_button(context, BUTTON_A, 200ms, 100ms);
-        pbf_press_button(context, BUTTON_A, 200ms, 100ms);
-        pbf_wait(context, 1000ms); //let search start
-        context.wait_for_all_requests();
+        start_local_trade(env, context);
 
         //Dateskip
         pbf_press_button(context, BUTTON_HOME, 160ms, 1000ms);
         home_to_date_time(context, true);
         if (year >= MAX_YEAR){
+            env.log("Rolling date back.");
             roll_date_backward_N(context, MAX_YEAR);
             year = 0;
         }else{
+            env.log("Rolling date forward.");
             roll_date_forward_1(context);
             year++;
         }

--- a/SerialPrograms/Source/PokemonLGPE/Programs/Farming/PokemonLGPE_DailyItemFarmer.h
+++ b/SerialPrograms/Source/PokemonLGPE/Programs/Farming/PokemonLGPE_DailyItemFarmer.h
@@ -30,6 +30,8 @@ public:
     virtual void program(SingleSwitchProgramEnvironment& env, CancellableScope& scope) override;
 
 private:
+    void start_local_trade(SingleSwitchProgramEnvironment& env, JoyconContext& context);
+
     SimpleIntegerOption<uint32_t> ATTEMPTS;
 
     enum class LinkCode{

--- a/SerialPrograms/Source/PokemonLGPE/Programs/ShinyHunting/PokemonLGPE_AlolanTrade.cpp
+++ b/SerialPrograms/Source/PokemonLGPE/Programs/ShinyHunting/PokemonLGPE_AlolanTrade.cpp
@@ -218,6 +218,7 @@ void AlolanTrade::program(SingleSwitchProgramEnvironment& env, CancellableScope&
         context.wait_for_all_requests();
 
         //Now check for shinies. Check everything that was traded.
+        env.log("Checking received Pokemon.");
         for (uint16_t i = 0; i < NUM_TRADES; i++) {
             VideoSnapshot screen = env.console.video().snapshot();
             ShinySymbolDetector shiny_checker(COLOR_YELLOW);
@@ -229,7 +230,27 @@ void AlolanTrade::program(SingleSwitchProgramEnvironment& env, CancellableScope&
                 env.update_stats();
                 send_program_notification(env, NOTIFICATION_SHINY, COLOR_YELLOW, "Shiny found!", {}, "", screen, true);
                 shiny_found = true;
-                //TODO: Favorite the shiny.
+
+                //Back out to menu and favorite the shiny.
+                env.log("Favoriting shiny.");
+                pbf_press_button(context, BUTTON_B, 200ms, 5000ms);
+                pbf_press_button(context, BUTTON_A, 200ms, 1000ms);
+                pbf_move_joystick(context, 128, 0, 100ms, 100ms);
+                pbf_move_joystick(context, 128, 0, 100ms, 100ms);
+                pbf_move_joystick(context, 128, 0, 100ms, 200ms);
+                pbf_press_button(context, BUTTON_A, 200ms, 800ms);
+                pbf_press_button(context, BUTTON_A, 200ms, 800ms);
+                pbf_press_button(context, BUTTON_B, 200ms, 800ms);
+
+                //Go into summary again
+                env.log("Navigating back into summary.");
+                pbf_press_button(context, BUTTON_A, 200ms, 1000ms);
+                pbf_move_joystick(context, 128, 255, 100ms, 100ms);
+                pbf_move_joystick(context, 128, 255, 100ms, 100ms);
+                pbf_press_button(context, BUTTON_A, 200ms, 100ms);
+                context.wait_for_all_requests();
+                pbf_wait(context, 5000ms);
+                context.wait_for_all_requests();
             }
             else {
                 env.log("Not shiny.");


### PR DESCRIPTION
date skip for joycon should be fixed now
daily farmer now rolls back time first before doing its skips
alolan trade now favorites any shinies it finds