### PR TITLE
Add deferred post-release stop to SV Egg Auto

### DIFF
--- a/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.h
+++ b/SerialPrograms/Source/PokemonSV/Programs/Eggs/PokemonSV_EggAutonomous.h
@@ -72,7 +72,8 @@ private:
 private:
     // Will need this to preserve raid den
     // TouchDateIntervalOption TOUCH_DATE_INTERVAL;
-
+    
+    DeferredStopButtonOption STOP_AFTER_CURRENT;
     GoHomeWhenDoneOption GO_HOME_WHEN_DONE;
 
     OCR::LanguageOCROption LANGUAGE;


### PR DESCRIPTION
Adds the same functionality as the LZA Restaurant Farmer's "Stop After Current Round" button, but for SV Egg Auto. Correctly stops after either releasing all non-keepers of the cycle, or after resetting the game due to no keepers being hatched.