### PR TITLE
Expose PrizeCornerReset in the FRLG UI panel for all users

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/PokemonFRLG_Panels.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/PokemonFRLG_Panels.cpp
@@ -39,9 +39,9 @@ std::vector<PanelEntry> PanelListFactory::make_panels() const{
     ret.emplace_back(make_single_switch_program<GiftReset_Descriptor, GiftReset>());
     ret.emplace_back(make_single_switch_program<LegendaryReset_Descriptor, LegendaryReset>());
     ret.emplace_back(make_single_switch_program<ShinyHuntOverworld_Descriptor, ShinyHuntOverworld>());
+    ret.emplace_back(make_single_switch_program<PrizeCornerReset_Descriptor, PrizeCornerReset>());
     if (PreloadSettings::instance().DEVELOPER_MODE){
         ret.emplace_back(make_single_switch_program<LegendaryRunAway_Descriptor, LegendaryRunAway>());
-        ret.emplace_back(make_single_switch_program<PrizeCornerReset_Descriptor, PrizeCornerReset>());
     }
     
 


### PR DESCRIPTION
PrizeCornerReset was fully implemented but hidden behind the DEVELOPER_MODE gate. Move it to the public panel so normal users can access the Celadon Game Corner shiny reset program. LegendaryRunAway remains developer-only.

https://claude.ai/code/session_015vXrzATBMMjDJyt6aZMmet