### PR TITLE
FRLG: Add an extra check to flee_battle()

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/PokemonFRLG_Navigation.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/PokemonFRLG_Navigation.cpp
@@ -412,6 +412,24 @@ BattleResult spam_first_move(ConsoleHandle& console, ProControllerContext& conte
 }
 
 void flee_battle(ConsoleHandle& console, ProControllerContext& context){
+    BattleMenuWatcher battle_menu(COLOR_RED);
+    context.wait_for_all_requests();
+    int ret = run_until<ProControllerContext>(
+        console, context,
+        [](ProControllerContext& context) {
+            pbf_wait(context, 1000ms);
+            pbf_mash_button(context, BUTTON_B, 9000ms);
+        },
+        { battle_menu }
+    );
+    if (ret < 0){
+        OperationFailedException::fire(
+            ErrorReport::SEND_ERROR_REPORT,
+            "flee_battle(): Unable to detect battle menu.",
+            console
+        );
+    }
+
     console.log("Navigate to Run.");
     pbf_press_dpad(context, DPAD_RIGHT, 160ms, 160ms);
     pbf_press_dpad(context, DPAD_DOWN, 160ms, 160ms);


### PR DESCRIPTION
This modifies `flee_battle()` to make it watch for the battle menu before trying to navigate to RUN, which relaxes some of the original assumptions of the function. Now it won't fail if called from the move selection menu, for example. 