### PR TITLE
Fix PLZA Latias Game Reset Occasional False Positive

### DIFF
--- a/SerialPrograms/Source/PokemonLZA/Programs/ShinyHunting/PokemonLZA_ShinyHunt_HyperspaceLegendary.h
+++ b/SerialPrograms/Source/PokemonLZA/Programs/ShinyHunting/PokemonLZA_ShinyHunt_HyperspaceLegendary.h
@@ -48,6 +48,7 @@ private:
     ShinySoundDetectedActionOption SHINY_DETECTED;
     EnumDropdownOption<Legendary> LEGENDARY;
     SimpleIntegerOption<uint16_t> MIN_CALORIE_TO_CATCH;
+    SimpleIntegerOption<uint16_t> LATIAS_VISUAL_SHINY_THRESHOLD;
 
     EventNotificationOption NOTIFICATION_STATUS;
     EventNotificationsOption NOTIFICATIONS;


### PR DESCRIPTION
Add an option for the user to adjust the shiny detection threshold, thereby reducing false positives (if they occur in their specific setup).