### PR TITLE
Frlg lucky egg party fix

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/Programs/Farming/PokemonFRLG_LuckyEggFarmer.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/Farming/PokemonFRLG_LuckyEggFarmer.cpp
@@ -361,7 +361,7 @@ bool LuckyEggFarmer::attempt_catch(SingleSwitchProgramEnvironment& env, ProContr
 }
 
 bool LuckyEggFarmer::check_for_lucky_egg(ConsoleHandle& console, ProControllerContext& context, bool returned_to_building) {
-	if (returned_to_building) {
+    if (returned_to_building) {
         open_party_menu_from_overworld(console, context, StartMenuContext::STANDARD);
     } 
     else {
@@ -476,7 +476,7 @@ void LuckyEggFarmer::program(SingleSwitchProgramEnvironment& env, ProControllerC
             WhiteDialogDetector dialog(COLOR_RED);
             bool in_safari_zone_building = dialog.detect(env.console.video().snapshot());
             
-			if (balls_left <= 0) {
+            if (balls_left <= 0) {
                 in_safari_zone_building = true;
             }
 

--- a/SerialPrograms/Source/PokemonFRLG/Programs/Farming/PokemonFRLG_LuckyEggFarmer.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/Farming/PokemonFRLG_LuckyEggFarmer.cpp
@@ -475,6 +475,10 @@ void LuckyEggFarmer::program(SingleSwitchProgramEnvironment& env, ProControllerC
 
             WhiteDialogDetector dialog(COLOR_RED);
             bool in_safari_zone_building = dialog.detect(env.console.video().snapshot());
+            
+			if (balls_left <= 0) {
+                in_safari_zone_building = true;
+            }
 
             if (in_safari_zone_building && !caught) {
                 break;

--- a/SerialPrograms/Source/PokemonFRLG/Programs/Farming/PokemonFRLG_LuckyEggFarmer.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/Farming/PokemonFRLG_LuckyEggFarmer.cpp
@@ -360,8 +360,14 @@ bool LuckyEggFarmer::attempt_catch(SingleSwitchProgramEnvironment& env, ProContr
     }
 }
 
-bool LuckyEggFarmer::check_for_lucky_egg(ConsoleHandle& console, ProControllerContext& context) {
-    open_party_menu_from_overworld(console, context, StartMenuContext::SAFARI_ZONE);
+bool LuckyEggFarmer::check_for_lucky_egg(ConsoleHandle& console, ProControllerContext& context, bool returned_to_building) {
+	if (returned_to_building) {
+        open_party_menu_from_overworld(console, context, StartMenuContext::STANDARD);
+    } 
+    else {
+        open_party_menu_from_overworld(console, context, StartMenuContext::SAFARI_ZONE);
+    }
+
     PartyHeldItemDetector held_item_detector(COLOR_RED, &console.overlay(), ImageFloatBox(0.432, 0.3, 0.030, 0.485));
     if (held_item_detector.detect(console.video().snapshot())) {
         return true;
@@ -480,7 +486,7 @@ void LuckyEggFarmer::program(SingleSwitchProgramEnvironment& env, ProControllerC
             }
 
             if (caught) {
-                if (check_for_lucky_egg(env.console, context)) {
+                if (check_for_lucky_egg(env.console, context, in_safari_zone_building)) {
                     env.log("Lucky Egg found!");
                     stats.eggs++;
                     env.update_stats();

--- a/SerialPrograms/Source/PokemonFRLG/Programs/Farming/PokemonFRLG_LuckyEggFarmer.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/Farming/PokemonFRLG_LuckyEggFarmer.h
@@ -43,7 +43,7 @@ private:
     bool is_chansey(SingleSwitchProgramEnvironment& env, ProControllerContext& context);
     bool find_encounter(SingleSwitchProgramEnvironment& env, ProControllerContext& context);
     bool attempt_catch(SingleSwitchProgramEnvironment& env, ProControllerContext& context, int& balls_left);
-    bool check_for_lucky_egg(ConsoleHandle& console, ProControllerContext& context);
+    bool check_for_lucky_egg(ConsoleHandle& console, ProControllerContext& context, bool returned_to_building);
 
     OCR::LanguageOCROption LANGUAGE;
 


### PR DESCRIPTION
Attempting to fix issue when catching chancey with the last safari ball. The start menu is back in the standard format:
<img width="506" height="560" alt="image" src="https://github.com/user-attachments/assets/f3f7e88c-4632-44ae-975e-94980b78182a" />
