### PR TITLE
Bump Cmake minimum version to 3.24

### DIFF
--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Set the minimum cmake version required
-cmake_minimum_required(VERSION 3.18.0)
+cmake_minimum_required(VERSION 3.24.0)
 
 # Tell CMake to re-run configuration when these files change (get around Qt issues with stale CMake files)
 set(_cmake_files_to_watch


### PR DESCRIPTION
The LINK_LIBRARY generator expression used in CMakeLists.txt [requires a minimum of version 3.24](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#genex:LINK_LIBRARY).

