### PR TITLE
Mac deploy branch

### DIFF
--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -1,9 +1,9 @@
 name: SerialPrograms MacOS Release
 
 on:
-  push:
-    tags:
-      # Start MacOS release flow when a new version tag is created
+  create:
+    branch:
+      # Start MacOS release flow when a new version branch is created
       - 'v*'
   workflow_dispatch:
     # Manual release / testing
@@ -125,5 +125,5 @@ jobs:
         with:
           files: SerialPrograms-Installer.dmg
           # Tag should be automatically set in the case of a tag push
-          tag_name: ${{ github.event.inputs.version }}
+          tag_name: ${{ github.event.inputs.version || github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ github.event.inputs.runner }}
+    runs-on: ${{ github.event.inputs.runner || 'macos-13'}}
     steps:
       - name: Checkout Arduino-Source
         uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
 
       - uses: jurplel/install-qt-action@v4
         with:
-          version: ${{ github.event.inputs.qt_version }}
+          version: ${{ github.event.inputs.qt_version || "6.8.2"}}
           modules: 'qtmultimedia qtserialport'
 
       - name: Build SerialPrograms.app
@@ -66,7 +66,7 @@ jobs:
           mkdir bin
           cd bin
           cmake .. -DUNIX_LINK_TESSERACT:BOOL=true -DCMAKE_BUILD_TYPE:STRING=Release
-          cmake --build . -j ${{ github.event.inputs.jobs }}
+          cmake --build . -j ${{ github.event.inputs.jobs || 4}}
           cp -r SerialPrograms.app ../../../SerialPrograms.app
 
       # Important: GitHub MacOS runners do not have the lib area in its rpath by default. It must manually be added for frameworks to be discovered and added to the bundle

--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -55,9 +55,12 @@ jobs:
           brew install tesseract-lang
           brew install opencv
 
+      - name: Get QT Version
+        run: echo "QT_VERSION=${{ github.event.inputs.qt_version || '6.8.2' }}" >> $GITHUB_ENV
+
       - uses: jurplel/install-qt-action@v4
         with:
-          version: ${{ github.event.inputs.qt_version || "6.8.2"}}
+          version: ${{ env.QT_VERSION }}
           modules: 'qtmultimedia qtserialport'
 
       - name: Build SerialPrograms.app


### PR DESCRIPTION
It looks like the Arduino-Source repo should be deploying on branch creation rather than on tag creation