### PR TITLE
Actually fix Cobalion shiny check

### DIFF
--- a/SerialPrograms/Source/PokemonLZA/Programs/ShinyHunting/PokemonLZA_ShinyHunt_HyperspaceLegendary.cpp
+++ b/SerialPrograms/Source/PokemonLZA/Programs/ShinyHunting/PokemonLZA_ShinyHunt_HyperspaceLegendary.cpp
@@ -343,13 +343,14 @@ void hunt_cobalion(
 
     // run right to line up with Cobalion
     ssf_press_button(context, BUTTON_B, 0ms, 6000ms, 0ms);
-    pbf_move_left_joystick(context, {+1, 0}, 8370ms, 0ms);
+    pbf_move_left_joystick(context, {+1, 0}, 8200ms, 0ms);
     context.wait_for_all_requests();
     stats.spawns++;
     env.update_stats();
     // run forward to trigger potential shiny sound
+    pbf_wait(context, 100ms);
     ssf_press_button(context, BUTTON_B, 0ms, 3000ms, 0ms);
-    pbf_move_left_joystick(context, {0, +1}, 4500ms, 0ms);
+    pbf_move_left_joystick(context, {0, +1}, 4800ms, 0ms);
     pbf_wait(context, 500ms);
 
     context.wait_for_all_requests();


### PR DESCRIPTION
The addition of the `context.wait_for_all_requests()` had broken part of the route for checking Cobalion by changing the last part of the route from a sprint to a walk, which is probably what was responsible for some [reports ](https://discord.com/channels/695809740428673034/1435100073406103562/1460109084702543934) of [problems](https://discord.com/channels/695809740428673034/1435100073406103562/1460678550557425734) with the beta release.

The attempted fix in #1026 probably didn't help, but this one will basically return things to the route that I originally tested. 

I won't be able to retest shiny sound detection, but I can re-check the route once I have some time to roll the correct Hyperspace map.