### PR TITLE
Fixed typographical mistakes in source files

### DIFF
--- a/3rdParty/QtWavFile/WavFile.cpp
+++ b/3rdParty/QtWavFile/WavFile.cpp
@@ -7,7 +7,7 @@
  *  The git repo for Qt multimedia code and exmamples is https://code.qt.io/qt/qtmultimedia.git 
  *  The version of the code is Qt5.
  *  Since the code is licensed by Qt under BSD, we can safely use it with our code base, provided
- *  that we have the orignal BSD license below and release the source code.
+ *  that we have the original BSD license below and release the source code.
  */
 
 /****************************************************************************

--- a/Common/Cpp/LifetimeSanitizer.cpp
+++ b/Common/Cpp/LifetimeSanitizer.cpp
@@ -183,7 +183,7 @@ void LifetimeSanitizer::internal_destruct(){
 
     auto iter = sanitizer_map.find(this);
     if (iter == sanitizer_map.end()){
-        std::cerr << "LifetimeSanitizer - Free non-existant: " << this << " : " << m_name << std::endl;
+        std::cerr << "LifetimeSanitizer - Free non-existent: " << this << " : " << m_name << std::endl;
         terminate_with_dump();
     }
     sanitizer_map.erase(this);

--- a/Common/Cpp/LifetimeSanitizer.cpp
+++ b/Common/Cpp/LifetimeSanitizer.cpp
@@ -189,7 +189,7 @@ void LifetimeSanitizer::internal_destruct(){
     sanitizer_map.erase(this);
 
     if (m_token != SANITIZER_TOKEN || m_self != this){
-        std::cerr << "LifetimeSanitizer - Free non-existant: " << this << " : " << m_name << std::endl;
+        std::cerr << "LifetimeSanitizer - Free non-existent: " << this << " : " << m_name << std::endl;
         terminate_with_dump();
     }
     if (m_use_counter != 0){

--- a/Common/Cpp/LifetimeSanitizer.cpp
+++ b/Common/Cpp/LifetimeSanitizer.cpp
@@ -128,7 +128,7 @@ void LifetimeSanitizer::start_using() const{
     }
     auto iter = sanitizer_map.find(this);
     if (iter == sanitizer_map.end()){
-        std::cerr << "Start using non-existant: " << this << " : " << m_name << std::endl;
+        std::cerr << "Start using non-existent: " << this << " : " << m_name << std::endl;
         terminate_with_dump();
     }
     if (m_token != SANITIZER_TOKEN || m_self != this){

--- a/Common/Cpp/LifetimeSanitizer.cpp
+++ b/Common/Cpp/LifetimeSanitizer.cpp
@@ -110,7 +110,7 @@ void LifetimeSanitizer::check_usage() const{
     }
     auto iter = sanitizer_map.find(this);
     if (iter == sanitizer_map.end()){
-        std::cerr << "Use non-existant: " << this << " : " << m_name << std::endl;
+        std::cerr << "Use non-existent: " << this << " : " << m_name << std::endl;
         terminate_with_dump();
     }
     if (m_token != SANITIZER_TOKEN || m_self != this){

--- a/Common/Cpp/LifetimeSanitizer.cpp
+++ b/Common/Cpp/LifetimeSanitizer.cpp
@@ -147,7 +147,7 @@ void LifetimeSanitizer::done_using() const{
     }
     auto iter = sanitizer_map.find(this);
     if (iter == sanitizer_map.end()){
-        std::cerr << "Done using non-existant: " << this << " : " << m_name << std::endl;
+        std::cerr << "Done using non-existent: " << this << " : " << m_name << std::endl;
         terminate_with_dump();
     }
     if (m_token != SANITIZER_TOKEN || m_self != this){

--- a/Common/Qt/WidgetStackFixedAspectRatio.cpp
+++ b/Common/Qt/WidgetStackFixedAspectRatio.cpp
@@ -113,7 +113,7 @@ void WidgetStackFixedAspectRatio::resize_to_width(int width){
 //    cout << "WidgetStackFixedAspectRatio::resize_to_width(): " << width << " <- " << previous_width << endl;
 
     if (width > previous_width && width < previous_width + 50 && !m_debouncer.check(width)){
-//        cout << "Supressing potential infinite resizing loop." << endl;
+//        cout << "Suppressing potential infinite resizing loop." << endl;
         return;
     }
 

--- a/SerialPrograms/Scripts/check_detector_regions.py
+++ b/SerialPrograms/Scripts/check_detector_regions.py
@@ -2,7 +2,7 @@
 
 """
 A script used to fine-tune detection box placements and check the color stats from those boxes.
-After using image_viewer.py to get an intial box placement, you can place the box values
+After using image_viewer.py to get an initial box placement, you can place the box values
 (x, y, width, height) into this script, repeating the line
 add_infer_box_to_image(raw_image, <x>, <y>, <width>, <height>, image) 
 to add a box onto the image.

--- a/SerialPrograms/Scripts/image_viewer.py
+++ b/SerialPrograms/Scripts/image_viewer.py
@@ -42,7 +42,7 @@ class ImageViewer:
 		self.mouse_down = False
 		self.mouse_move_counter = 0
 		self.nc = image.shape[2]  # num_channel
-		# The size of the cross used to highlight a slected pixel
+		# The size of the cross used to highlight a selected pixel
 		self.cross_size = max(1, min(self.width, self.height) // 200)
 
 	def _solid_color(self, color):

--- a/SerialPrograms/Scripts/image_viewer.py
+++ b/SerialPrograms/Scripts/image_viewer.py
@@ -8,7 +8,7 @@ PokemonAutomation visual inference methods.
 Single left clicking on a pixel shows you the info of that pixel. Note it may also print the
 alpha channel value.
 
-- Press 'w', 's', 'a', 'd' to move the slected pixels around.
+- Press 'w', 's', 'a', 'd' to move the selected pixels around.
 
 To draw a box: left click and drag the rectange.
 You can draw multiple boxes on the screen.

--- a/SerialPrograms/Source/CommonFramework/AudioPipeline/UI/AudioDisplayWidget.cpp
+++ b/SerialPrograms/Source/CommonFramework/AudioPipeline/UI/AudioDisplayWidget.cpp
@@ -181,7 +181,7 @@ void AudioDisplayWidget::update_size(){
     }
 
     if (height > m_previous_height && height < m_previous_height + 10 && !m_debouncer.check(height)){
-//        cout << "Supressing potential infinite resizing loop." << endl;
+//        cout << "Suppressing potential infinite resizing loop." << endl;
         return;
     }
 

--- a/SerialPrograms/Source/CommonTools/Audio/AudioPerSpectrumDetectorBase.cpp
+++ b/SerialPrograms/Source/CommonTools/Audio/AudioPerSpectrumDetectorBase.cpp
@@ -99,7 +99,7 @@ bool AudioPerSpectrumDetectorBase::process_spectrums(
     }
 
     const size_t sample_rate = new_spectrums[0].sample_rate;
-    // Lazy intialization of the spectrogram matcher.
+    // Lazy initialization of the spectrogram matcher.
     if (m_matcher == nullptr || m_matcher->sample_rate() != sample_rate){
         m_logger.log("Loading spectrogram...");
         m_matcher = build_spectrogram_matcher(sample_rate);

--- a/SerialPrograms/Source/CommonTools/Audio/SpectrogramMatcher.cpp
+++ b/SerialPrograms/Source/CommonTools/Audio/SpectrogramMatcher.cpp
@@ -67,7 +67,7 @@ SpectrogramMatcher::SpectrogramMatcher(
 
     const size_t halfSampleRate = sample_rate / 2;
 
-    // The frquency range from [0.0, halfSampleRate / numFrequencies, 2.0 halfSampleRate / numFrequencies, ... (numFrequencies-1) halfSampleRate / numFrequencies]
+    // The frequency range from [0.0, halfSampleRate / numFrequencies, 2.0 halfSampleRate / numFrequencies, ... (numFrequencies-1) halfSampleRate / numFrequencies]
     // Since human can only hear as high as 20KHz sound, matching on frequencies >= 20KHz is meaningless.
     // So the index i of the max frequency we should be matching is the one with
     // i * halfSampleRate/numFrequencies  <= 20KHz

--- a/SerialPrograms/Source/CommonTools/Audio/SpectrogramMatcher.cpp
+++ b/SerialPrograms/Source/CommonTools/Audio/SpectrogramMatcher.cpp
@@ -368,7 +368,7 @@ float SpectrogramMatcher::match(const std::vector<AudioSpectrum>& new_spectrums)
         // Match the full template
         std::tie(score, m_lastScale) = match_sub_template(0);
     }else{
-        // Match each indivdual sub-template
+        // Match each individual sub-template
         for (size_t sub_template = 0; sub_template < m_templateRange.size(); sub_template++){
             float sub_template_score = FLT_MAX;
             float sub_template_scale = 1.0f;

--- a/SerialPrograms/Source/CommonTools/ImageMatch/ExactImageDictionaryMatcher.cpp
+++ b/SerialPrograms/Source/CommonTools/ImageMatch/ExactImageDictionaryMatcher.cpp
@@ -23,7 +23,7 @@ namespace ImageMatch{
 
 // Generate candidate images to be matched against by translating the input image area
 // (`box` on `screen`) around.
-// The returned candidate images are scaled to match template shape `dimenstion`.
+// The returned candidate images are scaled to match template shape `dimension`.
 // `tolerance`: how much translation variances to produce.
 //   e.g. tolerance of 1 means translating the candidate images around so that it can match
 //   the template with at most 1 pixel off on the template image. 

--- a/SerialPrograms/Source/CommonTools/OCR/OCR_RawOCR.cpp
+++ b/SerialPrograms/Source/CommonTools/OCR/OCR_RawOCR.cpp
@@ -138,7 +138,7 @@ public:
         // Fortunately this class TesseractPool will not get built and destroyed repeatedly in
         // runtime. It will only get initialized once for each supported language. So I am able
         // to use this ugly workaround by not deleting the Tesseract API instances.
-        std::cout << "Warning: not release Tesseract API istance due to mutex bug similar to https://github.com/tesseract-ocr/tesseract/issues/3655" << std::endl;
+        std::cout << "Warning: not release Tesseract API instance due to mutex bug similar to https://github.com/tesseract-ocr/tesseract/issues/3655" << std::endl;
         for(auto& api : m_instances){
             api.release();
         }

--- a/SerialPrograms/Source/CommonTools/OCR/OCR_RawOCR.cpp
+++ b/SerialPrograms/Source/CommonTools/OCR/OCR_RawOCR.cpp
@@ -137,7 +137,7 @@ public:
         // There is no way of using HomeBrew to reinstall the older version.
         // Fortunately this class TesseractPool will not get built and destroyed repeatedly in
         // runtime. It will only get initialized once for each supported language. So I am able
-        // to use this ugly workaround by not deleting the Tesseract API intances.
+        // to use this ugly workaround by not deleting the Tesseract API instances.
         std::cout << "Warning: not release Tesseract API istance due to mutex bug similar to https://github.com/tesseract-ocr/tesseract/issues/3655" << std::endl;
         for(auto& api : m_instances){
             api.release();

--- a/SerialPrograms/Source/CommonTools/OCR/OCR_RawOCR.cpp
+++ b/SerialPrograms/Source/CommonTools/OCR/OCR_RawOCR.cpp
@@ -130,7 +130,7 @@ public:
 #ifdef UNIX_LINK_TESSERACT
     ~TesseractPool(){
         // As of Feb 05, 2022, the newest Tesseract (5.0.1) installed by HomeBrew on macOS
-        // has a bug that will crash the program when deleting internal Tesseract API intances,
+        // has a bug that will crash the program when deleting internal Tesseract API instances,
         // giving error: 
         // libc++abi.dylib: terminating with uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument
         // A similar issue is posted on Tesseract Github: https://github.com/tesseract-ocr/tesseract/issues/3655

--- a/SerialPrograms/Source/Controllers/SerialPABotBase/SerialPABotBase_Connection.cpp
+++ b/SerialPrograms/Source/Controllers/SerialPABotBase/SerialPABotBase_Connection.cpp
@@ -52,7 +52,7 @@ SerialPABotBase_Connection::SerialPABotBase_Connection(
             nullptr,
             "Error",
             "Cannot select Prolific controller.<br><br>"
-            "Prolific controllers do not work for Arduino and similar microntrollers.<br>"
+            "Prolific controllers do not work for Arduino and similar microcontrollers.<br>"
             "You were warned of this in the setup instructions. Please buy a CP210x controller instead."
         );
         std::string text = "Cannot connect to Prolific controller.";

--- a/SerialPrograms/Source/Kernels/ImageFilters/RGB32_EuclideanDistance/Kernels_ImageFilter_RGB32_Euclidean_ARM64_NEON.cpp
+++ b/SerialPrograms/Source/Kernels/ImageFilters/RGB32_EuclideanDistance/Kernels_ImageFilter_RGB32_Euclidean_ARM64_NEON.cpp
@@ -150,7 +150,7 @@ public:
             cmp_u32 = vandq_u32(cmp_u32, *cmp_mask_u32);
         }
         // Increase count for each pixel in range. Each uint32 lane is counted separately.
-        // We achieve +=1 by substracting 0xFFFFFFFF
+        // We achieve +=1 by subtracting 0xFFFFFFFF
         m_count_u32 = vsubq_u32(m_count_u32, cmp_u32);
         // select replacement color or in_u8 based on cmp_u32:
         uint32x4_t out_u32;

--- a/SerialPrograms/Source/NintendoSwitch/Programs/NintendoSwitch_PushJoySticks.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/Programs/NintendoSwitch_PushJoySticks.cpp
@@ -17,7 +17,7 @@ PushJoySticks_Descriptor::PushJoySticks_Descriptor()
         "NintendoSwitch:PushJoySticks",
         "Nintendo Switch", "Push Joy Sticks",
         "ComputerControl/blob/master/Wiki/Programs/NintendoSwitch/PushJoySticks.md",
-        "Push Joy Sticks continously.",
+        "Push Joy Sticks continuously.",
         FeedbackType::NONE,
         AllowCommandsWhenRunning::DISABLE_COMMANDS,
         {ControllerFeature::NintendoSwitch_ProController}

--- a/SerialPrograms/Source/Pokemon/Options/Pokemon_NameSelectWidget.cpp
+++ b/SerialPrograms/Source/Pokemon/Options/Pokemon_NameSelectWidget.cpp
@@ -67,7 +67,7 @@ NameSelectWidget::NameSelectWidget(
     }
     this->addItems(list);
 
-    // Inititalize the widget to at least select sth.
+    // Initialize the widget to at least select sth.
     if (slugs.size() > 0){
         this->setCurrentIndex(0);
     }

--- a/SerialPrograms/Source/Pokemon/Pokemon_StatsCalculation.cpp
+++ b/SerialPrograms/Source/Pokemon/Pokemon_StatsCalculation.cpp
@@ -118,7 +118,7 @@ NatureAdjustments get_nature_adjustments(NatureCheckerValue nature){
         return ret;
 
     default:
-        throw InternalProgramError(nullptr, PA_CURRENT_FUNCTION, "Unkwown Nature: " + std::to_string((int)nature));
+        throw InternalProgramError(nullptr, PA_CURRENT_FUNCTION, "Unknown Nature: " + std::to_string((int)nature));
     }
 }
 #endif

--- a/SerialPrograms/Source/PokemonLA/Inference/Map/PokemonLA_MapZoomLevelReader.cpp
+++ b/SerialPrograms/Source/PokemonLA/Inference/Map/PokemonLA_MapZoomLevelReader.cpp
@@ -59,7 +59,7 @@ int read_map_zoom_level(const ImageViewRGB32& screen){
                 max_yellow = yellow;
             }
         }
-        // std::cout << "Compability color " << stats.average << " " << stats.stddev << std::endl;
+        // std::cout << "Compatibility color " << stats.average << " " << stats.stddev << std::endl;
     }
 
     return max_yellow_index;

--- a/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_ItemCompatibilityDetector.cpp
+++ b/SerialPrograms/Source/PokemonLA/Inference/PokemonLA_ItemCompatibilityDetector.cpp
@@ -34,7 +34,7 @@ ItemCompatibility detect_item_compatibility(const ImageViewRGB32& screen){
     );
 
     ImageStats stats = image_stats(region);
-    // std::cout << "Compability color " << stats.average.r << " " << stats.average.g << " " << stats.average.b << std::endl;
+    // std::cout << "Compatibility color " << stats.average.r << " " << stats.average.g << " " << stats.average.b << std::endl;
     if (stats.average.r > stats.average.b + 50.0){
         return ItemCompatibility::INCOMPATIBLE;
     }

--- a/SerialPrograms/Source/PokemonLA/Options/PokemonLA_BattlePokemonActionTable.cpp
+++ b/SerialPrograms/Source/PokemonLA/Options/PokemonLA_BattlePokemonActionTable.cpp
@@ -223,7 +223,7 @@ std::unique_ptr<EditableTableRow> MoveGrinderActionRow::clone() const{
 
 MoveGrinderActionTable::MoveGrinderActionTable()
     : EditableTableOption_t<MoveGrinderActionRow>(
-        "For every move you want to perform, input the style and the number of attemps you want to achieve.",
+        "For every move you want to perform, input the style and the number of attempts you want to achieve.",
         LockMode::LOCK_WHILE_RUNNING
     )
 {}

--- a/SerialPrograms/Source/PokemonLA/Programs/Farming/PokemonLA_IngoBattleGrinder.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/Farming/PokemonLA_IngoBattleGrinder.cpp
@@ -388,7 +388,7 @@ void IngoBattleGrinder::program(SingleSwitchProgramEnvironment& env, ProControll
     //     return;
     // }
 
-    // pokemon index -> number of move attemps made so far
+    // pokemon index -> number of move attempts made so far
     std::map<size_t, size_t> pokemon_move_attempts;
 
     while (true){

--- a/SerialPrograms/Source/PokemonLA/Programs/Farming/PokemonLA_MagikarpMoveGrinder.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/Farming/PokemonLA_MagikarpMoveGrinder.cpp
@@ -236,7 +236,7 @@ void MagikarpMoveGrinder::program(SingleSwitchProgramEnvironment& env, ProContro
     MagikarpMoveGrinder_Descriptor::Stats& stats = env.current_stats<MagikarpMoveGrinder_Descriptor::Stats>();
 
     if (POKEMON_ACTIONS.num_pokemon() == 0){
-        throw UserSetupError(env.console, "No Pokemon sepecified to grind.");
+        throw UserSetupError(env.console, "No Pokemon specified to grind.");
     }
 
     //  Connect the controller.

--- a/SerialPrograms/Source/PokemonLA/Programs/Farming/PokemonLA_TenacityCandyFarmer.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/Farming/PokemonLA_TenacityCandyFarmer.cpp
@@ -253,7 +253,7 @@ bool TenacityCandyFarmer::run_iteration(SingleSwitchProgramEnvironment& env, Pro
 
             if (cur_battle == 1 && num_turns == 1){
                 // Change opponent to Froslass as Froslass is fast and Avalugg is slow.
-                // So better to finish Forslass first so that we may move immediately to finsih Avalugg
+                // So better to finish Forslass first so that we may move immediately to finish Avalugg
                 // without taking damage.
                 pbf_press_button(context, BUTTON_ZL, 10, 100);
             }

--- a/SerialPrograms/Source/PokemonLA/Programs/General/PokemonLA_SkipToFullMoon.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/General/PokemonLA_SkipToFullMoon.cpp
@@ -101,7 +101,7 @@ void SkipToFullMoon::program(SingleSwitchProgramEnvironment& env, ProControllerC
         // if (ret != 0){
         //     std::cout << "ERROR! Cannot detect the dialogue ellipse" << std::endl;
         // }
-        // Press B to clear the "You Pokemon happy and healty" dialogue.
+        // Press B to clear the "You Pokemon happy and healthy" dialogue.
         // pbf_press_button(context, BUTTON_B, 20, 100);
 
 

--- a/SerialPrograms/Source/PokemonLA/Programs/PokemonLA_EscapeFromAttack.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/PokemonLA_EscapeFromAttack.cpp
@@ -50,7 +50,7 @@ EscapeFromAttack::EscapeFromAttack(
     const std::chrono::milliseconds GET_ON_BRAVIARY_TIME_MILLIS(GET_ON_BRAVIARY_TIME * 1000 / TICKS_PER_SECOND);
 
     register_state_command(State::UNKNOWN, [this](){
-        m_stream.log("Unknown state. Moving foward...");
+        m_stream.log("Unknown state. Moving forward...");
         m_active_command->dispatch([](ProControllerContext& context){
             pbf_move_left_joystick(context, 128, 0, 300 * TICKS_PER_SECOND, 0);
         });

--- a/SerialPrograms/Source/PokemonLA/Programs/ShinyHunting/PokemonLA_AutoMultiSpawn.cpp
+++ b/SerialPrograms/Source/PokemonLA/Programs/ShinyHunting/PokemonLA_AutoMultiSpawn.cpp
@@ -248,7 +248,7 @@ std::vector<int> parse_multispawn_path(SingleSwitchProgramEnvironment& env, cons
     std::vector<int> path_despawns;
     std::string raw_path = path + "|";
     for(size_t pos = 0, next_pos = 0; (next_pos = raw_path.find('|', pos)) != std::string::npos; pos = next_pos + 1){
-        if (pos == next_pos){ // In the case it's jsut one "|"
+        if (pos == next_pos){ // In the case it's just one "|"
             continue;
         }
 

--- a/SerialPrograms/Source/PokemonSV/Inference/Battles/PokemonSV_EncounterWatcher.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Battles/PokemonSV_EncounterWatcher.cpp
@@ -53,7 +53,7 @@ bool EncounterWatcher::process_spectrums(
 
     WallClock threshold = current_time() - std::chrono::seconds(1);
 
-    //  Find the brighest frame.
+    //  Find the brightest frame.
     std::lock_guard<std::mutex> lg(m_lock);
 
     double best_bright_portion = 0;

--- a/SerialPrograms/Source/PokemonSV/Programs/Boxes/PokemonSV_BoxAttach.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Boxes/PokemonSV_BoxAttach.cpp
@@ -21,7 +21,7 @@ namespace PokemonSV{
 
 
 //  With the cursor over the item you want to attach, attach to the current
-//  Pokemon, replacing if neccessary.
+//  Pokemon, replacing if necessary.
 void attach_item_from_bag(
     const ProgramInfo& info,
     VideoStream& stream, ProControllerContext& context,

--- a/SerialPrograms/Source/PokemonSV/Programs/Boxes/PokemonSV_BoxRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Boxes/PokemonSV_BoxRoutines.cpp
@@ -181,7 +181,7 @@ void change_held_mode(const ProgramInfo& info, VideoStream& stream, ProControlle
     }
 }
 
-} // anonymous namesapce
+} // anonymous namespace
 
 // Use box selection mode to hold one column of pokemon.
 // Use visual feedback to ensure button Minus is pressed to turn on box selection mode/

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
@@ -565,7 +565,7 @@ void EggAutonomous::process_one_baby(SingleSwitchProgramEnvironment& env, ProCon
             send_keep_notification();
 
             if (move_pokemon_to_keep(env, context, party_row) == false){
-                env.log("No empty slot availble to place new pokemon.");
+                env.log("No empty slot available to place new pokemon.");
                 env.console.overlay().add_log("No box space", COLOR_RED);
                 throw ProgramFinishedException();
             }

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
@@ -278,7 +278,7 @@ void EggAutonomous::program(SingleSwitchProgramEnvironment& env, ProControllerCo
             env.log("Resetting game since nothing found, saving sandwich ingredients.");
             reset_game(env.program_info(), env.console, context);
         }else{ // game_already_resetted == true
-            env.log("Game resetted back to egg fetching routine.");
+            env.log("Game reset back to egg fetching routine.");
         }
 
         if (m_num_sandwich_spent >= max_num_sandwiches){

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.cpp
@@ -303,7 +303,7 @@ bool eat_egg_sandwich_at_picnic(
     case EggSandwichType::BITTER_SWEET_HERBS:
         enter_custom_sandwich_mode(env.program_info(), stream, context);
         if (language == Language::None){
-            throw UserSetupError(stream.logger(), "Must set game langauge option to read ingredient lists to make herb sandwich.");
+            throw UserSetupError(stream.logger(), "Must set game language option to read ingredient lists to make herb sandwich.");
         }
         make_two_herbs_sandwich(env.program_info(), env.realtime_dispatcher(), stream, context, sandwich_type, language);
         finish_sandwich_eating(env.program_info(), stream, context);

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.cpp
@@ -142,7 +142,7 @@ void do_egg_cycle_motion(
     }
 }
 
-} // annoymous namespace
+} // anonymous namespace
 
 void order_compote_du_fils(
     const ProgramInfo& info,

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_AuctionFarmer.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_AuctionFarmer.cpp
@@ -338,7 +338,7 @@ void AuctionFarmer::move_dialog_to_center(SingleSwitchProgramEnvironment& env, P
             center_y = offer.second.y + (0.5 * offer.second.height);
 
 
-            // check whether the stop condition is fullfilled by now.
+            // check whether the stop condition is fulfilled by now.
             if (!(center_x < 0.43 || center_x > 0.57)){
                 break;
             }

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_ESPTraining.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_ESPTraining.cpp
@@ -181,7 +181,7 @@ void ESPTraining::program(SingleSwitchProgramEnvironment& env, ProControllerCont
                     break;
                 case Detection::GREY:
                     //Press any button to start next round
-                    //Pressing A tends to make Dendra :D two extra times during the transistion so press B instead
+                    //Pressing A tends to make Dendra :D two extra times during the transition so press B instead
                     //Sometimes this is detected as blue, the B press there also works
                     env.log("ESPEmotionDetector: Grey - Mash though dialog", COLOR_BLACK);
                     emotion_button = BUTTON_B;

--- a/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_MassPurchase.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_MassPurchase.cpp
@@ -55,7 +55,7 @@ std::unique_ptr<StatsTracker> MassPurchase_Descriptor::make_stats() const{
 
 MassPurchase::MassPurchase()
     : ITEMS(
-        "<b>Items to Buy:</b><br>The amount of Items to buy from the postion of the cursor.",
+        "<b>Items to Buy:</b><br>The amount of Items to buy from the position of the cursor.",
         LockMode::LOCK_WHILE_RUNNING,
         50
     )

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
@@ -250,7 +250,7 @@ bool select_sandwich_recipe(
     }
 
     // we cannot find the receipt
-    stream.log("Max list travese attempt reached. Target recipe not found", COLOR_RED);
+    stream.log("Max list traverse attempt reached. Target recipe not found", COLOR_RED);
     stream.overlay().add_log("Recipe not found", COLOR_RED);
 
     return false;

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
@@ -1238,7 +1238,7 @@ void run_sandwich_maker(ProgramEnvironment& env, VideoStream& stream, ProControl
     if (ret < 0){
         OperationFailedException::fire(
             ErrorReport::SEND_ERROR_REPORT,
-            "SandwichMaker: Cannot detect grabing hand when waiting for upper bread.",
+            "SandwichMaker: Cannot detect grabbing hand when waiting for upper bread.",
             stream,
             grabbing_hand.last_snapshot()
         );

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
@@ -739,7 +739,7 @@ void make_two_herbs_sandwich(
         DeterminedSandwichIngredientWatcher herb_watcher(SandwichIngredientType::CONDIMENT, herb_index);
         repeat_button_press_until(
             info, stream, context, BUTTON_A, 40, 60, {herb_watcher}, "CondimentsPageNotDetected",
-            "make_two_herbs_sandwich(): cannot detect detemined herb at cell " + std::to_string(herb_index) + " after 50 seconds."
+            "make_two_herbs_sandwich(): cannot detect determined herb at cell " + std::to_string(herb_index) + " after 50 seconds."
         );
     };
 

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
@@ -654,7 +654,7 @@ void finish_two_herbs_sandwich(
     stream.overlay().add_log("Built sandwich", COLOR_WHITE);
 }
 
-} // anonymous namesapce
+} // anonymous namespace
 
 void make_two_herbs_sandwich(
     const ProgramInfo& info, AsyncDispatcher& dispatcher, VideoStream& stream, ProControllerContext& context,

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
@@ -748,7 +748,7 @@ void make_two_herbs_sandwich(
         move_one_up_to_row(9 - i);
     }
     press_a_to_determine_herb(0); // Press A to determine one herb
-    // Press DPAD_UP againt to move to the second herb row
+    // Press DPAD_UP against to move to the second herb row
     for(size_t i = first_herb_index_last+1; i < sweet_herb_index_last+1; i++){
         move_one_up_to_row(9 - i);
     }

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
@@ -752,7 +752,7 @@ void make_two_herbs_sandwich(
     for(size_t i = first_herb_index_last+1; i < sweet_herb_index_last+1; i++){
         move_one_up_to_row(9 - i);
     }
-    press_a_to_determine_herb(1); // Press A to detemine the second herb
+    press_a_to_determine_herb(1); // Press A to determine the second herb
 
     {
         // Press button + to go to picks page

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
@@ -517,7 +517,7 @@ ImageFloatBox move_sandwich_hand(
     }
 }
 
-} // end anonymous namesapce
+} // end anonymous namespace
 
 void finish_sandwich_eating(
     const ProgramInfo& info,

--- a/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp
@@ -747,7 +747,7 @@ void make_two_herbs_sandwich(
     for(size_t i = 0; i < first_herb_index_last+1; i++){
         move_one_up_to_row(9 - i);
     }
-    press_a_to_determine_herb(0); // Press A to detemine one herb
+    press_a_to_determine_herb(0); // Press A to determine one herb
     // Press DPAD_UP againt to move to the second herb row
     for(size_t i = first_herb_index_last+1; i < sweet_herb_index_last+1; i++){
         move_one_up_to_row(9 - i);

--- a/SerialPrograms/Source/PokemonSwSh/Inference/PokemonSwSh_DialogTriangleDetector.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Inference/PokemonSwSh_DialogTriangleDetector.cpp
@@ -84,7 +84,7 @@ bool DialogTriangleDetector::process_frame(const ImageViewRGB32& frame, WallCloc
     );
 
     if (detected){
-        m_logger.log("Detected dialog black traingle.", COLOR_PURPLE);
+        m_logger.log("Detected dialog black triangle.", COLOR_PURPLE);
     }
 
     m_detected.store(detected, std::memory_order_release);

--- a/SerialPrograms/Source/PokemonSwSh/Inference/ShinyDetection/PokemonSwSh_SparkleDetectorRadial.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Inference/ShinyDetection/PokemonSwSh_SparkleDetectorRadial.cpp
@@ -130,7 +130,7 @@ bool RadialSparkleDetector::is_star() const{
         return false;
     }
 
-    //  Make sure dimentions are roughly square-ish.
+    //  Make sure dimensions are roughly square-ish.
     if (width > 2 * height || height > 2 * width){
         return false;
     }

--- a/SerialPrograms/Source/PokemonSwSh/MaxLair/Options/PokemonSwSh_MaxLair_Options_Consoles.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/MaxLair/Options/PokemonSwSh_MaxLair_Options_Consoles.cpp
@@ -62,7 +62,7 @@ CaughtScreenActionsOption::CaughtScreenActionsOption(
     )
     , shiny_boss(
         true, winrate_reset_tooltip,
-        "<b>Boss/Legendary is Shiny:</b><br>If there are mulitiple shinies where one is the boss, this option still applies.<br><br>"
+        "<b>Boss/Legendary is Shiny:</b><br>If there are multiple shinies where one is the boss, this option still applies.<br><br>"
         "<font color=\"red\">For safety reasons, this program will <i>NEVER</i> automatically take a boss. "
         "Likewise, the settings here are intentionally worded so that it's impossible to ask the program to take a boss. "
         "Because taking a boss is irreversible, we refuse to automate it and require you to do it manually to avoid any mistakes.</font>",

--- a/SerialPrograms/Source/PokemonSwSh/Programs/EggPrograms/PokemonSwSh_EggAutonomous.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/EggPrograms/PokemonSwSh_EggAutonomous.cpp
@@ -319,7 +319,7 @@ bool EggAutonomous::run_batch(
         bool restart_bike_loop = false;
         for (size_t i_bike_loop = 0; i_bike_loop < this->LOOPS_PER_FETCH && bike_loop_count < MAX_BIKE_LOOP_COUNT;){
             context.wait_for_all_requests();
-            // +1 here because video overlay is for general users. Genearl users start counts at 1, while us programmers start count at 0.
+            // +1 here because video overlay is for general users. General users start counts at 1, while us programmers start count at 0.
             if (restart_bike_loop){
                 env.console.overlay().add_log("Restart loop " + std::to_string(bike_loop_count+1), COLOR_WHITE);
                 restart_bike_loop = false;

--- a/SerialPrograms/Source/Tests/PokemonLA_Tests.cpp
+++ b/SerialPrograms/Source/Tests/PokemonLA_Tests.cpp
@@ -554,7 +554,7 @@ int test_pokemonLA_MMOSpriteMatcher(const std::string& filepath){
     ImageRGB32 sprite_image(mmo_revealed_image_path.toStdString());
     
     if (!question_mark_image){
-        cerr << "Error: cannot load MMO quesiton mark image file " << filepath << endl;
+        cerr << "Error: cannot load MMO question mark image file " << filepath << endl;
         return 1;
     }
     if (!sprite_image){


### PR DESCRIPTION
Corrected several spelling issues in various files.

### List of modifications:
- `3rdParty/QtWavFile/WavFile.cpp`, line 10: `orignal` → `original`
- `Common/Cpp/LifetimeSanitizer.cpp`, line 113: `non-existant` → `non-existent`
- `Common/Cpp/LifetimeSanitizer.cpp`, line 131: `non-existant` → `non-existent`
- `Common/Cpp/LifetimeSanitizer.cpp`, line 150: `non-existant` → `non-existent`
- `Common/Cpp/LifetimeSanitizer.cpp`, line 186: `non-existant` → `non-existent`
- `Common/Cpp/LifetimeSanitizer.cpp`, line 192: `non-existant` → `non-existent`
- `Common/Qt/WidgetStackFixedAspectRatio.cpp`, line 116: `Supressing` → `Suppressing`
- `SerialPrograms/Scripts/check_detector_regions.py`, line 5: `intial` → `initial`
- `SerialPrograms/Scripts/image_viewer.py`, line 11: `slected` → `selected`
- `SerialPrograms/Scripts/image_viewer.py`, line 45: `slected` → `selected`
- `SerialPrograms/Source/CommonFramework/AudioPipeline/UI/AudioDisplayWidget.cpp`, line 184: `Supressing` → `Suppressing`
- `SerialPrograms/Source/CommonTools/Audio/AudioPerSpectrumDetectorBase.cpp`, line 102: `intialization` → `initialization`
- `SerialPrograms/Source/CommonTools/Audio/SpectrogramMatcher.cpp`, line 70: `frquency` → `frequency`
- `SerialPrograms/Source/CommonTools/Audio/SpectrogramMatcher.cpp`, line 371: `indivdual` → `individual`
- `SerialPrograms/Source/CommonTools/ImageMatch/ExactImageDictionaryMatcher.cpp`, line 26: `dimenstion` → `dimension`
- `SerialPrograms/Source/CommonTools/OCR/OCR_RawOCR.cpp`, line 133: `intances` → `instances`
- `SerialPrograms/Source/CommonTools/OCR/OCR_RawOCR.cpp`, line 140: `intances` → `instances`
- `SerialPrograms/Source/CommonTools/OCR/OCR_RawOCR.cpp`, line 141: `istance` → `instance`
- `SerialPrograms/Source/Controllers/SerialPABotBase/SerialPABotBase_Connection.cpp`, line 55: `microntrollers` → `microcontrollers`
- `SerialPrograms/Source/Kernels/ImageFilters/RGB32_EuclideanDistance/Kernels_ImageFilter_RGB32_Euclidean_ARM64_NEON.cpp`, line 153: `substracting` → `subtracting`
- `SerialPrograms/Source/NintendoSwitch/Programs/NintendoSwitch_PushJoySticks.cpp`, line 20: `continously` → `continuously`
- `SerialPrograms/Source/Pokemon/Options/Pokemon_NameSelectWidget.cpp`, line 70: `Inititalize` → `Initialize`
- `SerialPrograms/Source/Pokemon/Pokemon_StatsCalculation.cpp`, line 121: `Unkwown` → `Unknown`
- `SerialPrograms/Source/PokemonLA/Inference/Map/PokemonLA_MapZoomLevelReader.cpp`, line 62: `Compability` → `Compatibility`
- `SerialPrograms/Source/PokemonLA/Inference/PokemonLA_ItemCompatibilityDetector.cpp`, line 37: `Compability` → `Compatibility`
- `SerialPrograms/Source/PokemonLA/Options/PokemonLA_BattlePokemonActionTable.cpp`, line 226: `attemps` → `attempts`
- `SerialPrograms/Source/PokemonLA/Programs/Farming/PokemonLA_IngoBattleGrinder.cpp`, line 391: `attemps` → `attempts`
- `SerialPrograms/Source/PokemonLA/Programs/Farming/PokemonLA_MagikarpMoveGrinder.cpp`, line 239: `sepecified` → `specified`
- `SerialPrograms/Source/PokemonLA/Programs/Farming/PokemonLA_TenacityCandyFarmer.cpp`, line 256: `finsih` → `finish`
- `SerialPrograms/Source/PokemonLA/Programs/General/PokemonLA_SkipToFullMoon.cpp`, line 104: `healty` → `healthy`
- `SerialPrograms/Source/PokemonLA/Programs/PokemonLA_EscapeFromAttack.cpp`, line 53: `foward` → `forward`
- `SerialPrograms/Source/PokemonLA/Programs/ShinyHunting/PokemonLA_AutoMultiSpawn.cpp`, line 251: `jsut` → `just`
- `SerialPrograms/Source/PokemonSV/Inference/Battles/PokemonSV_EncounterWatcher.cpp`, line 56: `brighest` → `brightest`
- `SerialPrograms/Source/PokemonSV/Programs/Boxes/PokemonSV_BoxAttach.cpp`, line 24: `neccessary` → `necessary`
- `SerialPrograms/Source/PokemonSV/Programs/Boxes/PokemonSV_BoxRoutines.cpp`, line 184: `namesapce` → `namespace`
- `SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp`, line 281: `resetted` → `reset`
- `SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp`, line 568: `availble` → `available`
- `SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.cpp`, line 145: `annoymous` → `anonymous`
- `SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.cpp`, line 306: `langauge` → `language`
- `SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_AuctionFarmer.cpp`, line 341: `fullfilled` → `fulfilled`
- `SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_ESPTraining.cpp`, line 184: `transistion` → `transition`
- `SerialPrograms/Source/PokemonSV/Programs/General/PokemonSV_MassPurchase.cpp`, line 58: `postion` → `position`
- `SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp`, line 253: `travese` → `traverse`
- `SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp`, line 520: `namesapce` → `namespace`
- `SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp`, line 657: `namesapce` → `namespace`
- `SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp`, line 742: `detemined` → `determined`
- `SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp`, line 750: `detemine` → `determine`
- `SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp`, line 751: `againt` → `against`
- `SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp`, line 755: `detemine` → `determine`
- `SerialPrograms/Source/PokemonSV/Programs/Sandwiches/PokemonSV_SandwichRoutines.cpp`, line 1241: `grabing` → `grabbing`
- `SerialPrograms/Source/PokemonSwSh/Inference/PokemonSwSh_DialogTriangleDetector.cpp`, line 87: `traingle` → `triangle`
- `SerialPrograms/Source/PokemonSwSh/Inference/ShinyDetection/PokemonSwSh_SparkleDetectorRadial.cpp`, line 133: `dimentions` → `dimensions`
- `SerialPrograms/Source/PokemonSwSh/MaxLair/Options/PokemonSwSh_MaxLair_Options_Consoles.cpp`, line 65: `mulitiple` → `multiple`
- `SerialPrograms/Source/PokemonSwSh/Programs/EggPrograms/PokemonSwSh_EggAutonomous.cpp`, line 322: `Genearl` → `General`
- `SerialPrograms/Source/Tests/PokemonLA_Tests.cpp`, line 557: `quesiton` → `question`

This PR does not modify any logic or behavior.