### PR TITLE
Add start menu check if flee fails to detect overworld transition

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/PokemonFRLG_Navigation.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/PokemonFRLG_Navigation.cpp
@@ -464,11 +464,11 @@ void flee_battle(ConsoleHandle& console, ProControllerContext& context){
     if (ret3 == 0){
         console.log("Successfully fled the battle.");
     }else{
-        OperationFailedException::fire(
-            ErrorReport::SEND_ERROR_REPORT,
-            "flee_battle(): Unable to flee from battle.",
-            console
-        );
+        console.log("flee_battle(): failed to detect transition to overworld. Attempting to open start menu to verify successful flee..");
+        
+        open_start_menu(console, context);
+        close_start_menu(console, context);
+        context.wait_for_all_requests();
     }
 }
 

--- a/SerialPrograms/Source/PokemonFRLG/Programs/PokemonFRLG_StartMenuNavigation.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/PokemonFRLG_StartMenuNavigation.h
@@ -24,7 +24,7 @@ using ProControllerContext = ControllerContext<ProController>;
 
 namespace PokemonFRLG {
 
-// Open the start menu from the overworld
+// Open the start menu from the overworld. Throws OperationFailedException if it fails to open the menu after several attempts.
 void open_start_menu(ConsoleHandle& console, ProControllerContext& context);
 
 // Close the start menu to return to the overworld


### PR DESCRIPTION
Attempting to recover when fleeing misses the overworld transition:
<img width="449" height="460" alt="image" src="https://github.com/user-attachments/assets/2551f245-658c-431a-898a-c6c0bf5b41d3" />
