### PR TITLE
Add extra Qt modules and wayland plugins to AppImage packaging

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -395,6 +395,9 @@ stages:
           chmod +x appimagetool-x86_64.AppImage
 
           echo "=== Running linuxdeploy to package AppImage ==="
+          export EXTRA_QT_MODULES="$(echo $(qt_modules) | sed 's/ /;/g')"
+          export EXTRA_QT_PLUGINS=waylandcompositor
+          export EXTRA_PLATFORM_PLUGINS=libqwayland-egl.so;libqwayland-generic.so
           ./linuxdeploy-x86_64.AppImage \
               --appdir "AppDir" \
               -d "$APPDIR/usr/share/applications/SerialPrograms.desktop" \


### PR DESCRIPTION
Hopefully using the environment variables specified [here](https://github.com/linuxdeploy/linuxdeploy-plugin-qt) will convince the AppImage to include the required libraries? At the very least it seems like it won't bundle wayland libs without EXTRA_QT_PLUGINS and/or EXTRA_PLATFORM_PLUGINS