### PR TITLE
macOS: eliminate startup warning

### DIFF
--- a/SerialPrograms/cmake/MacOSXBundleInfo.plist.in
+++ b/SerialPrograms/cmake/MacOSXBundleInfo.plist.in
@@ -32,6 +32,8 @@
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
 	<key>NSCameraUsageDescription</key>
 	<string>The cameras are listed to choose the Switch video stream from the captrue card.</string>
+	<key>NSCameraUseContinuityCameraDeviceType</key>
+	<true/>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>The microphones are listed to choose the Switch audio stream from the captrue card.</string>
 </dict>


### PR DESCRIPTION
to get rid of the following warning:
```
    WARNING: Add NSCameraUseContinuityCameraDeviceType to your Info.plist to use AVCaptureDeviceTypeContinuityCamera.
```