### PR TITLE
Fixed Detection of Poke

### DIFF
--- a/SerialPrograms/Source/PokemonLZA/Options/PokemonLZA_DonutBerriesOption.cpp
+++ b/SerialPrograms/Source/PokemonLZA/Options/PokemonLZA_DonutBerriesOption.cpp
@@ -212,7 +212,7 @@ std::string FlavorPowerTableEntry::to_str() const{
             selected_power += "treasure-";
             break;
         case Power_Item_Types::pokeballs:
-            selected_power += "poke-balls-";
+            selected_power += "poké-balls-";
             break;
         case Power_Item_Types::special:
             selected_power += "special-";


### PR DESCRIPTION
A couple users reported that Poke Ball item power was not being detected, ocr returns "poké", but was compared to "poke"