### PR TITLE
read_number_waterfill: add another parameter line_index for logging purposes, when multithreaded

### DIFF
--- a/SerialPrograms/Source/CommonTools/OCR/OCR_NumberReader.h
+++ b/SerialPrograms/Source/CommonTools/OCR/OCR_NumberReader.h
@@ -27,10 +27,13 @@ int read_number(Logger& logger, const ImageViewRGB32& image, Language language =
 //  This version attempts to improve reliability by first isolating each number
 //  via waterfill. Then it OCRs each number by itself and recombines them at the
 //  end. This requires specifying the color range for the text.
+//
+// line_index: specifies the current number's row. for logging purposes, when multithreaded.
 int read_number_waterfill(
     Logger& logger, const ImageViewRGB32& image,
     uint32_t rgb32_min, uint32_t rgb32_max,
-    bool text_inside_range = true
+    bool text_inside_range = true,
+    int8_t line_index = -1
  );
 
 // run OCR on each individual character in the string of numbers.
@@ -53,12 +56,15 @@ int read_number_waterfill(
 // prioritize_numeric_only_results: 
 //  - if true: if OCR reads only numeric characters, the candidate gets 2 votes. If OCR reads non-numeric characters, the candidate gets only 1 vote.
 //  - if false: all reads only get 1 vote
+//
+// line_index: specifies the current number's row. for logging purposes, when multithreaded.
 int read_number_waterfill_multifilter(
     Logger& logger, const ImageViewRGB32& image,
     std::vector<std::pair<uint32_t, uint32_t>> filters,
     uint32_t width_max,
     bool text_inside_range = true,
-    bool prioritize_numeric_only_results = true
+    bool prioritize_numeric_only_results = true,
+    int8_t line_index = -1
  );
 
 

--- a/SerialPrograms/Source/PokemonSV/Inference/ItemPrinter/PokemonSV_ItemPrinterMaterialDetector.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/ItemPrinter/PokemonSV_ItemPrinterMaterialDetector.h
@@ -76,7 +76,8 @@ public:
 
     int16_t read_number(
         Logger& logger, AsyncDispatcher& dispatcher,
-        const ImageViewRGB32& screen, const ImageFloatBox& box
+        const ImageViewRGB32& screen, const ImageFloatBox& box,
+        int8_t row_index
     ) const;
 
 

--- a/SerialPrograms/Source/PokemonSV/Inference/ItemPrinter/PokemonSV_ItemPrinterPrizeReader.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/ItemPrinter/PokemonSV_ItemPrinterPrizeReader.cpp
@@ -164,7 +164,7 @@ std::array<int16_t, 10> ItemPrinterPrizeReader::read_quantity(
         // filtered.save("DebugDumps/test"+ std::to_string(i) +".png");   
 
         tasks[i] = dispatcher.dispatch([&, i]{
-            results[i] = read_number(logger, screen, boxes[i]);
+            results[i] = read_number(logger, screen, boxes[i], (int8_t)i);
         });
     }
 
@@ -179,11 +179,12 @@ std::array<int16_t, 10> ItemPrinterPrizeReader::read_quantity(
 int16_t ItemPrinterPrizeReader::read_number(
     Logger& logger, 
     const ImageViewRGB32& screen, 
-    const ImageFloatBox& box
+    const ImageFloatBox& box,
+    int8_t line_index
 ) const{
 
     ImageViewRGB32 cropped = extract_box_reference(screen, box);
-    int16_t number = (int16_t)OCR::read_number_waterfill(logger, cropped, 0xff808000, 0xffffffff);
+    int16_t number = (int16_t)OCR::read_number_waterfill(logger, cropped, 0xff808000, 0xffffffff, true, line_index);
 
     if (number < 1 || number > 40){
         number = 1; // default to 1 if we can't read the prize quantity

--- a/SerialPrograms/Source/PokemonSV/Inference/ItemPrinter/PokemonSV_ItemPrinterPrizeReader.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/ItemPrinter/PokemonSV_ItemPrinterPrizeReader.h
@@ -43,7 +43,8 @@ public:
     int16_t read_number(
         Logger& logger,
         const ImageViewRGB32& screen, 
-        const ImageFloatBox& box
+        const ImageFloatBox& box,
+        int8_t line_index = -1
     ) const;
 
     double average_sum_filtered(const ImageViewRGB32& screen, const ImageFloatBox& box) const;


### PR DESCRIPTION
When multithreaded, it's hard to tell which OCR reads are referring to which line/row.