### PR TITLE
frlg and rse min time for throw no sound

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/PokemonFRLG_Navigation.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/PokemonFRLG_Navigation.cpp
@@ -296,7 +296,7 @@ bool handle_encounter(ConsoleHandle& console, ProControllerContext& context, boo
         },
         {{shiny_detector}}
     );
-    shiny_detector.throw_if_no_sound();
+    shiny_detector.throw_if_no_sound(std::chrono::milliseconds(1000));
     if (res == 0){
         console.log("Shiny detected!");
         return true;

--- a/SerialPrograms/Source/PokemonRSE/PokemonRSE_Navigation.cpp
+++ b/SerialPrograms/Source/PokemonRSE/PokemonRSE_Navigation.cpp
@@ -176,7 +176,7 @@ bool handle_encounter(ConsoleHandle& console, ProControllerContext& context, boo
         },
         {{shiny_detector}}
     );
-    shiny_detector.throw_if_no_sound();
+    shiny_detector.throw_if_no_sound(std::chrono::milliseconds(1000));
     if (res == 0){
         console.log("Shiny detected!");
         return true;

--- a/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_AudioStarterReset.cpp
+++ b/SerialPrograms/Source/PokemonRSE/Programs/ShinyHunting/PokemonRSE_AudioStarterReset.cpp
@@ -224,7 +224,7 @@ void AudioStarterReset::program(SingleSwitchProgramEnvironment& env, ProControll
             },
             {{pooch_detector}}
         );
-        pooch_detector.throw_if_no_sound();
+        pooch_detector.throw_if_no_sound(std::chrono::milliseconds(1000));
         if (res == 0){
             env.log("Shiny Poochyena detected!");
             stats.poochyena++;
@@ -277,7 +277,7 @@ void AudioStarterReset::program(SingleSwitchProgramEnvironment& env, ProControll
             },
             {{starter_detector}}
         );
-        starter_detector.throw_if_no_sound();
+        starter_detector.throw_if_no_sound(std::chrono::milliseconds(1000));
         context.wait_for_all_requests();
         if (res2 == 0){
             env.log("Shiny starter detected!");


### PR DESCRIPTION
```shiny_detector.throw_if_no_sound();``` changed to ```shiny_detector.throw_if_no_sound(std::chrono::milliseconds(1000));``` This seems to fix the issue reported by Dhruv in [this thread](https://discord.com/channels/695809740428673034/1488572246908866591).

I was only able to inconsistently replicate in FRLG Legendary Reset, so I tried with the other audio-required programs as well. In Area Zero Platform  I was able to do it twice ([see video here for #2](https://youtu.be/iYc2iV3rxSM?si=b4iYaXaWbvxlBryD&t=90)) but only by causing an encounter right away by starting on the platform, which was similar to how the shiny detector for FRLG in handle_encounter() doesn't detect for very long. Plus, attempting to replicate in other programs (LZA Overworld Reset and LA Alpha Crobat Hunter) that use throw_if_no_sound() failed. The other programs all have the audio detector running for longer periods of time, which is why I think this fixed it.