### PR TITLE
[linux] ControllerInterface map reworked to a static getter

### DIFF
--- a/SerialPrograms/Source/Controllers/ControllerDescriptor.cpp
+++ b/SerialPrograms/Source/Controllers/ControllerDescriptor.cpp
@@ -21,14 +21,17 @@ namespace PokemonAutomation{
 //
 //  Here we store a map of all controller types in the program.
 //
-std::map<ControllerInterface, std::unique_ptr<InterfaceType>> ALL_CONTROLLER_INTERFACES;
+static std::map<ControllerInterface, std::unique_ptr<InterfaceType>>& all_controller_interfaces(){
+    static std::map<ControllerInterface, std::unique_ptr<InterfaceType>> instance;
+    return instance;
+}
 
 
 void InterfaceType::register_factory(
     ControllerInterface controller_interface,
     std::unique_ptr<InterfaceType> factory
 ){
-    auto ret = ALL_CONTROLLER_INTERFACES.emplace(controller_interface, std::move(factory));
+    auto ret = all_controller_interfaces().emplace(controller_interface, std::move(factory));
     if (!ret.second){
         throw InternalProgramError(
             nullptr, PA_CURRENT_FUNCTION,
@@ -76,7 +79,7 @@ void ControllerOption::load_json(const JsonValue& json){
             break;
         }
 
-        for (const auto& item : ALL_CONTROLLER_INTERFACES){
+        for (const auto& item : all_controller_interfaces()){
             const JsonValue* params = obj->get_value(CONTROLLER_INTERFACE_STRINGS.get_string(item.first));
             if (params == nullptr){
                 continue;


### PR DESCRIPTION
This is a weird fix. When running on Linux, the ControllerInterface map `ALL_CONTROLLER_INTERFACES` was causing weird segfaults during program initialization before even hitting main. Seems like `gcc` on Linux was causing initialization order of static and global variables to not consider initializing some `ControllerInterfaces` before actually storing them or allocating the memory. Anyway, this fixes a big hurdle for Linux support.

NOTE: I haven't tested this on any other compilers or OS's, but the change is pretty minimal since `ALL_CONTROLLER_INTERFACES` is only used with `InterfaceType::register_factory`.