### PR TITLE
Mac Distributable Workflow

### DIFF
--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -96,13 +96,13 @@ jobs:
       - name: Codesign
         run: codesign --force --deep --sign - SerialPrograms.app
 
-      # Read-write format in case Resources needs to be updated
+      # Create a disk image for installation
       - name: Create disk image
         run: |
           brew install create-dmg
           mkdir dmg
           cd dmg
-          cp -r ../SerialPrograms.app .
+          mv ../SerialPrograms.app ./SerialPrograms.app
           create-dmg --volname "SerialPrograms Installer" \
             --window-pos 150 150 \
             --window-size 600 400  \
@@ -112,17 +112,18 @@ jobs:
             --app-drop-link 450 160 \
             "SerialPrograms-Installer.dmg" \
             "./"
-
+          mv SerialPrograms-Installer.dmg $GITHUB_WORKSPACE/SerialPrograms-Installer.dmg
+          
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: SerialPrograms.dmg
-          path: SerialPrograms.dmg
+          name: SerialPrograms-Installer.dmg
+          path: SerialPrograms-Installer.dmg
 
       - name: GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: SerialPrograms.dmg
+          files: SerialPrograms-Installer.dmg
           # Tag should be automatically set in the case of a tag push
           tag_name: ${{ github.event.inputs.version }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -1,0 +1,115 @@
+name: SerialPrograms MacOS Release
+
+on:
+  push:
+    tags:
+      # Start MacOS release flow when a new version tag is created
+      - 'v*'
+  workflow_dispatch:
+    # Manual release / testing
+    inputs:
+      version:
+        description: 'Version for the manual release'
+        required: true
+      jobs:
+        description: 'Number of parallel jobs to build with'
+        default: 1
+        type: number
+      qt_version:
+        description: 'Qt version to use'
+        required: true
+        default: '6.8.2'
+        type: choice
+        options:
+          - '6.8.2'
+          - '6.5.3'
+      runner:
+        description: "MacOS Runner"
+        required: true
+        default: "macos-13"
+        type: choice
+        options:
+          - "macos-15"
+          - "macos-13"
+ 
+
+jobs:
+  build:
+    runs-on: ${{ github.event.inputs.runner }}
+    steps:
+      - name: Checkout Arduino-Source
+        uses: actions/checkout@v4
+        with:
+          path: Arduino-Source
+
+      - name: Checkout Packages
+        uses: actions/checkout@v4
+        with:
+          repository: 'PokemonAutomation/Packages'
+          path: Packages
+
+      # MacOS runners have Homebrew, Xcode, and Cmake already installed
+      - name: Install Dependencies
+        run: | 
+          brew install tesseract
+          brew install tesseract-lang
+          brew install opencv
+
+      - uses: jurplel/install-qt-action@v4
+        with:
+          version: ${{ github.event.inputs.qt_version }}
+          modules: 'qtmultimedia qtserialport'
+
+      - name: Build SerialPrograms.app
+        run: |
+          cd Arduino-Source/SerialPrograms
+          mkdir bin
+          cd bin
+          cmake .. -DUNIX_LINK_TESSERACT:BOOL=true -DCMAKE_BUILD_TYPE:STRING=Release
+          cmake --build . -j ${{ github.event.inputs.jobs }}
+          cp -r SerialPrograms.app ../../../SerialPrograms.app
+
+      # Important: GitHub MacOS runners do not have the lib area in its rpath by default. It must manually be added for frameworks to be discovered and added to the bundle
+      # Some libraries are not copied in QT deployment on the runner but will still be proprely linked if they're added prior to deployment
+      - name: rpath resolution
+        run: |
+          BREW_PREFIX=$(brew --prefix)
+          install_name_tool -add_rpath $BREW_PREFIX/lib SerialPrograms.app/Contents/MacOS/SerialPrograms
+          otool -l SerialPrograms.app/Contents/MacOS/SerialPrograms | grep -A2 LC_RPATH
+          mkdir SerialPrograms.app/Contents/Frameworks
+          cp $BREW_PREFIX/Cellar/protobuf/29.3/lib/libutf8_validity.dylib SerialPrograms.app/Contents/Frameworks
+          cp $BREW_PREFIX/Cellar/webp/1.5.0/lib/libsharpyuv.0.dylib SerialPrograms.app/Contents/Frameworks
+          cp $BREW_PREFIX/Cellar/jpeg-xl/0.11.1/lib/libjxl_cms.0.11.dylib SerialPrograms.app/Contents/Frameworks
+          cp $BREW_PREFIX/Cellar/vtk/9.4.1_2/lib/libvtkCommonComputationalGeometry-9.4.1.dylib SerialPrograms.app/Contents/Frameworks
+          cp $BREW_PREFIX/Cellar/vtk/9.4.1_2/lib/libvtkFiltersVerdict-9.4.1.dylib SerialPrograms.app/Contents/Frameworks
+          cp $BREW_PREFIX/Cellar/vtk/9.4.1_2/lib/libvtkfmt-9.4.1.dylib SerialPrograms.app/Contents/Frameworks
+          cp $BREW_PREFIX/Cellar/vtk/9.4.1_2/lib/libvtkFiltersGeometry-9.4.1.dylib SerialPrograms.app/Contents/Frameworks
+          cp $BREW_PREFIX/Cellar/vtk/9.4.1_2/lib/libvtkFiltersCore-9.4.1.dylib SerialPrograms.app/Contents/Frameworks
+          cp $BREW_PREFIX/Cellar/vtk/9.4.1_2/lib/libvtkCommonCore-9.4.1.dylib SerialPrograms.app/Contents/Frameworks
+          cp $BREW_PREFIX/Cellar/vtk/9.4.1_2/lib/libvtkCommonSystem-9.4.1.dylib SerialPrograms.app/Contents/Frameworks
+
+      # Use macdeployqt to bundle the app with dependencies
+      - name: Run macdeployqt
+        run: macdeployqt SerialPrograms.app -verbose=3
+
+      # Dummy codesign
+      - name: Codesign
+        run: codesign --force --deep --sign - SerialPrograms.app
+
+      # Read-write format in case Resources needs to be updated
+      - name: Create disk image
+        run: hdiutil create -volname "SerialPrograms" -format UDRW -srcfolder SerialPrograms.app SerialPrograms.dmg
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SerialPrograms.dmg
+          path: SerialPrograms.dmg
+
+      - name: GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: SerialPrograms.dmg
+          # Tag should be automatically set in the case of a tag push
+          tag_name: ${{ github.event.inputs.version }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -13,7 +13,7 @@ on:
         required: true
       jobs:
         description: 'Number of parallel jobs to build with'
-        default: 1
+        default: 4
         type: number
       qt_version:
         description: 'Qt version to use'
@@ -98,7 +98,20 @@ jobs:
 
       # Read-write format in case Resources needs to be updated
       - name: Create disk image
-        run: hdiutil create -volname "SerialPrograms" -format UDRW -srcfolder SerialPrograms.app SerialPrograms.dmg
+        run: |
+          brew install create-dmg
+          mkdir dmg
+          cd dmg
+          cp -r ../SerialPrograms.app .
+          create-dmg --volname "SerialPrograms Installer" \
+            --window-pos 150 150 \
+            --window-size 600 400  \
+            --icon-size 128 \
+            --icon "SerialPrograms.app" 140 160 \
+            --hide-extension "SerialPrograms.app" \
+            --app-drop-link 450 160 \
+            "SerialPrograms-Installer.dmg" \
+            "./"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -2204,7 +2204,7 @@ if (APPLE)
         TARGET SerialPrograms
         POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory
-        "${CMAKE_CURRENT_SOURCE_DIR}/../Resources"
+        "${CMAKE_CURRENT_SOURCE_DIR}/../../Packages/SerialPrograms/Resources"
         "$<TARGET_FILE_DIR:SerialPrograms>/../Resources"
     )
 else() # WIN and Linux:

--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -2199,6 +2199,14 @@ if (APPLE)
         MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/cmake/MacOSXBundleInfo.plist.in
         RESOURCE ${SerialPrograms_ICON}
     )
+
+    add_custom_command(
+        TARGET SerialPrograms
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        "${CMAKE_CURRENT_SOURCE_DIR}/../Resources"
+        "$<TARGET_FILE_DIR:SerialPrograms>/../Resources"
+    )
 else() # WIN and Linux:
     add_executable(SerialPrograms WIN32 ${MAIN_SOURCES})
 endif()

--- a/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.cpp
+++ b/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.cpp
@@ -107,25 +107,25 @@ GlobalSettings::GlobalSettings()
         false,
         "<b>Stats File:</b><br>Use the stats file here. Multiple instances of the program can use the same file.",
         LockMode::LOCK_WHILE_RUNNING,
-        #if defined(__APPLE__)
+#if defined(__APPLE__)
         QStandardPaths::writableLocation(QStandardPaths::AppDataLocation).toStdString() + "/UserSettings/PA-Stats.txt",
         QStandardPaths::writableLocation(QStandardPaths::AppDataLocation).toStdString() + "/UserSettings/PA-Stats.txt"
-        #else
+#else
         "UserSettings/PA-Stats.txt",
         "UserSettings/PA-Stats.txt"
-        #endif
+#endif
     )
     , TEMP_FOLDER(
         false,
         "<b>Temp Folder:</b><br>Place temporary files in this directory.",
         LockMode::LOCK_WHILE_RUNNING,
-        #if defined(__APPLE__)
+#if defined(__APPLE__)
         QStandardPaths::writableLocation(QStandardPaths::AppDataLocation).toStdString() + "/TempFiles/",
         QStandardPaths::writableLocation(QStandardPaths::AppDataLocation).toStdString() + "/TempFiles/"
-        #else
+#else
         "TempFiles/",
         "TempFiles/"
-        #endif
+#endif
     )
     , THEME(CONSTRUCT_TOKEN)
     , WINDOW_SIZE(

--- a/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.cpp
+++ b/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.cpp
@@ -6,6 +6,7 @@
 
 #include <iostream>
 #include <set>
+#include <QStandardPaths>
 #include <QCryptographicHash>
 #include "Common/Cpp/Containers/Pimpl.tpp"
 #include "Common/Cpp/LifetimeSanitizer.h"
@@ -106,15 +107,25 @@ GlobalSettings::GlobalSettings()
         false,
         "<b>Stats File:</b><br>Use the stats file here. Multiple instances of the program can use the same file.",
         LockMode::LOCK_WHILE_RUNNING,
+        #if defined(__APPLE__)
+        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation).toStdString() + "/UserSettings/PA-Stats.txt",
+        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation).toStdString() + "/UserSettings/PA-Stats.txt"
+        #else
         "UserSettings/PA-Stats.txt",
         "UserSettings/PA-Stats.txt"
+        #endif
     )
     , TEMP_FOLDER(
         false,
         "<b>Temp Folder:</b><br>Place temporary files in this directory.",
         LockMode::LOCK_WHILE_RUNNING,
+        #if defined(__APPLE__)
+        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation).toStdString() + "/TempFiles/",
+        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation).toStdString() + "/TempFiles/"
+        #else
         "TempFiles/",
         "TempFiles/"
+        #endif
     )
     , THEME(CONSTRUCT_TOKEN)
     , WINDOW_SIZE(

--- a/SerialPrograms/Source/CommonFramework/Globals.cpp
+++ b/SerialPrograms/Source/CommonFramework/Globals.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <QCoreApplication>
+#include <QStandardPaths>
 #include <QFile>
 #include <QFileInfo>
 #include <QDir>
@@ -112,9 +113,14 @@ std::string get_training_path(){
 }
 
 std::string get_runtime_base_path(){
+    //  On MacOS, find the writable application support directory
     if (QSysInfo::productType() == "macos" || QSysInfo::productType() == "osx"){
-        QString application_dir_path = get_application_base_dir_path();
-        return application_dir_path.toStdString() + "/";
+        QString appSupportPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+        QDir dir(appSupportPath);
+        if (!dir.exists()) {
+            dir.mkpath(".");
+        }
+        return appSupportPath.toStdString() + "/";
     }
     return "./";
 }


### PR DESCRIPTION
Adding a barebones workflow to compile a standalone SerialPrograms applet on MacOS.

Notes:
- Changed path of SerialPrograms collateral to writable application space 
- Bundled Resources into the app to make the application portable
- Compiles the application when a new tag is pushed in Arduino-Source, currently releasing to this repo
  - This workflow can also be moved to ComputerControl to release there instead or add a token to have this workflow release to the ComputerControl repo
- Run on macos-13 Intel runner. macos-15 compile is a can-of-worms and local compiles are done on x86_64 anyways
- The /usr/local/lib or /opt/homebrew areas are not part of the default rpath on runners and needs to be added for certain frameworks to be discovered
- Some secondary dependency frameworks are not copied in via the qt deployment in the runner environment. They're added into the bundle manually before deployment since the tool is still able to properly link the library paths but not copy them
  - I believe this is a tool bug but I'm not sure what about the runner environment is triggering it
  - There are other libraries that are not discovered and linked unless these frameworks are included
- The app needs to be codesigned to be able to run, a dummy signature is good enough