### PR TITLE
Added non-template constructor

### DIFF
--- a/SerialPrograms/Source/CommonTools/VisualDetector.h
+++ b/SerialPrograms/Source/CommonTools/VisualDetector.h
@@ -42,6 +42,17 @@ public:
         CONSISTENT, //  process_frame() returns true when detected consecutively or not detected consecutively
     };
 
+    DetectorToFinder(
+        std::string label,
+        std::chrono::milliseconds duration
+    )
+        : Detector()
+        , VisualInferenceCallback(std::move(label))
+        , m_duration(duration)
+        , m_finder_type(FinderType::PRESENT)
+    {}
+    
+
     template <class... Args>
     DetectorToFinder(
         std::string label,

--- a/SerialPrograms/Source/PokemonLZA/Inference/PokemonLZA_ButtonDetector.h
+++ b/SerialPrograms/Source/PokemonLZA/Inference/PokemonLZA_ButtonDetector.h
@@ -7,6 +7,7 @@
 #ifndef PokemonAutomation_PokemonLZA_ButtonDetector_H
 #define PokemonAutomation_PokemonLZA_ButtonDetector_H
 
+#include <optional>
 #include "CommonFramework/VideoPipeline/VideoOverlayScopes.h"
 #include "CommonTools/ImageMatch/WaterfillTemplateMatcher.h"
 #include "CommonTools/VisualDetector.h"


### PR DESCRIPTION
Compile issue on MacOS x86 runners. The DetectorToFinder constructors in PLZA files pass in more arguments and the constructor cannot be matched. Adding in a base constructor resolves the lookup to match the constructor to the correct template