### PR TITLE
Update Ut Installer Url

### DIFF
--- a/SerialPrograms/BuildInstructions/Build-Windows-Qt6.8.3.md
+++ b/SerialPrograms/BuildInstructions/Build-Windows-Qt6.8.3.md
@@ -7,13 +7,13 @@
 The installation order here is important. While other orderings may work, this is the specific order that we have tested. And the Qt installation must be the last thing installed.
 
 1. Install Visual Studio 2022:
-    1. [Download Page](https://docs.microsoft.com/en-us/visualstudio/releases/2022/release-notes)
-    2. Make sure you select the C++ development tools.
+   1. [Download Page](https://docs.microsoft.com/en-us/visualstudio/releases/2022/release-notes)
+   2. Make sure you select the C++ development tools.
 2. Install Windows Development SDK:
-    1. [Download Page](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/)
+   1. [Download Page](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/)
 3. Install CMake:
-    1. [Download Page](https://cmake.org/download/)
-    2. When prompted select, "Add CMake to the system PATH for all users".
+   1. [Download Page](https://cmake.org/download/)
+   2. When prompted select, "Add CMake to the system PATH for all users".
 
 ## Install Qt 6.8.3:
 
@@ -23,16 +23,16 @@ Unlike with Qt 5.12, there is no offline installer for it. So you have two optio
 
 If you are ok with creating an account with Qt and using their online installer, then use this method.
 
-1. Download the online installer from here: https://www.qt.io/download-qt-Images/
-3. Select the following options: 
-    - Qt 6.8.3
-        - MSVC 2022 64-bit
-        - Sources
-        - Additional Libraries
-            - Qt Image Formats
-            - Qt Multimedia
-            - Qt Serial Port
-        - Qt Debug Information Files   
+1. Download the online installer from here: https://www.qt.io/download-qt-installer-oss/
+2. Select the following options:
+   - Qt 6.8.3
+     - MSVC 2022 64-bit
+     - Sources
+     - Additional Libraries
+       - Qt Image Formats
+       - Qt Multimedia
+       - Qt Serial Port
+     - Qt Debug Information Files
 
 ![](Images/Windows-Install-Qt6.8.3-Custom.png)
 ![](Images/Windows-Install-Qt6.8.3-Components.png)
@@ -43,12 +43,12 @@ If you repeatedly run into an error involving "SSL handshake failed", you will n
 
 If you are unable or unwilling to use the online installer, the alternative is to copy an installation directly into your system. To do this, you will need to download the installation from us, and copy it into your C drive.
 
-1. Join our [Discord server](https://discord.gg/cQ4gWxN) and ask for the link to the Qt6 standalone. Someone will DM you with a link*.
+1. Join our [Discord server](https://discord.gg/cQ4gWxN) and ask for the link to the Qt6 standalone. Someone will DM you with a link\*.
 2. Download `Qt6.8.3.7z` and decompress it. You can use [7-zip](https://www.7-zip.org/) to decompress it. This will create a folder with the same name.
 3. Move this folder to `C:\`. It will probably ask you for permissions to do it.
 4. Navigate to: `C:\Qt6.8.3\Tools\QtCreator\bin\` and create a shortcut to `qtcreator.exe`. Copy this shortcut to somewhere convenient. (By default this shortcut is named, `Qt Creator 16.0.0 (Community)`)
 
-*This Qt6 standalone file is 3GB in size and is being hosted by our staff for our own developers. We don't want the entire world converging here and overrunning the server.
+\*This Qt6 standalone file is 3GB in size and is being hosted by our staff for our own developers. We don't want the entire world converging here and overrunning the server.
 
 ## Setup:
 
@@ -62,8 +62,8 @@ If you are unable or unwilling to use the online installer, the alternative is t
 5. Click on `File` -> `Open File or Project`.
 6. Navigate to `SerialPrograms` and select `CMakeLists.txt`.
 7. It will then ask you to configure the project. Ensure `Desktop Qt 6.8.3 MSVC2022 64bit` and `Release with Debug Information` are selected.
-    - Ensure the build directory for `Desktop_Qt_6_8_2_MSVC2022_64bit-RelWithDebInfo` is located in the root of the `Arduino-Source` repo, and not buried in subfolders (e.g. `build` or `SerialPrograms`).
-    - Click `Configure Project`.
+   - Ensure the build directory for `Desktop_Qt_6_8_2_MSVC2022_64bit-RelWithDebInfo` is located in the root of the `Arduino-Source` repo, and not buried in subfolders (e.g. `build` or `SerialPrograms`).
+   - Click `Configure Project`.
 
 ![](Images/Windows-configure-project-qt-creator-13.png)
 
@@ -79,13 +79,13 @@ If you are unable or unwilling to use the online installer, the alternative is t
 
 - Click `Projects` on the left sidebar.
 - In `Build directory`, ensure the build directory for `Desktop_Qt_6_8_3_MSVC2022_64bit-RelWithDebInfo` is located in the root of the `Arduino-Source` repo, and not buried in subfolders (e.g. `build` or `SerialPrograms`).
-  - e.g. change the default build directory from:  `Arduino-Source/SerialPrograms/build/Desktop_Qt_6_8_3_MSVC2022_64bit-RelWithDebInfo`
+  - e.g. change the default build directory from: `Arduino-Source/SerialPrograms/build/Desktop_Qt_6_8_3_MSVC2022_64bit-RelWithDebInfo`
     - to: `Arduino-Source/build-SerialPrograms-Desktop_Qt_6_8_3_MSVC2022_64bit-RelWithDebInfo`
-
 
 ## Upgrading Qt components
 
 ### Installing newer Qt version
+
 If you have already have older versions of Qt installed, but need to upgrade Qt components, you can use the Maintenance tool, which comes pre-instaled with Qt (C:\Qt\MaintenanceTool.exe).
 
 - When prompted, in `Maintenance Actions`, choose `Add or remove components`.
@@ -93,15 +93,16 @@ If you have already have older versions of Qt installed, but need to upgrade Qt 
 - Optional: In `Maintenance Actions`, you may also choose `Update components` as well. To update Qt Creator, and other components.
 
 ### Building with the newer Qt version
+
 - Open the `SerialPrograms` project in Qt, as outlined in the "Setup" section above.
 - In the toolbar, click `Edit` -> `Preferences`
 - Under `Kits` tab, choose the newer Qt version (e.g. Desktop Qt 6.8.3)
-<img src="Images/QT-kits.png">
+  <img src="Images/QT-kits.png">
 
 - Under `Compiler`, set it to Microsoft Visual C++ Compiler or Visual Studio, if not already set.
 - Click `Ok`, to save Kits preferences.
 - Click the Monitor symbol at the bottom left
-<img src="Images/QT-kit-build.png">
+  <img src="Images/QT-kit-build.png">
 
 - Under `Kit`: choose the desired Qt version.
 - Under `Build`: choose `Release with Debug Information`
@@ -109,18 +110,17 @@ If you have already have older versions of Qt installed, but need to upgrade Qt 
 - Optional: Move the `UserSettings` folder from the old build folder to the new build folder, to keep your old settings, such as the dev key.
 
 ### Upgrade compiler
+
 - Upgrade the compiler by installing a new version of Visual Studio. Ensure `Desktop development with C++` is checked, so the latest MSVC compiler is also installed.
 - Open the `SerialPrograms` project in Qt, as outlined in the "Setup" section above.
 - In the toolbar, click `Edit` -> `Preferences`
-- Click the `Kits` tab on the left. Then click the `Compilers` tab, click `Re-detect` to refresh the list of compilers. Then click `Apply` in the bottom right. 
+- Click the `Kits` tab on the left. Then click the `Compilers` tab, click `Re-detect` to refresh the list of compilers. Then click `Apply` in the bottom right.
 - Back in the `Kits` tab, your newly installed compilers should now show up in the list of compilers.
 
 When building, if you get the error `yvals_core.h:931: error: STL1001: Unexpected compiler version, expected MSVC 19.42 or newer` (or something similar), consider deleting the old build folder, and rebuilding from scratch.
 
 <hr>
 
-**Discord Server:** 
-
+**Discord Server:**
 
 [<img src="https://canary.discordapp.com/api/guilds/695809740428673034/widget.png?style=banner2">](https://discord.gg/cQ4gWxN)
-


### PR DESCRIPTION
When following the Build Instructions I noticed that the current url (https://www.qt.io/download-qt-Images/) returns a 404.

<img width="1412" height="747" alt="image" src="https://github.com/user-attachments/assets/75343915-3649-441f-b337-0b19419a3245" />

Without knowing exactly what this page was for, my best guess was the following url (https://www.qt.io/download-qt-installer-oss)

<img width="1433" height="740" alt="image" src="https://github.com/user-attachments/assets/a46052bb-906e-48f8-a083-8f7a004d7358" />

Successfully installed qt 6.8.3, built from latest, and currently running LZA Restaurant Farmer. 

I know the new wiki exists however, it currently points to this md file and I didn't see a replacement for it in the new repo. If this needs to move to the new repo just let me know.