### PR TITLE
Refactor Logger Code

### DIFF
--- a/Common/Cpp/Filesystem.h
+++ b/Common/Cpp/Filesystem.h
@@ -97,6 +97,17 @@ public:
     Path stem() const{
         return m_path.stem();
     }
+    //  Return the extension of the filename component.
+    //  "/foo/bar.txt" -> ".txt"
+    //  "/foo/bar." -> "."
+    //  "/foo/bar" -> ""
+    //  "/foo/.bar" -> ""
+    //  "/foo/..bar" -> ".bar"
+    //  "/foo/." -> ""
+    //  "/foo/.." -> ""
+    Path extension() const{
+        return m_path.extension();
+    }
 
 public:
     Path& replace_extension(const Path& replacement){
@@ -140,6 +151,30 @@ inline auto remove_all(const Path& path){
 //  Copy a file.
 inline bool copy_file(const Path& from, const Path& to){
     return std::filesystem::copy_file(from.stdpath(), to.stdpath());
+}
+
+//  Return the size of a file in bytes.
+//  Throw std::filesystem::filesystem_error on underlying OS API errors
+inline std::uintmax_t file_size(const Path& path){
+    return std::filesystem::file_size(path.stdpath());
+}
+
+//  Return the size of a file in bytes.
+//  If an error occurs, set `ec`. Execute `ec.clear()` if no errors occur.
+inline std::uintmax_t file_size(const Path& path, std::error_code& ec){
+    return std::filesystem::file_size(path.stdpath(), ec);
+}
+
+//  Rename a file or directory.
+//  Throw std::filesystem::filesystem_error on underlying OS API errors
+inline void rename(const Path& old_path, const Path& new_path){
+    std::filesystem::rename(old_path.stdpath(), new_path.stdpath());
+}
+
+//  Rename a file or directory.
+//  If an error occurs, set `ec`. Execute `ec.clear()` if no errors occur.
+inline void rename(const Path& old_path, const Path& new_path, std::error_code& ec){
+    std::filesystem::rename(old_path.stdpath(), new_path.stdpath(), ec);
 }
 
 

--- a/Common/Cpp/Logging/FileLogger.cpp
+++ b/Common/Cpp/Logging/FileLogger.cpp
@@ -1,0 +1,201 @@
+/*  File Logger
+ *
+ *  From: https://github.com/PokemonAutomation/
+ *
+ */
+
+#include "Common/Cpp/Filesystem.h"
+#include "Common/Cpp/PrettyPrint.h"
+#include "FileLogger.h"
+#include <iostream>
+
+namespace PokemonAutomation{
+
+
+FileLogger::~FileLogger(){
+    {
+        std::lock_guard<std::mutex> lg(m_lock);
+        m_stopping = true;
+        m_cv.notify_all();
+    }
+    m_thread.join();
+}
+
+FileLogger::FileLogger(FileLoggerConfig config)
+    : m_config(std::move(config))
+    , m_last_log_tracker(m_config.last_log_max_lines)
+    , m_stopping(false)
+{
+    Filesystem::Path file_path(m_config.file_path);
+    bool exists = Filesystem::exists(file_path);
+    m_file.open(file_path, std::ios::out | std::ios::app | std::ios::binary);
+
+    if (!exists && m_file.is_open()){
+        // Write UTF-8 BOM to new files
+        const char bom[] = "\xef\xbb\xbf";
+        m_file.write(bom, 3);
+        std::cout << "Write log to new file " << file_path << std::endl;
+    }else{
+        std::cout << "Write log to existing file " << file_path << std::endl;
+    }
+
+    m_thread = Thread([this]{
+        thread_loop();
+    });
+}
+
+void FileLogger::add_listener(Listener& listener){
+    m_listeners.add(listener);
+}
+
+void FileLogger::remove_listener(Listener& listener){
+    m_listeners.remove(listener);
+}
+
+void FileLogger::log(const std::string& msg, Color color){
+    std::unique_lock<std::mutex> lg(m_lock);
+    m_last_log_tracker += msg;
+    m_cv.wait(lg, [this]{ return m_queue.size() < m_config.max_queue_size; });
+    m_queue.emplace_back(msg, color);
+    m_cv.notify_all();
+}
+
+void FileLogger::log(std::string&& msg, Color color){
+    std::unique_lock<std::mutex> lg(m_lock);
+    m_last_log_tracker += msg;
+    m_cv.wait(lg, [this]{ return m_queue.size() < m_config.max_queue_size; });
+    m_queue.emplace_back(std::move(msg), color);
+    m_cv.notify_all();
+}
+
+std::vector<std::string> FileLogger::get_last() const{
+    std::unique_lock<std::mutex> lg(m_lock);
+    return m_last_log_tracker.snapshot();
+}
+
+std::string FileLogger::normalize_newlines(const std::string& msg){
+    std::string str;
+    size_t index = 0;
+
+    while (true){
+        auto pos = msg.find("\r\n", index);
+        if (pos == std::string::npos){
+            str += msg.substr(index, pos);
+            break;
+        }else{
+            str += msg.substr(index, pos - index);
+            str += "\n";
+            index = pos + 2;
+        }
+    }
+
+    if (!str.empty() && str.back() == '\n'){
+        str.pop_back();
+    }
+
+    return str;
+}
+
+std::string FileLogger::to_file_str(const std::string& msg){
+    // Replace all newlines with \r\n for the log file (Windows compatibility).
+    std::string str;
+    for (char ch : msg){
+        if (ch == '\n'){
+            str += "\r\n";
+            continue;
+        }
+        str += ch;
+    }
+    str += "\r\n";
+    return str;
+}
+
+void FileLogger::internal_log(const std::string& msg, Color color){
+    std::string line = normalize_newlines(msg);
+
+    // Notify all listeners (e.g., UI windows)
+    m_listeners.run_method(&Listener::on_log, line, color);
+
+    // Write to file
+    if (m_file.is_open()){
+        std::string file_str = to_file_str(line);
+        m_file.write(file_str.c_str(), file_str.size());
+        // Flush every time so if the program crashes we will still have the latest log in the log file
+        m_file.flush();
+    }
+}
+
+void FileLogger::thread_loop(){
+    size_t file_size_check_counter = 100;
+    std::unique_lock<std::mutex> lg(m_lock);
+    while (true){
+        m_cv.wait(lg, [&]{
+            return m_stopping || !m_queue.empty();
+        });
+        if (m_stopping){
+            break;
+        }
+        auto& item = m_queue.front();
+        std::string msg = std::move(item.first);
+        Color color = item.second;
+        m_queue.pop_front();
+
+        lg.unlock();
+        if (++file_size_check_counter >= 100){
+            file_size_check_counter = 0;
+            // We call Filesystem::file_size() to check file size, which may be slow.
+            // So we only check every 100 lines.
+            // The counter is initialized to be 100 so we always have a check at start
+            // of the program so if the log file becomes too large from a previous session
+            // we will be able to rotate it.
+            rotate_log_file();
+        }
+        internal_log(msg, color);
+        lg.lock();
+
+        if (m_queue.size() <= m_config.max_queue_size / 2){
+            m_cv.notify_all();
+        }
+    }
+}
+
+void FileLogger::rotate_log_file(){
+    if (!m_file.is_open()){
+        return;
+    }
+
+    // Check file size
+    Filesystem::Path file_path(m_config.file_path);
+    std::error_code ec;
+    auto size = Filesystem::file_size(file_path, ec);
+    if (ec || size < m_config.max_file_size_bytes){
+        return;
+    }
+
+    // Close current file
+    m_file.close();
+
+    // Generate backup filename: <basename>-<timestamp>.log
+    std::string stem = file_path.stem().string();
+    std::string extension = file_path.extension().string();
+
+    std::string backup_filename = stem + "-" + now_to_filestring() + extension;
+    Filesystem::Path backup_path = file_path.parent_path() / Filesystem::Path(backup_filename);
+
+    // Rename current file to backup
+    Filesystem::rename(file_path, backup_path, ec);
+    if (ec){
+        std::cerr << "Failed to rename log file: " << ec.message() << std::endl;
+    }
+
+    // Re-open the file (creates a new, empty file)
+    bool exists = Filesystem::exists(file_path);
+    m_file.open(file_path, std::ios::out | std::ios::app | std::ios::binary);
+    if (!exists && m_file.is_open()){
+        const char bom[] = "\xef\xbb\xbf";
+        m_file.write(bom, 3);
+    }
+}
+
+
+}

--- a/Common/Cpp/Logging/FileLogger.h
+++ b/Common/Cpp/Logging/FileLogger.h
@@ -1,0 +1,110 @@
+/*  File Logger
+ *
+ *  From: https://github.com/PokemonAutomation/
+ *
+ *  A Qt-free file logger that writes log messages to a file with optional
+ *  log rotation. Supports listeners for UI integration (e.g., displaying
+ *  logs in a Qt window without coupling the core logger to Qt).
+ */
+
+#ifndef PokemonAutomation_Logging_FileLogger_H
+#define PokemonAutomation_Logging_FileLogger_H
+
+#include <deque>
+#include <fstream>
+#include <mutex>
+#include <condition_variable>
+#include "AbstractLogger.h"
+#include "Common/Cpp/Concurrency/Thread.h"
+#include "Common/Cpp/ListenerSet.h"
+#include "LastLogTracker.h"
+
+namespace PokemonAutomation{
+
+
+// Configuration for the FileLogger.
+struct FileLoggerConfig{
+    std::string file_path;                          // Path to the log file, assuming UTF-8
+    size_t max_queue_size = 10000;                  // Max pending log entries before blocking
+    size_t max_file_size_bytes = 50 * 1024 * 1024;  // Max file size before rotation (50MB default)
+    size_t last_log_max_lines = 10000;              // Max lines to keep in memory for get_last()
+};
+
+
+// A Qt-free file logger that:
+// 1. Writes log messages to a file asynchronously via a background thread
+// 2. Supports log rotation when the file exceeds a configured size
+// 3. Notifies registered listeners when a log message is written (for UI integration)
+// 4. Keeps track of recent log lines for retrieval via get_last()
+//
+// The Listener interface allows Qt GUI components to receive log messages
+// without the core logger depending on Qt.
+class FileLogger : public Logger{
+public:
+    // Listener interface for receiving log messages.
+    // Implement this to integrate with UI components (e.g., QTextEdit).
+    struct Listener{
+        // Called when a log message is written. This is called from the
+        // logger's background thread, so implementations must handle
+        // thread safety (e.g., using Qt signals/slots for cross-thread updates).
+        //
+        // Parameters:
+        //   msg: The log message with newlines normalized (no \r\n, just \n)
+        //   color: Optional color for the message
+        virtual void on_log(const std::string& msg, Color color) = 0;
+    };
+
+public:
+    ~FileLogger();
+
+    // Construct a FileLogger with the given configuration.
+    // The log file is created if it doesn't exist, or appended to if it does.
+    // A UTF-8 BOM is written to new files.
+    FileLogger(FileLoggerConfig config);
+
+    // Add a listener to receive log messages. Thread-safe.
+    void add_listener(Listener& listener);
+
+    // Remove a listener. Thread-safe.
+    void remove_listener(Listener& listener);
+
+    // Logger interface implementation
+    virtual void log(const std::string& msg, Color color = Color()) override;
+    virtual void log(std::string&& msg, Color color = Color()) override;
+    virtual std::vector<std::string> get_last() const override;
+
+private:
+    // Normalize newlines: convert \r\n to \n, remove trailing newline.
+    static std::string normalize_newlines(const std::string& msg);
+
+    // Convert message to file format (with \r\n line endings for Windows compatibility).
+    static std::string to_file_str(const std::string& msg);
+
+    // Internal log processing (called from background thread).
+    void internal_log(const std::string& msg, Color color);
+
+    // Background thread loop that processes the log queue.
+    void thread_loop();
+
+    // Rotate the log file if it exceeds the configured max size.
+    // Renames the current file to "<basename>-<timestamp>.log" and creates a new file.
+    void rotate_log_file();
+
+private:
+    FileLoggerConfig m_config;
+    std::ofstream m_file;
+    std::string m_current_file_size_approx;  // Approximate file size for rotation check
+
+    mutable std::mutex m_lock;
+    std::condition_variable m_cv;
+    LastLogTracker m_last_log_tracker;
+    bool m_stopping;
+    std::deque<std::pair<std::string, Color>> m_queue;
+
+    ListenerSet<Listener> m_listeners;
+    Thread m_thread;
+};
+
+
+}
+#endif

--- a/SerialPrograms/Source/CommonFramework/Logging/FileWindowLogger.cpp
+++ b/SerialPrograms/Source/CommonFramework/Logging/FileWindowLogger.cpp
@@ -7,7 +7,6 @@
 #include <QCoreApplication>
 #include <QMenuBar>
 #include <QDir>
-#include "Common/Cpp/PrettyPrint.h"
 #include "CommonFramework/Globals.h"
 #include "CommonFramework/GlobalSettingsPanel.h"
 #include "CommonFramework/Windows/DpiScaler.h"
@@ -31,117 +30,64 @@ Logger& global_logger_raw(){
         }
         return USER_FILE_PATH() + (application_name + ".log").toStdString();
     };
-    
-    static FileWindowLogger logger(get_log_filepath());
+
+    static FileWindowLogger logger(get_log_filepath(), LOG_HISTORY_LINES);
     return logger;
 }
 
 
 FileWindowLogger::~FileWindowLogger(){
-    {
-        std::lock_guard<std::mutex> lg(m_lock);
-        m_stopping = true;
-        m_cv.notify_all();
-    }
-    m_thread.join();
+    m_file_logger.remove_listener(*this);
 }
-FileWindowLogger::FileWindowLogger(const std::string& path)
-    : m_file(QString::fromStdString(path))
-    , m_max_queue_size(LOG_HISTORY_LINES)
-    , m_stopping(false)
-{
-    bool exists = m_file.exists();
-    bool opened = m_file.open(QIODevice::WriteOnly | QIODevice::Append);
-    if (!exists && opened){
-        std::string bom = "\xef\xbb\xbf";
-        m_file.write(bom.c_str(), bom.size());
-        cout << "Write log to new file " << path << endl;
-    }else{
-        cout << "Write log to existing file " << path << endl;
-    }
 
-    m_thread = Thread([this]{
-        thread_loop();
-    });
+FileWindowLogger::FileWindowLogger(const std::string& path, size_t max_queue_size)
+    : m_file_logger(FileLoggerConfig{
+        .file_path = path,
+        .max_queue_size = max_queue_size,
+        .max_file_size_bytes = 50 * 1024 * 1024,  // 50MB
+        .last_log_max_lines = max_queue_size,
+    })
+{
+    m_file_logger.add_listener(*this);
 }
+
 void FileWindowLogger::operator+=(FileWindowLoggerWindow& widget){
-//    auto scope_check = m_sanitizer.check_scope();
-    std::lock_guard<std::mutex> lg(m_lock);
+    std::lock_guard<std::mutex> lg(m_window_lock);
     m_windows.insert(&widget);
 }
+
 void FileWindowLogger::operator-=(FileWindowLoggerWindow& widget){
-//    auto scope_check = m_sanitizer.check_scope();
-    std::lock_guard<std::mutex> lg(m_lock);
+    std::lock_guard<std::mutex> lg(m_window_lock);
     m_windows.erase(&widget);
 }
 
 void FileWindowLogger::log(const std::string& msg, Color color){
-//    auto scope_check = m_sanitizer.check_scope();
-    std::unique_lock<std::mutex> lg(m_lock);
-    m_last_log_tracker += msg;
-    m_cv.wait(lg, [this]{ return m_queue.size() < m_max_queue_size; });
-    m_queue.emplace_back(msg, color);
-    m_cv.notify_all();
+    m_file_logger.log(msg, color);
 }
+
 void FileWindowLogger::log(std::string&& msg, Color color){
-//    auto scope_check = m_sanitizer.check_scope();
-    std::unique_lock<std::mutex> lg(m_lock);
-    m_last_log_tracker += msg;
-    m_cv.wait(lg, [this]{ return m_queue.size() < m_max_queue_size; });
-    m_queue.emplace_back(std::move(msg), color);
-    m_cv.notify_all();
+    m_file_logger.log(std::move(msg), color);
 }
+
 std::vector<std::string> FileWindowLogger::get_last() const{
-//    auto scope_check = m_sanitizer.check_scope();
-    std::unique_lock<std::mutex> lg(m_lock);
-    return m_last_log_tracker.snapshot();
+    return m_file_logger.get_last();
 }
 
-
-std::string FileWindowLogger::normalize_newlines(const std::string& msg){
-    std::string str;
-    size_t index = 0;
-
-    while (true){
-        auto pos = msg.find("\r\n", index);
-        if (pos == std::string::npos){
-            str += msg.substr(index, pos);
-            break;
-        }else{
-            str += msg.substr(index, pos);
-            str += "\n";
-            index = pos + 2;
+void FileWindowLogger::on_log(const std::string& msg, Color color){
+    // This is called from FileLogger's background thread.
+    // Format the message for Qt display and send to all windows.
+    std::lock_guard<std::mutex> lg(m_window_lock);
+    if (!m_windows.empty()){
+        QString str = to_window_str(msg, color);
+        for (FileWindowLoggerWindow* window : m_windows){
+            window->log(str);
         }
     }
-
-    if (!str.empty() && str.back() == '\n'){
-        str.pop_back();
-    }
-
-    return str;
 }
-std::string FileWindowLogger::to_file_str(const std::string& msg){
-    //  Replace all newlines with:
-    //      <br>    for the output window.
-    //      \r\n    for the log file.
 
-    std::string str;
-    for (char ch : msg){
-        if (ch == '\n'){
-            str += "\r\n";
-            continue;
-        }
-        str += ch;
-    }
-    str += "\r\n";
-
-    return str;
-}
 QString FileWindowLogger::to_window_str(const std::string& msg, Color color){
-    //  Replace all newlines with:
-    //      <br>    for the output window.
-    //      \r\n    for the log file.
-
+    // Convert message to HTML for display in QTextEdit.
+    // Replace spaces with &nbsp; and newlines with <br>.
     std::string str;
     if (color){
         str += "<font color=\"" + QColor((uint32_t)color).name().toStdString() + "\">";
@@ -159,89 +105,10 @@ QString FileWindowLogger::to_window_str(const std::string& msg, Color color){
         }
         str += ch;
     }
-//    if (color){
-        str += "</font>";
-//    }
+    str += "</font>";
 
     return QString::fromStdString(str);
 }
-void FileWindowLogger::internal_log(const std::string& msg, Color color){
-//    auto scope_check = m_sanitizer.check_scope();
-    std::string line = normalize_newlines(msg);
-    {
-        if (!m_windows.empty()){
-            QString str = to_window_str(line, color);
-            for (FileWindowLoggerWindow* window : m_windows){
-                window->log(str);
-            }
-        }
-    }
-    {
-        m_file.write(to_file_str(msg).c_str());
-        m_file.flush();
-    }
-}
-void FileWindowLogger::thread_loop(){
-//    auto scope_check = m_sanitizer.check_scope();
-    std::unique_lock<std::mutex> lg(m_lock);
-    while (true){
-        m_cv.wait(lg, [&]{
-            return m_stopping || !m_queue.empty();
-        });
-        if (m_stopping){
-            break;
-        }
-        auto& item = m_queue.front();
-        std::string msg = std::move(item.first);
-        Color color = item.second;
-        m_queue.pop_front();
-
-        lg.unlock();
-        rotate_log_file();
-        internal_log(msg, color);
-        lg.lock();
-
-        if (m_queue.size() <= m_max_queue_size / 2){
-            m_cv.notify_all();
-        }
-    }
-}
-
-void FileWindowLogger::rotate_log_file(){
-
-    static const qint64 max_size = 1024 * 1024 * 50;
-    if (m_file.size() < max_size){
-        return;
-    }
-
-    if (m_file.isOpen()) {
-        m_file.close();
-    }
-
-    QString log_name = QString::fromStdString(USER_FILE_PATH() + QCoreApplication::applicationName().toStdString() + ".log");
-    QString backup_log_name = QString::fromStdString(USER_FILE_PATH() + QCoreApplication::applicationName().toStdString() + "-" + now_to_filestring() + ".log");
-    if (QFile::exists(log_name)) {
-        bool success = QFile::rename(log_name, backup_log_name);  // rename SerialPrograms.log to SerialPrograms-[date].log
-        if (!success) {
-            // TODO: Handle error (e.g., file locked by another process)
-        }
-    }
-
-    // Re-open the file (this creates a new, empty file)
-    // We use the same name as before, so the path is preserved
-    bool exists = m_file.exists();
-    bool opened = m_file.open(QIODevice::WriteOnly | QIODevice::Append);
-    if (!exists && opened){
-        std::string bom = "\xef\xbb\xbf";
-        m_file.write(bom.c_str(), bom.size());
-    }
-}
-
-
-
-
-
-
 
 
 FileWindowLoggerWindow::FileWindowLoggerWindow(FileWindowLogger& logger, QWidget* parent)
@@ -273,7 +140,6 @@ FileWindowLoggerWindow::FileWindowLoggerWindow(FileWindowLogger& logger, QWidget
     connect(
         this, &FileWindowLoggerWindow::signal_log,
         m_text, [this](QString msg){
-//            cout << "signal_log(): " << msg.toStdString() << endl;
             m_text->append(msg);
         }
     );
@@ -281,7 +147,7 @@ FileWindowLoggerWindow::FileWindowLoggerWindow(FileWindowLogger& logger, QWidget
     GlobalSettings::instance().LOG_WINDOW_SIZE->WIDTH.add_listener(*this);
     GlobalSettings::instance().LOG_WINDOW_SIZE->HEIGHT.add_listener(*this);
     GlobalSettings::instance().LOG_WINDOW_SIZE->X_POS.add_listener(*this);
-    GlobalSettings::instance().LOG_WINDOW_SIZE->Y_POS.add_listener(*this);  
+    GlobalSettings::instance().LOG_WINDOW_SIZE->Y_POS.add_listener(*this);
 
     m_logger += *this;
     log("================================================================================");
@@ -292,17 +158,17 @@ FileWindowLoggerWindow::FileWindowLoggerWindow(FileWindowLogger& logger, QWidget
     log(QString::fromStdString("Program resources folder: " + RESOURCE_PATH()));
     add_window(*this);
 }
+
 FileWindowLoggerWindow::~FileWindowLoggerWindow(){
     remove_window(*this);
     m_logger -= *this;
     GlobalSettings::instance().LOG_WINDOW_SIZE->WIDTH.remove_listener(*this);
     GlobalSettings::instance().LOG_WINDOW_SIZE->HEIGHT.remove_listener(*this);
     GlobalSettings::instance().LOG_WINDOW_SIZE->X_POS.remove_listener(*this);
-    GlobalSettings::instance().LOG_WINDOW_SIZE->Y_POS.remove_listener(*this);      
+    GlobalSettings::instance().LOG_WINDOW_SIZE->Y_POS.remove_listener(*this);
 }
 
 void FileWindowLoggerWindow::log(QString msg){
-//    cout << "FileWindowLoggerWindow::log(): " << msg.toStdString() << endl;
     emit signal_log(msg);
 }
 
@@ -314,7 +180,7 @@ void FileWindowLoggerWindow::resizeEvent(QResizeEvent* event){
 }
 
 void FileWindowLoggerWindow::moveEvent(QMoveEvent* event){
-    m_pending_move = true;    
+    m_pending_move = true;
     GlobalSettings::instance().LOG_WINDOW_SIZE->X_POS.set(x());
     GlobalSettings::instance().LOG_WINDOW_SIZE->Y_POS.set(y());
     m_pending_move = false;
@@ -338,27 +204,9 @@ void FileWindowLoggerWindow::on_config_value_changed(void* object){
                     move_y_within_screen_bounds(GlobalSettings::instance().LOG_WINDOW_SIZE->Y_POS)
                 );
             }
-        });        
+        });
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 }

--- a/SerialPrograms/Source/CommonFramework/Logging/FileWindowLogger.h
+++ b/SerialPrograms/Source/CommonFramework/Logging/FileWindowLogger.h
@@ -2,69 +2,66 @@
  *
  *  From: https://github.com/PokemonAutomation/
  *
+ *  Qt-dependent layer that adds GUI window support on top of the Qt-free FileLogger.
+ *  The actual file I/O is handled by Common/Cpp/Logging/FileLogger.
  */
 
 #ifndef PokemonAutomation_Logging_FileWindowLogger_H
 #define PokemonAutomation_Logging_FileWindowLogger_H
 
-#include <deque>
 #include <set>
 #include <mutex>
-#include <condition_variable>
-#include <QFile>
 #include <QTextEdit>
 #include <QMainWindow>
-#include "Common/Cpp/Logging/AbstractLogger.h"
-#include "Common/Cpp/Logging/LastLogTracker.h"
+#include "Common/Cpp/Logging/FileLogger.h"
 #include "Common/Cpp/Options/ConfigOption.h"
-//#include "Common/Cpp/LifetimeSanitizer.h"
-#include "Common/Cpp/Concurrency/Thread.h"
 
 namespace PokemonAutomation{
 
 class FileWindowLoggerWindow;
 
 
-class FileWindowLogger : public Logger{
+// A logger that writes to a file (via FileLogger) and can also display
+// log messages in Qt GUI windows (FileWindowLoggerWindow).
+//
+// This class acts as a thin Qt wrapper around the Qt-free FileLogger,
+// adding the ability to manage multiple Qt windows that display log output.
+class FileWindowLogger : public Logger, private FileLogger::Listener{
 public:
     ~FileWindowLogger();
-    FileWindowLogger(const std::string& path);
 
+    // Construct a FileWindowLogger that writes to the given file path.
+    // The max_queue_size parameter controls how many log messages can be
+    // queued before the log() call blocks.
+    FileWindowLogger(const std::string& path, size_t max_queue_size);
+
+    // Add/remove Qt windows that will display log messages.
     void operator+=(FileWindowLoggerWindow& widget);
     void operator-=(FileWindowLoggerWindow& widget);
 
+    // Logger interface implementation - forwards to FileLogger.
     virtual void log(const std::string& msg, Color color = Color()) override;
     virtual void log(std::string&& msg, Color color = Color()) override;
     virtual std::vector<std::string> get_last() const override;
 
 private:
-    static std::string normalize_newlines(const std::string& msg);
-    static std::string to_file_str(const std::string& msg);
+    // FileLogger::Listener implementation - called when a message is logged.
+    // Formats the message for Qt display and sends to all registered windows.
+    virtual void on_log(const std::string& msg, Color color) override;
+
+    // Convert a log message to HTML for display in QTextEdit.
     static QString to_window_str(const std::string& msg, Color color);
 
-    void internal_log(const std::string& msg, Color color);
-    void thread_loop();
-
-    // when SerialPrograms.log is above a certain size, rename it to SerialPrograms-[timestamp].log
-    // then create a new, empty SerialPrograms.log
-    // this is only called from thread_loop(). So, we don't need to worry about synchronization because the thread loop is the only thread here.
-    void rotate_log_file();
-
 private:
-    QFile m_file;
-    size_t m_max_queue_size;
-    mutable std::mutex m_lock;
-    std::condition_variable m_cv;
-    LastLogTracker m_last_log_tracker;
-    bool m_stopping;
-    std::deque<std::pair<std::string, Color>> m_queue;
-    std::set<FileWindowLoggerWindow*> m_windows;
-    Thread m_thread;
+    FileLogger m_file_logger;
 
-//    LifetimeSanitizer m_sanitizer;
+    std::mutex m_window_lock;
+    std::set<FileWindowLoggerWindow*> m_windows;
 };
 
 
+// A Qt window that displays log output from a FileWindowLogger.
+// Uses Qt signals/slots for thread-safe updates from the logger's background thread.
 class FileWindowLoggerWindow : public QMainWindow, public ConfigOption::Listener{
     Q_OBJECT
 
@@ -72,7 +69,10 @@ public:
     FileWindowLoggerWindow(FileWindowLogger& logger, QWidget* parent = nullptr);
     virtual ~FileWindowLoggerWindow();
 
+    // Called by FileWindowLogger to display a log message.
+    // Thread-safe: emits a signal that is handled on the UI thread.
     void log(QString msg);
+
     virtual void resizeEvent(QResizeEvent* event) override;
     virtual void moveEvent(QMoveEvent* event) override;
 
@@ -81,6 +81,7 @@ signals:
 
 private:
     virtual void on_config_value_changed(void* object) override;
+
     FileWindowLogger& m_logger;
     QMenuBar* m_menubar;
     QTextEdit* m_text;

--- a/SerialPrograms/Source/ML/Models/ML_ONNXRuntimeHelpers.cpp
+++ b/SerialPrograms/Source/ML/Models/ML_ONNXRuntimeHelpers.cpp
@@ -151,7 +151,7 @@ Ort::Session create_session(const Ort::Env& env, const Ort::SessionOptions& so,
     std::string file_hash;
     std::tie(write_flag_file, file_hash) = clean_up_old_model_cache(model_cache_path, model_path);
     
-    auto& logger = global_logger_command_line();
+    auto& logger = global_logger_tagged();
     logger.log("Creating Ort::session from model " + model_path);
     try{
         Ort::Session session{env, str_to_onnx_str(model_path).c_str(), so};

--- a/SerialPrograms/cmake/SourceFiles.cmake
+++ b/SerialPrograms/cmake/SourceFiles.cmake
@@ -94,6 +94,8 @@ file(GLOB LIBRARY_SOURCES
     ../Common/Cpp/LifetimeSanitizer.h
     ../Common/Cpp/ListenerSet.h
     ../Common/Cpp/Logging/AbstractLogger.h
+    ../Common/Cpp/Logging/FileLogger.cpp
+    ../Common/Cpp/Logging/FileLogger.h
     ../Common/Cpp/Logging/LastLogTracker.cpp
     ../Common/Cpp/Logging/LastLogTracker.h
     ../Common/Cpp/Logging/OutputRedirector.cpp


### PR DESCRIPTION
Move Qt-free code in CommonFrameworks/Logging/ to Common/Logging/. This makes it easier to reuse logging code for GUI-free build targets.