### PR TITLE
adjust rmsd for lgpe legendary reset

### DIFF
--- a/SerialPrograms/Source/PokemonLGPE/Inference/Battles/PokemonLGPE_BattleArrowDetector.cpp
+++ b/SerialPrograms/Source/PokemonLGPE/Inference/Battles/PokemonLGPE_BattleArrowDetector.cpp
@@ -54,7 +54,7 @@ bool BattleArrowDetector::detect(const ImageViewRGB32& screen){
         //cropped.save("test-object-" + std::to_string(c++) + ".png");
         double rmsd = matcher.rmsd(cropped);
         //cout << rmsd << endl;
-        if (rmsd < 110){
+        if (rmsd < 116){
             return true;
         }
     }


### PR DESCRIPTION
110 → 116

Add more room for the catch menu arrow detection after the battle part of a legendary is concluded.