### PR TITLE
Fix Hyperspace Cobalion shiny check

### DIFF
--- a/SerialPrograms/Source/PokemonLZA/Programs/ShinyHunting/PokemonLZA_ShinyHunt_HyperspaceLegendary.cpp
+++ b/SerialPrograms/Source/PokemonLZA/Programs/ShinyHunting/PokemonLZA_ShinyHunt_HyperspaceLegendary.cpp
@@ -179,7 +179,8 @@ void hunt_cobalion(
     stats.spawns++;
     env.update_stats();
     // run forward to trigger potential shiny sound
-    pbf_move_left_joystick(context, {0, +1}, 4500ms, 0ms); 
+    pbf_move_left_joystick(context, {0, +1}, 5000ms, 0ms); 
+    pbf_wait(context, 500ms);
 
     context.wait_for_all_requests();
 }


### PR DESCRIPTION
The route for checking for shininess now runs forward a little bit further, based on a report from L Aj