### PR TITLE
FRLG RNG: remove option for inference during reset

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_HardReset.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_HardReset.cpp
@@ -212,6 +212,7 @@ void reset_and_perform_blind_sequence(
     }
 }
 
+#if 0
 void reset_and_detect_copyright_text(ConsoleHandle& console, ProControllerContext& context, uint8_t PROFILE){
     go_home(console, context);
     close_game_from_home(console, context);
@@ -279,6 +280,7 @@ void reset_and_detect_copyright_text(ConsoleHandle& console, ProControllerContex
     }
 
 }
+#endif
 
 }
 }

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_HardReset.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_HardReset.h
@@ -28,11 +28,13 @@ void reset_and_perform_blind_sequence(
     uint8_t PROFILE
 );
 
+#if 0
 void reset_and_detect_copyright_text(
     ConsoleHandle& console, 
     ProControllerContext& context, 
     uint8_t PROFILE = 0
 );
+#endif
 
 }
 }

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngHelper.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngHelper.cpp
@@ -146,12 +146,6 @@ RngHelper::RngHelper()
         LockMode::UNLOCK_WHILE_RUNNING,
         0 // default
     )
-    , USE_COPYRIGHT_TEXT(
-        "<b>Detect Copyright Text:</b>"
-        "<br>Start the seed timer only after detecting the copyright text. Can be helpful if your seeds are inconsistent.",
-        LockMode::LOCK_WHILE_RUNNING,
-        true // default
-    )
     , USE_TEACHY_TV(
         "<b>Use Teachy TV:</b>"
         "<br>Opens the Teachy TV to quickly advance the RNG at 313x speed.<br>"
@@ -193,7 +187,6 @@ RngHelper::RngHelper()
     PA_ADD_OPTION(CONTINUE_SCREEN_CALIBRATION);
     PA_ADD_OPTION(INGAME_ADVANCES);
     PA_ADD_OPTION(INGAME_CALIBRATION);
-    PA_ADD_OPTION(USE_COPYRIGHT_TEXT);
     PA_ADD_OPTION(USE_TEACHY_TV);
     PA_ADD_OPTION(PROFILE);
     PA_ADD_OPTION(TAKE_VIDEO);
@@ -215,7 +208,7 @@ void RngHelper::program(SingleSwitchProgramEnvironment& env, ProControllerContex
     double FRAMERATE = 59.999977; // FPS
     double FRAME_DURATION = 1000 / FRAMERATE;
 
-    int64_t FIXED_SEED_OFFSET = USE_COPYRIGHT_TEXT ? -2140 : -845; // milliseconds. approximate
+    int64_t FIXED_SEED_OFFSET = -845; // milliseconds. approximate
 
     while (!shiny_found){
         // prepare timings
@@ -258,13 +251,12 @@ void RngHelper::program(SingleSwitchProgramEnvironment& env, ProControllerContex
 
         
         // handle the blind part
-        if (USE_COPYRIGHT_TEXT){
-            reset_and_detect_copyright_text(env.console, context, PROFILE);
-            env.log("Starting blind button presses...");
-            perform_blind_sequence(context, TARGET, SEED_BUTTON, TOTAL_SEED_DELAY, CONTINUE_SCREEN_DELAY, TEACHY_DELAY, INGAME_DELAY, SAFARI_ZONE);
-        }else{
-            reset_and_perform_blind_sequence(env.console, context, TARGET, SEED_BUTTON, TOTAL_SEED_DELAY, CONTINUE_SCREEN_DELAY, TEACHY_DELAY, INGAME_DELAY, SAFARI_ZONE, PROFILE);
-        }
+        reset_and_perform_blind_sequence(
+            env.console, context, 
+            TARGET, SEED_BUTTON, TOTAL_SEED_DELAY, 
+            CONTINUE_SCREEN_DELAY, TEACHY_DELAY, INGAME_DELAY, 
+            SAFARI_ZONE, PROFILE
+        );
         env.log("Blind button presses complete.");
         stats.resets++;
 

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngHelper.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngHelper.h
@@ -49,7 +49,6 @@ private:
     SimpleIntegerOption<uint64_t> INGAME_ADVANCES;
     FloatingPointOption INGAME_CALIBRATION;
 
-    BooleanCheckBoxOption USE_COPYRIGHT_TEXT;
     BooleanCheckBoxOption USE_TEACHY_TV;
 
     SimpleIntegerOption<uint8_t> PROFILE;

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StarterRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StarterRng.cpp
@@ -148,11 +148,6 @@ StarterRng::StarterRng()
     //     LockMode::LOCK_WHILE_RUNNING,
     //     1000, 192 // default, min
     // )
-    , USE_COPYRIGHT_TEXT(
-        "<b>Detect Copyright Text:</b><br>Start the seed timer only after detecting the copyright text. Can be helpful if your seeds are inconsistent.",
-        LockMode::LOCK_WHILE_RUNNING,
-        true // default
-    )
     , IGNORE_WILD_SHINIES(
         "<b>Ignore wild shinies</b><br>Do not stop the program when a wild shiny is encountered.",
         LockMode::LOCK_WHILE_RUNNING, 
@@ -194,7 +189,6 @@ StarterRng::StarterRng()
     PA_ADD_OPTION(SEED_DELAY);
     PA_ADD_OPTION(ADVANCES);
     // PA_ADD_OPTION(CONTINUE_SCREEN_FRAMES);
-    PA_ADD_OPTION(USE_COPYRIGHT_TEXT);
     PA_ADD_OPTION(PROFILE);
     PA_ADD_OPTION(TAKE_VIDEO);
     PA_ADD_OPTION(GO_HOME_WHEN_DONE);
@@ -953,7 +947,7 @@ void StarterRng::program(SingleSwitchProgramEnvironment& env, ProControllerConte
 
     uint64_t CONTINUE_SCREEN_FRAMES = 200;
 
-    const uint64_t FIXED_SEED_OFFSET = USE_COPYRIGHT_TEXT ? -2140 : -845; // milliseconds. approximate;
+    const int64_t FIXED_SEED_OFFSET = -845; // milliseconds. approximate;
     double SEED_CALIBRATION_FRAMES = 0;
     double ADVANCES_CALIBRATION = 0;
     double CONTINUE_SCREEN_ADJUSTMENT = 0;
@@ -1050,14 +1044,14 @@ void StarterRng::program(SingleSwitchProgramEnvironment& env, ProControllerConte
         env.log("In-game duration: " + std::to_string(INGAME_DELAY) + "ms");
 
         env.log("Resetting Game...");
-        if (USE_COPYRIGHT_TEXT){
-            reset_and_detect_copyright_text(env.console, context, PROFILE);
-            env.log("Starting blind button presses.");
-            perform_blind_sequence(context, PokemonFRLG_RngTarget::starters, SEED_BUTTON, CALIBRATED_SEED_DELAY, CONTINUE_SCREEN_DELAY, 0, INGAME_DELAY, false);
-        }else{
-            reset_and_perform_blind_sequence(
-                env.console, context, PokemonFRLG_RngTarget::starters, SEED_BUTTON, CALIBRATED_SEED_DELAY, CONTINUE_SCREEN_DELAY, 0, INGAME_DELAY, false, PROFILE);
-        }
+        reset_and_perform_blind_sequence(
+            env.console, 
+            context, 
+            PokemonFRLG_RngTarget::starters, 
+            SEED_BUTTON, CALIBRATED_SEED_DELAY, 
+            CONTINUE_SCREEN_DELAY, 
+            0, INGAME_DELAY, false, PROFILE
+        );
         stats.resets++; 
 
         RNG_FILTERS.reset();

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StarterRng.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StarterRng.h
@@ -134,11 +134,9 @@ private:
     TextEditOption SEED_LIST;
     EnumDropdownOption<SeedButton> SEED_BUTTON;
     SimpleIntegerOption<uint64_t> SEED_DELAY;
-    
+
     SimpleIntegerOption<uint64_t>ADVANCES;
     // SimpleIntegerOption<uint64_t>CONTINUE_SCREEN_FRAMES;
-
-    BooleanCheckBoxOption USE_COPYRIGHT_TEXT;
 
     BooleanCheckBoxOption IGNORE_WILD_SHINIES;
 


### PR DESCRIPTION
This removes the optional detection of the copyright text during resets