### PR TITLE
constexpr compile fix

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Programs/AutoStory/PokemonSV_AutoStory_Segment_34.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/AutoStory/PokemonSV_AutoStory_Segment_34.h
@@ -26,24 +26,22 @@ public:
     ) const override;
 };
 
-static constexpr std::string segment_num = "34";
+static constexpr const char* segment_num = "34";
 
-
-
-inline std::string checkpoint90_start(){ return segment_num + ": Beat Geeta. At Pokemon League Pokecenter.";}
-inline std::string checkpoint90_end(){ return segment_num + ": Beat Nemona. At dormitory room, next to bed.";}
+inline std::string checkpoint90_start(){ return std::string(segment_num) + ": Beat Geeta. At Pokemon League Pokecenter.";}
+inline std::string checkpoint90_end(){ return std::string(segment_num) + ": Beat Nemona. At dormitory room, next to bed.";}
 // start: Beat Geeta. At Pokemon League Pokecenter.
 // end: Beat Nemona. At dormitory room, next to bed.
 void checkpoint_90(SingleSwitchProgramEnvironment& env, ProControllerContext& context, EventNotificationOption& notif_status_update, AutoStoryStats& stats);
 
 inline std::string checkpoint91_start(){ return checkpoint90_end();}
-inline std::string checkpoint91_end(){ return segment_num + ": Beat Penny. At Academy fly point.";}
+inline std::string checkpoint91_end(){ return std::string(segment_num) + ": Beat Penny. At Academy fly point.";}
 // start: Beat Nemona. At dormitory room, next to bed."
 // end: Beat Penny. At Academy fly point.
 void checkpoint_91(SingleSwitchProgramEnvironment& env, ProControllerContext& context, EventNotificationOption& notif_status_update, AutoStoryStats& stats);
 
 inline std::string checkpoint92_start(){ return checkpoint91_end();}
-inline std::string checkpoint92_end(){ return segment_num + ": Beat Arven. At Los Platos Pokecenter.";}
+inline std::string checkpoint92_end(){ return std::string(segment_num) + ": Beat Arven. At Los Platos Pokecenter.";}
 // start: Beat Penny. At Academy fly point.
 // end: Beat Arven. At Los Platos Pokecenter.
 void checkpoint_92(SingleSwitchProgramEnvironment& env, ProControllerContext& context, EventNotificationOption& notif_status_update, AutoStoryStats& stats);


### PR DESCRIPTION
A small change to fix the compile for the older Clang version used by the GitHub MacOS runner