### PR TITLE
Prevent auto fullscreen when maximizing pop-out video window

### DIFF
--- a/SerialPrograms/Source/CommonFramework/VideoPipeline/UI/VideoDisplayWindow.cpp
+++ b/SerialPrograms/Source/CommonFramework/VideoPipeline/UI/VideoDisplayWindow.cpp
@@ -51,10 +51,6 @@ VideoDisplayWindow::~VideoDisplayWindow(){
 
 void VideoDisplayWindow::changeEvent(QEvent* event){
     QMainWindow::changeEvent(event);
-    if (this->windowState() == Qt::WindowMaximized){
-        this->showFullScreen();
-//        cout << "Display Widget: " << m_display_widget->width() << " x " << m_display_widget->height() << endl;
-    }
 }
 void VideoDisplayWindow::closeEvent(QCloseEvent* event){
     close();


### PR DESCRIPTION
Fixes behavior on Mac (and Linux?) where the pop-out video feed cannot be maximized without also switching to exclusive fullscreen.