### PR TITLE
Continue bench resets if unable to save

### DIFF
--- a/SerialPrograms/Source/PokemonLZA/Programs/PokemonLZA_BasicNavigation.cpp
+++ b/SerialPrograms/Source/PokemonLZA/Programs/PokemonLZA_BasicNavigation.cpp
@@ -27,7 +27,7 @@ namespace PokemonLZA{
 
 
 
-void save_game_to_menu(ConsoleHandle& console, ProControllerContext& context){
+bool save_game_to_menu(ConsoleHandle& console, ProControllerContext& context){
 
     bool seen_save_button = false;
     bool seen_saved_dialog = false;
@@ -59,9 +59,9 @@ void save_game_to_menu(ConsoleHandle& console, ProControllerContext& context){
             std::chrono::seconds(30),
             {
                 overworld,
+                dialog,
                 main_menu,
                 save_button,
-                dialog,
             }
         );
         context.wait_for(100ms);
@@ -71,21 +71,27 @@ void save_game_to_menu(ConsoleHandle& console, ProControllerContext& context){
             pbf_press_button(context, BUTTON_X, 160ms, 240ms);
             continue;
         case 1:
-            console.log("Detected main menu...");
-            if (seen_save_button && seen_saved_dialog){
-                return;
-            }
-            pbf_press_button(context, BUTTON_R, 160ms, 240ms);
-            continue;
-        case 2:
-            console.log("Detected save button...");
-            seen_save_button = true;
-            pbf_press_button(context, BUTTON_A, 160ms, 240ms);
-            continue;
-        case 3:
+            if (!seen_save_button){
+                console.log("Detected dialog before save prompt. Unable to save.", COLOR_RED);
+                pbf_press_button(context, BUTTON_B, 160ms, 240ms);
+                return false;
+			}
+
             console.log("Detected dialog...");
             seen_saved_dialog = true;
             pbf_press_button(context, BUTTON_B, 160ms, 240ms);
+            continue;
+        case 2:
+            console.log("Detected main menu...");
+            if (seen_save_button && seen_saved_dialog){
+                return true;
+            }
+            pbf_press_button(context, BUTTON_R, 160ms, 240ms);
+            continue;
+        case 3:
+            console.log("Detected save button...");
+            seen_save_button = true;
+            pbf_press_button(context, BUTTON_A, 160ms, 240ms);
             continue;
         }
     }

--- a/SerialPrograms/Source/PokemonLZA/Programs/PokemonLZA_BasicNavigation.h
+++ b/SerialPrograms/Source/PokemonLZA/Programs/PokemonLZA_BasicNavigation.h
@@ -24,7 +24,8 @@ namespace PokemonLZA{
 
 //  Starting from either the overworld or the main menu, save the game.
 //  This function returns in the main menu.
-void save_game_to_menu(ConsoleHandle& console, ProControllerContext& context);
+//  Return true if the game is saved successfully, false otherwise.
+bool save_game_to_menu(ConsoleHandle& console, ProControllerContext& context);
 
 
 

--- a/SerialPrograms/Source/PokemonLZA/Programs/ShinyHunting/PokemonLZA_ShinyHunt_BenchSit.cpp
+++ b/SerialPrograms/Source/PokemonLZA/Programs/ShinyHunting/PokemonLZA_ShinyHunt_BenchSit.cpp
@@ -184,9 +184,14 @@ void ShinyHunt_BenchSit::program(SingleSwitchProgramEnvironment& env, ProControl
 
                 uint32_t periodic_save = PERIODIC_SAVE;
                 if (periodic_save != 0 && rounds_since_last_save >= periodic_save) {
-                    save_game_to_menu(env.console, context);
+                    bool save_successful = save_game_to_menu(env.console, context);
                     pbf_mash_button(context, BUTTON_B, 2000ms);
-                    rounds_since_last_save = 0;
+                    if (save_successful) {
+                        env.console.overlay().add_log("Game Saved Successfully", COLOR_BLUE);
+                        rounds_since_last_save = 0;
+                    } else {
+                        env.console.overlay().add_log("Game Save Failed. Will attempt to save after the next reset.", COLOR_RED);
+					}
                 }
 
                 Milliseconds duration = WALK_FORWARD_DURATION;

--- a/SerialPrograms/Source/PokemonLZA/Programs/ShinyHunting/PokemonLZA_ShinyHunt_BenchSit.cpp
+++ b/SerialPrograms/Source/PokemonLZA/Programs/ShinyHunting/PokemonLZA_ShinyHunt_BenchSit.cpp
@@ -88,7 +88,7 @@ ShinyHunt_BenchSit::ShinyHunt_BenchSit()
     )
     , PERIODIC_SAVE(
         "<b>Periodically Save:</b><br>"
-        "Save the game every this many bench sits. This reduces the loss to game crashes. Set to zero to disable.",
+        "Save the game every this many bench sits. This reduces the loss to game crashes. Set to zero to disable. Saving will be unsuccessful if you are under attack",
         LockMode::UNLOCK_WHILE_RUNNING,
         100,
         0
@@ -181,6 +181,14 @@ void ShinyHunt_BenchSit::program(SingleSwitchProgramEnvironment& env, ProControl
                 shiny_sound_handler.process_pending(context);
                 stats.resets++;
                 env.update_stats();
+
+                uint32_t periodic_save = PERIODIC_SAVE;
+                if (periodic_save != 0 && rounds_since_last_save >= periodic_save) {
+                    save_game_to_menu(env.console, context);
+                    pbf_mash_button(context, BUTTON_B, 2000ms);
+                    rounds_since_last_save = 0;
+                }
+
                 Milliseconds duration = WALK_FORWARD_DURATION;
                 if (duration > Milliseconds::zero()){
                     if (WALK_DIRECTION.current_value() == 0){ // forward
@@ -212,13 +220,6 @@ void ShinyHunt_BenchSit::program(SingleSwitchProgramEnvironment& env, ProControl
                 }
 
                 shiny_sound_handler.process_pending(context);
-
-                uint32_t periodic_save = PERIODIC_SAVE;
-                if (periodic_save != 0 && rounds_since_last_save >= periodic_save) {
-                    save_game_to_menu(env.console, context);
-                    pbf_mash_button(context, BUTTON_B, 2000ms);
-                    rounds_since_last_save = 0;
-                }
             }
         },
         {shiny_detector}


### PR DESCRIPTION
Saving is disabled when under attack. 

Added logic to detect when unable to save.
Return bool to state if save was successful.

Moved save timing to be immediately after loading screen to reduce chances of being attacked.