### PR TITLE
Bbq switch2 fixes

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_BlueberryCatchPhoto.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_BlueberryCatchPhoto.cpp
@@ -126,7 +126,11 @@ CameraAngle quest_photo_navi(
 
             pbf_press_button(context, BUTTON_L, 20, 50);
             pbf_move_left_joystick(context, 128, 0, 100, 50);
-            pbf_move_left_joystick(context, 0, 0, 20, 50);
+
+            //Turn slightly for switch 1
+            if (console.state().console_type() == ConsoleType::Switch1) {
+                pbf_move_left_joystick(context, 0, 0, 20, 50);
+            }
 
             break;
         case BBQuests::photo_bug: case BBQuests::photo_rock:
@@ -400,8 +404,11 @@ void quest_catch_navi(
             pbf_press_button(context, BUTTON_L, 20, 50);
             pbf_move_left_joystick(context, 128, 0, 100, 50);
 
-            pbf_move_left_joystick(context, 0, 0, 20, 50);
-            pbf_press_button(context, BUTTON_L, 20, 50);
+            //Turn slightly for switch 1
+            if (console.state().console_type() == ConsoleType::Switch1) {
+                pbf_move_left_joystick(context, 0, 0, 20, 50);
+                pbf_press_button(context, BUTTON_L, 20, 50);
+            }
 
             break;
 

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_BlueberryCatchPhoto.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_BlueberryCatchPhoto.cpp
@@ -183,8 +183,8 @@ CameraAngle quest_photo_navi(
             pbf_press_button(context, BUTTON_L, 20, 50);
 
             break;
-        case BBQuests::photo_flying: case BBQuests::photo_dark:
-            console.log("Photo: Dark/Flying");
+        case BBQuests::photo_flying:
+            console.log("Photo: Flying");
 
             //Vullaby/Mandibuzz
             central_to_savanna_plaza(info, console, context);
@@ -228,8 +228,8 @@ CameraAngle quest_photo_navi(
             context.wait_for_all_requests();
 
             break;
-        case BBQuests::photo_poison:
-            console.log("Photo: Poison");
+        case BBQuests::photo_poison: case BBQuests::photo_dark:
+            console.log("Photo: Poison/Dark");
 
             //Muk-A - area a bit laggy but consistently so
             central_to_coastal_plaza(info, console, context);
@@ -511,8 +511,8 @@ void quest_catch_navi(
 
             jump_glide_fly(console, context, BBQ_OPTIONS.INVERTED_FLIGHT, 1000, 1650, 500);
             break;
-        case BBQuests::catch_dark: case BBQuests::catch_flying:
-            console.log("Catch: Dark/Flying");
+        case BBQuests::catch_flying:
+            console.log("Catch: Flying");
 
             //Vullaby/Mandibuzz
             central_to_savanna_plaza(info, console, context);
@@ -584,8 +584,8 @@ void quest_catch_navi(
             pbf_move_left_joystick(context, 128, 0, 50, 50);
 
             break;
-        case BBQuests::catch_poison:
-            console.log("Catch: Poison");
+        case BBQuests::catch_poison: case BBQuests::catch_dark: 
+            console.log("Catch: Poison/Dark");
 
             //Muk-A - area a bit laggy but consistently so
             central_to_coastal_plaza(info, console, context);

--- a/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_BlueberryQuests.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Farming/PokemonSV_BlueberryQuests.h
@@ -49,7 +49,7 @@ const std::set<BBQuests> gold_quests = {
 
 //Quests that are not currently supported. Gold quests currently excluded as this is singleplayer only right now.
 const std::set<BBQuests> not_possible_quests = {
-    BBQuests::UnableToDetect, BBQuests::pickup_10
+    BBQuests::UnableToDetect, BBQuests::pickup_10, BBQuests::photo_flying, BBQuests::catch_flying
 };
 
 


### PR DESCRIPTION
- Fix Pyroar targeting for Switch 2 for the following quests: catch 1 (any), photo/catch normal/fire, photo savanna
- Change target of catch/photo dark-type quests to Alolan Muk.
- Disable catch/photo of a flying-type quests until I can find out why Vullaby isn't spawning and/or find another fixed encounter that works.