### PR TITLE
Decreased Retry Threshold Entering Hotel Z

### DIFF
--- a/SerialPrograms/Source/PokemonLZA/Programs/Farming/PokemonLZA_DonutMaker.cpp
+++ b/SerialPrograms/Source/PokemonLZA/Programs/Farming/PokemonLZA_DonutMaker.cpp
@@ -470,7 +470,7 @@ void move_to_ansha(SingleSwitchProgramEnvironment& env, ProControllerContext& co
     WallClock end_time = current_time();
     const auto duration = end_time - start_time;
     // Due to day/night change may eating the mashing button A sequence, we may still be outside the hotel!
-    if (duration >= 16s){
+    if (duration >= 10s){
         // mash A again to make sure we are inside the hotel
         pbf_mash_button(context, BUTTON_A, Seconds(2));
         context.wait_for_all_requests();


### PR DESCRIPTION
Decreased time required for retrying Hotel Z entrance. On Switch 2 and on the shorter ~~day to night~~ night to day transition, this was observed:

```
2026-01-05 01:51:13.677580 - [Console 0]: Detected button A. Reached gate.
2026-01-05 01:51:13.677600 - [Console 0]: issue_mash_button(): A, duration = 2000ms
2026-01-05 01:51:14.712895 - [Console 0]: wait_for_all()
2026-01-05 01:51:14.712912 - [Console 0]: Waiting for all requests to finish...
2026-01-05 01:51:17.392200 - [Console 0]: ConvertFrame: Count = 159, Mean = 3.90166ms, Stddev = 0.650444ms, Min = 3.141ms, Max = 8.192ms
2026-01-05 01:51:27.091632 - [Console 0]: DirectionArrowWatcher: Count = 226, Mean = 0.0934867 ms, Stddev = 0.016294 ms, Min = 0.073 ms, Max = 0.238 ms
2026-01-05 01:51:27.091646 - [Console 0]: OverworldPartySelectionWatcher: Count = 227, Mean = 0.1877 ms, Stddev = 0.0242154 ms, Min = 0.151 ms, Max = 0.247 ms
2026-01-05 01:51:27.091659 - [Console 0]: Detected overworld within 50000 milliseconds
2026-01-05 01:51:27.198428 - [Console 0]: Detected overworld after entering zone.
2026-01-05 01:51:27.198468 - [Console 0]: issue_buttons(): Y, delay = 1100ms, hold = 100ms, cooldown = 0ms
2026-01-05 01:51:27.198474 - [Console 0]: issue_buttons(): Y, delay = 1100ms, hold = 100ms, cooldown = 0ms
2026-01-05 01:51:27.198526 - [Console 0]: issue_left_joystick(): (-1.000,0.000), delay = 600ms, hold = 500ms, cooldown = 0ms
2026-01-05 01:51:27.198530 - [Console 0]: wait_for_all()
```

The 16 second threshold to retry the mash is not short enough to flag the day night transition if it happens before the player is able to enter Hotel Z