### PR TITLE
BBQ farmer: reset date after skipping

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_BlueberryCatchPhoto.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_BlueberryCatchPhoto.cpp
@@ -918,6 +918,16 @@ void quest_catch(
     pbf_press_button(context, BUTTON_HOME, 160ms, ConsoleSettings::instance().SETTINGS_TO_HOME_DELAY0);
     resume_game_from_home(console, context);
 
+    //Wait a bit and then fix the time to prevent running out of years
+    pbf_wait(context, 250);
+    context.wait_for_all_requests();
+    pbf_press_button(context, BUTTON_HOME, 80ms, GameSettings::instance().GAME_TO_HOME_DELAY1);
+    home_to_date_time(console, context, false);
+    pbf_press_button(context, BUTTON_A, 20, 105);
+    pbf_press_button(context, BUTTON_A, 20, 105);
+    pbf_press_button(context, BUTTON_HOME, 160ms, ConsoleSettings::instance().SETTINGS_TO_HOME_DELAY0);
+    resume_game_from_home(console, context);
+
     //Heal up and then reset position again.
     OverworldWatcher done_healing(console.logger(), COLOR_BLUE);
     pbf_move_left_joystick(context, 128, 0, 100, 20);

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_BlueberryQuests.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_BlueberryQuests.cpp
@@ -707,6 +707,16 @@ void quest_tera_self_defeat(
     pbf_press_button(context, BUTTON_HOME, 160ms, ConsoleSettings::instance().SETTINGS_TO_HOME_DELAY0);
     resume_game_from_home(console, context);
 
+    //Wait a bit and then fix the time to prevent running out of years
+    pbf_wait(context, 250);
+    context.wait_for_all_requests();
+    pbf_press_button(context, BUTTON_HOME, 80ms, GameSettings::instance().GAME_TO_HOME_DELAY1);
+    home_to_date_time(console, context, false);
+    pbf_press_button(context, BUTTON_A, 20, 105);
+    pbf_press_button(context, BUTTON_A, 20, 105);
+    pbf_press_button(context, BUTTON_HOME, 160ms, ConsoleSettings::instance().SETTINGS_TO_HOME_DELAY0);
+    resume_game_from_home(console, context);
+
     //Heal up and then reset position again.
     OverworldWatcher done_healing(console.logger(), COLOR_BLUE);
     pbf_move_left_joystick(context, 128, 0, 100, 20);
@@ -843,6 +853,16 @@ void quest_sneak_up(
     pbf_press_button(context, BUTTON_HOME, 160ms, ConsoleSettings::instance().SETTINGS_TO_HOME_DELAY0);
     resume_game_from_home(console, context);
     context.wait_for_all_requests();
+
+    //Wait a bit and then fix the time to prevent running out of years
+    pbf_wait(context, 250);
+    context.wait_for_all_requests();
+    pbf_press_button(context, BUTTON_HOME, 80ms, GameSettings::instance().GAME_TO_HOME_DELAY1);
+    home_to_date_time(console, context, false);
+    pbf_press_button(context, BUTTON_A, 20, 105);
+    pbf_press_button(context, BUTTON_A, 20, 105);
+    pbf_press_button(context, BUTTON_HOME, 160ms, ConsoleSettings::instance().SETTINGS_TO_HOME_DELAY0);
+    resume_game_from_home(console, context);
 }
 
 void quest_wild_tera(
@@ -914,6 +934,16 @@ void quest_wild_tera(
     pbf_press_button(context, BUTTON_HOME, 160ms, GameSettings::instance().GAME_TO_HOME_DELAY1);
     home_to_date_time(console, context, true);
     roll_date_forward_1(console, context, true);
+    pbf_press_button(context, BUTTON_HOME, 160ms, ConsoleSettings::instance().SETTINGS_TO_HOME_DELAY0);
+    resume_game_from_home(console, context);
+
+    //Wait a bit and then fix the time to prevent running out of years
+    pbf_wait(context, 250);
+    context.wait_for_all_requests();
+    pbf_press_button(context, BUTTON_HOME, 80ms, GameSettings::instance().GAME_TO_HOME_DELAY1);
+    home_to_date_time(console, context, false);
+    pbf_press_button(context, BUTTON_A, 20, 105);
+    pbf_press_button(context, BUTTON_A, 20, 105);
     pbf_press_button(context, BUTTON_HOME, 160ms, ConsoleSettings::instance().SETTINGS_TO_HOME_DELAY0);
     resume_game_from_home(console, context);
 


### PR DESCRIPTION
re-syncs date/time after performing a day skip to avoid running out of years

BBQ farmer world navigation tends to overshoot since the original values assumed lag, and will need two different sets of values for movement in some quests.