### PR TITLE
SV Egg Auto new location

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
@@ -93,6 +93,15 @@ EggAutonomous::EggAutonomous()
         LockMode::LOCK_WHILE_RUNNING,
         true
     )
+    , LOCATION(
+        "<b>Location:</b><br>The location to hatch eggs.",
+        {
+            {EggAutoLocation::ZeroGate,         "zero-gate",        "Zero Gate"},
+            {EggAutoLocation::NorthLighthouse,  "north-lighthouse", "North Province (Area Three) Lighthouse"}
+        },
+        LockMode::LOCK_WHILE_RUNNING,
+        EggAutoLocation::ZeroGate
+    )
     , MAX_KEEPERS(
         "<b>Max Keepers:</b><br>Stop the program after keeping this many " + STRING_POKEMON + ". "
         "The program will put them into a box neighboring the current box.",
@@ -173,6 +182,7 @@ EggAutonomous::EggAutonomous()
     PA_ADD_OPTION(GO_HOME_WHEN_DONE);
     PA_ADD_OPTION(LANGUAGE);
     PA_ADD_OPTION(EGG_SANDWICH);
+    PA_ADD_OPTION(LOCATION);
     PA_ADD_OPTION(MAX_KEEPERS);
     PA_ADD_OPTION(AUTO_SAVING);
     PA_ADD_OPTION(KEEP_BOX_LOCATION);
@@ -185,11 +195,6 @@ EggAutonomous::EggAutonomous()
 
 void EggAutonomous::program(SingleSwitchProgramEnvironment& env, ProControllerContext& context){
     assert_16_9_720p_min(env.logger(), env.console);
-
-    //Console Type is now required.
-    if (env.console.state().console_type() == ConsoleType::Unknown) {
-        throw UserSetupError(env.console, "Switch 1 or 2 must be set.");
-    }
 
     //  Connect the controller.
     pbf_press_button(context, BUTTON_L, 10, 100);
@@ -317,7 +322,7 @@ void EggAutonomous::program(SingleSwitchProgramEnvironment& env, ProControllerCo
 int EggAutonomous::fetch_eggs_full_routine(SingleSwitchProgramEnvironment& env, ProControllerContext& context){
     auto& stats = env.current_stats<EggAutonomous_Descriptor::Stats>();
 
-    if (env.console.state().console_type() == ConsoleType::Switch1) {
+    if (LOCATION == EggAutoLocation::ZeroGate) {
         picnic_at_zero_gate(env.program_info(), env.console, context);
     } else {
         pbf_press_button(context, BUTTON_L, 50, 40);
@@ -348,10 +353,10 @@ int EggAutonomous::fetch_eggs_full_routine(SingleSwitchProgramEnvironment& env, 
     leave_picnic(env.program_info(), env.console, context);
 
     // Reset position to flying spot:
-    if (env.console.state().console_type() == ConsoleType::Switch1) {
+    if (LOCATION == EggAutoLocation::ZeroGate) {
         reset_position_to_flying_spot(env, context);
     } else {
-        //Switch 2: We haven't moved much so just fly.
+        //Lighthouse: We haven't moved much so just fly.
         open_map_from_overworld(env.program_info(), env.console, context);
         fly_to_overworld_from_map(env.program_info(), env.console, context);
     }
@@ -452,7 +457,7 @@ void EggAutonomous::hatch_eggs_full_routine(SingleSwitchProgramEnvironment& env,
             stats.m_hatched++;
             env.update_stats();
         };
-        if (env.console.state().console_type() == ConsoleType::Switch1) {
+        if (LOCATION == EggAutoLocation::ZeroGate) {
             hatch_eggs_at_zero_gate(env.program_info(), env.console, context, (uint8_t)num_eggs_in_party, hatched_callback);
             reset_position_to_flying_spot(env, context);
         } else {
@@ -671,9 +676,9 @@ bool EggAutonomous::move_pokemon_to_keep(SingleSwitchProgramEnvironment& env, Pr
 void EggAutonomous::reset_position_to_flying_spot(SingleSwitchProgramEnvironment& env, ProControllerContext& context){
     // Use map to fly back to the flying spot
     open_map_from_overworld(env.program_info(), env.console, context);
-    if (env.console.state().console_type() == ConsoleType::Switch1) {
+    if (LOCATION == EggAutoLocation::ZeroGate) {
         pbf_move_left_joystick(context, 128, 160, 20, 50);
-    } else { //Switch 2
+    } else { //lighthouse
         pbf_move_left_joystick(context, 130, 0, 150ms, 50ms);
         pbf_press_button(context, BUTTON_ZL, 40, 100);
     }

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
@@ -440,10 +440,14 @@ void EggAutonomous::hatch_eggs_full_routine(SingleSwitchProgramEnvironment& env,
         };
         if (env.console.state().console_type() == ConsoleType::Switch1) {
             hatch_eggs_at_zero_gate(env.program_info(), env.console, context, (uint8_t)num_eggs_in_party, hatched_callback);
+            reset_position_to_flying_spot(env, context);
         } else {
             hatch_eggs_at_area_three_lighthouse(env.program_info(), env.console, context, (uint8_t)num_eggs_in_party, hatched_callback);
+            reset_position_to_flying_spot(env, context);
+            //Clear spawns - over time floette/vivillon drift over past the fence (usually aroudn the 3rd batch)
+            picnic_from_overworld(env.program_info(), env.console, context);
+            leave_picnic(env.program_info(), env.console, context);
         }
-        reset_position_to_flying_spot(env, context);
 
         enter_box_system_from_overworld(env.program_info(), env.console, context);
         
@@ -656,7 +660,7 @@ void EggAutonomous::reset_position_to_flying_spot(SingleSwitchProgramEnvironment
     if (env.console.state().console_type() == ConsoleType::Switch1) {
         pbf_move_left_joystick(context, 128, 160, 20, 50);
     } else { //Switch 2
-        pbf_move_left_joystick(context, 140, 0, 150ms, 50ms);
+        pbf_move_left_joystick(context, 130, 0, 150ms, 50ms);
         pbf_press_button(context, BUTTON_ZL, 40, 100);
     }
     fly_to_overworld_from_map(env.program_info(), env.console, context);

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
@@ -185,6 +185,11 @@ EggAutonomous::EggAutonomous()
 void EggAutonomous::program(SingleSwitchProgramEnvironment& env, ProControllerContext& context){
     assert_16_9_720p_min(env.logger(), env.console);
 
+    //Console Type is now required.
+    if (env.console.state().console_type() == ConsoleType::Unknown) {
+        throw UserSetupError(env.console, "Switch 1 or 2 must be set.");
+    }
+
     //  Connect the controller.
     pbf_press_button(context, BUTTON_L, 10, 100);
 
@@ -298,7 +303,12 @@ void EggAutonomous::program(SingleSwitchProgramEnvironment& env, ProControllerCo
 int EggAutonomous::fetch_eggs_full_routine(SingleSwitchProgramEnvironment& env, ProControllerContext& context){
     auto& stats = env.current_stats<EggAutonomous_Descriptor::Stats>();
 
-    picnic_at_zero_gate(env.program_info(), env.console, context);
+    if (env.console.state().console_type() == ConsoleType::Switch1) {
+        picnic_at_zero_gate(env.program_info(), env.console, context);
+    } else {
+        pbf_press_button(context, BUTTON_L, 50, 40);
+        picnic_from_overworld(env.program_info(), env.console, context);
+    }
     // Now we are at picnic. We are at one end of picnic table while the egg basket is at the other end
     bool can_make_sandwich = eat_egg_sandwich_at_picnic(env, env.console, context,
         EGG_SANDWICH.EGG_SANDWICH_TYPE, LANGUAGE);
@@ -422,7 +432,11 @@ void EggAutonomous::hatch_eggs_full_routine(SingleSwitchProgramEnvironment& env,
             stats.m_hatched++;
             env.update_stats();
         };
-        hatch_eggs_at_zero_gate(env.program_info(), env.console, context, (uint8_t)num_eggs_in_party, hatched_callback);
+        if (env.console.state().console_type() == ConsoleType::Switch1) {
+            hatch_eggs_at_zero_gate(env.program_info(), env.console, context, (uint8_t)num_eggs_in_party, hatched_callback);
+        } else {
+            hatch_eggs_at_area_three_lighthouse(env.program_info(), env.console, context, (uint8_t)num_eggs_in_party, hatched_callback);
+        }
         reset_position_to_flying_spot(env, context);
 
         enter_box_system_from_overworld(env.program_info(), env.console, context);
@@ -633,7 +647,9 @@ bool EggAutonomous::move_pokemon_to_keep(SingleSwitchProgramEnvironment& env, Pr
 void EggAutonomous::reset_position_to_flying_spot(SingleSwitchProgramEnvironment& env, ProControllerContext& context){
     // Use map to fly back to the flying spot
     open_map_from_overworld(env.program_info(), env.console, context);
-    pbf_move_left_joystick(context, 128, 160, 20, 50);
+    if (env.console.state().console_type() == ConsoleType::Switch1) {
+        pbf_move_left_joystick(context, 128, 160, 20, 50);
+    }
     fly_to_overworld_from_map(env.program_info(), env.console, context);
 }
 

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.cpp
@@ -334,7 +334,13 @@ int EggAutonomous::fetch_eggs_full_routine(SingleSwitchProgramEnvironment& env, 
     leave_picnic(env.program_info(), env.console, context);
 
     // Reset position to flying spot:
-    reset_position_to_flying_spot(env, context);
+    if (env.console.state().console_type() == ConsoleType::Switch1) {
+        reset_position_to_flying_spot(env, context);
+    } else {
+        //Switch 2: We haven't moved much so just fly.
+        open_map_from_overworld(env.program_info(), env.console, context);
+        fly_to_overworld_from_map(env.program_info(), env.console, context);
+    }
 
     return picnic_party_to_hatch_party(env, context);
 }
@@ -649,6 +655,9 @@ void EggAutonomous::reset_position_to_flying_spot(SingleSwitchProgramEnvironment
     open_map_from_overworld(env.program_info(), env.console, context);
     if (env.console.state().console_type() == ConsoleType::Switch1) {
         pbf_move_left_joystick(context, 128, 160, 20, 50);
+    } else { //Switch 2
+        pbf_move_left_joystick(context, 140, 0, 150ms, 50ms);
+        pbf_press_button(context, BUTTON_ZL, 40, 100);
     }
     fly_to_overworld_from_map(env.program_info(), env.console, context);
 }

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.h
@@ -76,6 +76,13 @@ private:
     GoHomeWhenDoneOption GO_HOME_WHEN_DONE;
 
     OCR::LanguageOCROption LANGUAGE;
+
+    enum class EggAutoLocation{
+        ZeroGate,
+        NorthLighthouse,
+    };
+    EnumDropdownOption<EggAutoLocation> LOCATION;
+
     SimpleIntegerOption<uint8_t> MAX_KEEPERS;
 
     enum class AutoSave{

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.cpp
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.cpp
@@ -633,11 +633,13 @@ void hatch_eggs_at_area_three_lighthouse(
                         //Face at an angle, to avoid the tent to the left
                         pbf_move_left_joystick(context, 0, 0, 50, 50);
                         //Get on your mount
-                        pbf_press_button(context, BUTTON_PLUS, 50, 100);
-                        //Press L
                         pbf_press_button(context, BUTTON_L, 50, 40);
-                        //Move forward
-                        pbf_move_left_joystick(context, 128, 0, 250, 0);
+                        pbf_press_button(context, BUTTON_PLUS, 50, 100);
+                        //Go in deep, spawns outside the fence like to come in otherwise
+                        pbf_move_left_joystick(context, 128, 0, 750, 0);
+                        pbf_move_left_joystick(context, 0, 0, 50, 50);
+                        pbf_press_button(context, BUTTON_L, 50, 40);
+                        pbf_move_left_joystick(context, 128, 0, 550, 0);
                     }
                 },
                 {dialog}
@@ -649,7 +651,7 @@ void hatch_eggs_at_area_three_lighthouse(
                 stream.log("Reset location by flying back to lighthouse.");
                 // Use map to fly back to the flying spot
                 open_map_from_overworld(info, stream, context);
-                pbf_move_left_joystick(context, 255, 0, 20, 50);
+                pbf_move_left_joystick(context, 200, 0, 20, 50);
                 fly_to_overworld_from_map(info, stream, context);
                 continue;
             }

--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggRoutines.h
@@ -76,6 +76,18 @@ void hatch_eggs_at_zero_gate(
     std::function<void(uint8_t)> egg_hatched_callback = nullptr
 );
 
+// Start at North Province (Area Three) Lighthouse flying spot, go in circles in Ruchbah (fairy) Squad's base to hatch eggs.
+// Switch 2 only, this is an alternate egg hatch spot as Zero Gate now has spawns in the way.
+// Switch 1 is untested in this location but the area is extremely laggy.
+// This is a minor modification to hatch_eggs_at_zero_gate
+// `egg_hatched_callback` will be called after each egg hatched, with egg index (0-indexed)
+void hatch_eggs_at_area_three_lighthouse(
+    const ProgramInfo& info,
+    VideoStream& stream, ProControllerContext& context,
+    uint8_t num_eggs_in_party,
+    std::function<void(uint8_t)> egg_hatched_callback = nullptr
+);
+
 // From overworld, go in circles to hatch eggs.
 // `egg_hatched_callback` will be called after each egg hatched, with egg index (0-indexed)
 // `already_on_ride`: whether the player character is on ride when starting the function.


### PR DESCRIPTION
Add an option to use the North Province (Area Three) Lighthouse fly point to hatch eggs. This was tested on Switch 2 only, the area (Team Star fairy squad) runs poorly on Switch 1 so it may not work well. Setting requirements remain the same as with Zero Gate (Camera support on, camera normal and not inverted, etc.). To prevent spawns from hopping the fence (this happens frequently enough), the new location will picnic after flying back after each batch of eggs. I'm not sure if always picnicking is faster or slower than resetting during encounters at Zero Gate but at least with this location saving after each batch of eggs won't be required?