### PR TITLE
Extend purchase arrow detection wait time for languages with longer text

### DIFF
--- a/SerialPrograms/Source/PokemonLZA/Programs/PokemonLZA_ClothingBuyer.cpp
+++ b/SerialPrograms/Source/PokemonLZA/Programs/PokemonLZA_ClothingBuyer.cpp
@@ -80,7 +80,7 @@ void ClothingBuyer::program(SingleSwitchProgramEnvironment& env, ProControllerCo
             FlatWhiteDialogWatcher already_bought(COLOR_RED, &env.console.overlay());
             int ret = wait_until(
                 env.console, context,
-                std::chrono::seconds(3),
+                std::chrono::seconds(30),
                 { buy_yes_no, already_bought }
             );
             switch (ret) {


### PR DESCRIPTION
The purchase prompt appears after the dialog text is fully displayed and takes slightly longer for some languages