### PR TITLE
Detect the start menu using the selection arrow.

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_StartMenuDetector.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_StartMenuDetector.cpp
@@ -4,15 +4,11 @@
  *
  */
 
-#include "CommonTools/Images/SolidColorTest.h"
-#include "CommonTools/Images/ImageFilter.h"
-#include "CommonFramework/ImageTools/ImageBoxes.h"
-#include "CommonFramework/ImageTools/ImageStats.h"
+#include "Common/Cpp/Color.h"
 #include "CommonFramework/ImageTypes/ImageViewRGB32.h"
 #include "CommonFramework/VideoPipeline/VideoOverlayScopes.h"
-#include "CommonTools/Images/SolidColorTest.h"
-#include "CommonTools/Images/WaterfillUtilities.h"
 #include "PokemonFRLG/PokemonFRLG_Settings.h"
+#include "PokemonFRLG/Programs/PokemonFRLG_StartMenuNavigation.h"
 #include "PokemonFRLG_StartMenuDetector.h"
 
 namespace PokemonAutomation{
@@ -20,29 +16,14 @@ namespace NintendoSwitch{
 namespace PokemonFRLG{
 
 StartMenuDetector::StartMenuDetector(Color color)
-    : m_right_box(0.989846, 0.775077, 0.00369231, 0.2025)
-    , m_top_box(0.004, 0.769885, 0.989538, 0.00519231)
-    , m_bottom_box(0.00153846, 0.972385, 0.988308, 0.00623077)
+    : m_selection_arrow(color, nullptr, MENU_ARROW_BOX)
 {}
 void StartMenuDetector::make_overlays(VideoOverlaySet& items) const{
     const BoxOption& GAME_BOX = GameSettings::instance().GAME_BOX;
-    items.add(COLOR_RED, GAME_BOX.inner_to_outer(m_right_box));
-    items.add(COLOR_RED, GAME_BOX.inner_to_outer(m_top_box));
-    items.add(COLOR_RED, GAME_BOX.inner_to_outer(m_bottom_box));
+    items.add(COLOR_RED, GAME_BOX.inner_to_outer(MENU_ARROW_BOX));
 }
 bool StartMenuDetector::detect(const ImageViewRGB32& screen){
-    ImageViewRGB32 game_screen = extract_box_reference(screen, GameSettings::instance().GAME_BOX);
-
-    ImageViewRGB32 right_image = extract_box_reference(game_screen, m_right_box);
-    ImageViewRGB32 top_image = extract_box_reference(game_screen, m_top_box);
-    ImageViewRGB32 bottom_image = extract_box_reference(game_screen, m_bottom_box);
-    if (is_solid(right_image, { 0.00, 0.38, 0.62 })
-        && is_solid(top_image, { 0.00, 0.38, 0.62 })
-        && is_solid(bottom_image, { 0.00, 0.38, 0.62 })
-    ){
-        return true;
-    }
-    return false;
+    return m_selection_arrow.detect(screen);
 }
 
 

--- a/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_StartMenuDetector.h
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_StartMenuDetector.h
@@ -8,11 +8,10 @@
 #define PokemonAutomation_PokemonFRLG_StartMenuDetector_H
 
 #include <chrono>
-#include "CommonFramework/VideoPipeline/VideoOverlayScopes.h"
 #include "Common/Cpp/Color.h"
-#include "CommonFramework/ImageTools/ImageBoxes.h"
+#include "CommonFramework/VideoPipeline/VideoOverlayScopes.h"
 #include "CommonTools/VisualDetector.h"
-#include "CommonTools/InferenceCallbacks/VisualInferenceCallback.h"
+#include "PokemonFRLG/Inference/PokemonFRLG_SelectionArrowDetector.h"
 
 namespace PokemonAutomation{
     class CancellableScope;
@@ -20,22 +19,20 @@ namespace PokemonAutomation{
 namespace NintendoSwitch{
 namespace PokemonFRLG{
 
-// Detect Start menu by looking for the blue info panel
+// Detect Start menu by looking for the selection arrow
 class StartMenuDetector : public StaticScreenDetector{
 public:
-    StartMenuDetector(Color color);
+    StartMenuDetector(Color color = COLOR_RED);
 
     virtual void make_overlays(VideoOverlaySet& items) const override;
     virtual bool detect(const ImageViewRGB32& screen) override;
 
 private:
-    ImageFloatBox m_right_box;
-    ImageFloatBox m_top_box;
-    ImageFloatBox m_bottom_box;
+    SelectionArrowDetector m_selection_arrow;
 };
 class StartMenuWatcher : public DetectorToFinder<StartMenuDetector>{
 public:
-    StartMenuWatcher(Color color)
+    StartMenuWatcher(Color color = COLOR_RED)
         : DetectorToFinder("StartMenuWatcher", std::chrono::milliseconds(250), color)
     {}
 };

--- a/SerialPrograms/Source/PokemonFRLG/Programs/PokemonFRLG_StartMenuNavigation.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/PokemonFRLG_StartMenuNavigation.cpp
@@ -62,8 +62,6 @@ void close_start_menu(ConsoleHandle& console, ProControllerContext& context){
 
 namespace {
 
-const ImageFloatBox MENU_ARROW_BOX(0.727692, 0.0523077, 0.0369231, 0.6438461);
-
 bool move_cursor_impl(
     ConsoleHandle& console,
     ProControllerContext& context,

--- a/SerialPrograms/Source/PokemonFRLG/Programs/PokemonFRLG_StartMenuNavigation.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/PokemonFRLG_StartMenuNavigation.h
@@ -24,6 +24,9 @@ using ProControllerContext = ControllerContext<ProController>;
 
 namespace PokemonFRLG {
 
+// Box that contains all the possible start menu selection arrow positions
+const ImageFloatBox MENU_ARROW_BOX(0.727692, 0.0523077, 0.0369231, 0.6438461);
+
 // Open the start menu from the overworld. Throws OperationFailedException if it fails to open the menu after several attempts.
 void open_start_menu(ConsoleHandle& console, ProControllerContext& context);
 


### PR DESCRIPTION
Detect the start menu from the selection arrow instead of the blue info box.
This allows users to select button options other than "help"

Tested with:
Lucky Egg Farmer (open start menu -> swap party members)
Nugget Bridge (Periodically Save)
Gift Reset - Magikarp (open start menu -> open party -> check pokemon stats

Potential improvement:
Pass the last_detected from the selection arrow detector. This would remove the need to find the selection arrow twice in some navigation methods.