### PR TITLE
Add Extra Button option to FRLG RNG programs

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_BlindNavigation.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_BlindNavigation.cpp
@@ -7,6 +7,7 @@
 #include "CommonTools/Random.h"
 #include "CommonFramework/Exceptions/OperationFailedException.h"
 #include "NintendoSwitch/Commands/NintendoSwitch_Commands_PushButtons.h"
+#include "NintendoSwitch/Commands/NintendoSwitch_Commands_Superscalar.h"
 #include "NintendoSwitch/Controllers/Procon/NintendoSwitch_ProController.h"
 #include "NintendoSwitch/NintendoSwitch_ConsoleHandle.h"
 #include "PokemonFRLG_BlindNavigation.h"
@@ -16,26 +17,47 @@ namespace NintendoSwitch{
 namespace PokemonFRLG{
 
 
-void set_seed_after_delay(ProControllerContext& context, SeedButton SEED_BUTTON, int64_t SEED_DELAY){
-    // wait on title screen for the specified delay
-    pbf_wait(context, std::chrono::milliseconds(SEED_DELAY));
+void set_seed_after_delay(ProControllerContext& context, SeedButton SEED_BUTTON, BlackoutButton BLACKOUT_BUTTON, int64_t SEED_DELAY){
+    // wait on title screen for the specified delay    
+    // hold the "blackout" button starting from the black screen after the copyright text until getting to the continue screen
+    if (BLACKOUT_BUTTON != BlackoutButton::None){
+        Button b_button;
+        switch (BLACKOUT_BUTTON){
+        case BlackoutButton::L:
+            b_button = BUTTON_L;
+            break;
+        case BlackoutButton::R:
+            b_button = BUTTON_R;
+            break;
+        default:
+            b_button = BUTTON_L;
+        }
+        Milliseconds blackout_wait = 3600ms; // wait for the copyright text to disappear
+        Milliseconds blackout_delay = std::chrono::milliseconds(SEED_DELAY) - blackout_wait;
+        Milliseconds blackout_hold = 30000ms; // wait for leaves/flames to appear on the title screen. It's okay if this is held over the seed button press
+        ssf_do_nothing(context, blackout_wait);
+        ssf_press_button(context, b_button, blackout_delay, blackout_hold, 0ms);
+    }else{
+        pbf_wait(context, std::chrono::milliseconds(SEED_DELAY));
+    }
+
     // hold the specified button for a few seconds through the transition to the Continue Screen
-    Button button;
+    Button s_button;
     switch (SEED_BUTTON){
     case SeedButton::A:
-        button = BUTTON_A;
+        s_button = BUTTON_A;
         break;
     case SeedButton::Start:
-        button = BUTTON_PLUS;
+        s_button = BUTTON_PLUS;
         break;
     case SeedButton::L:
-        button = BUTTON_L;
+        s_button = BUTTON_L;
         break;
     default:
-        button = BUTTON_A;
+        s_button = BUTTON_A;
         break;
     }
-    pbf_press_button(context, button, 3000ms, 0ms);
+    pbf_press_button(context, s_button, 3000ms, 0ms);
 }
 
 void load_game_after_delay(ProControllerContext& context, uint64_t CONTINUE_SCREEN_DELAY){
@@ -564,6 +586,7 @@ void perform_blind_sequence(
     ProControllerContext& context, 
     PokemonFRLG_RngTarget TARGET,
     SeedButton SEED_BUTTON,
+    BlackoutButton BLACKOUT_BUTTON,
     uint64_t SEED_DELAY,
     uint64_t CONTINUE_SCREEN_DELAY, 
     uint64_t TEACHY_DELAY, 
@@ -571,7 +594,7 @@ void perform_blind_sequence(
     bool SAFARI_ZONE
 ){
     pbf_press_button(context, BUTTON_A, 80ms, 0ms); // start the game from the Home screen
-    set_seed_after_delay(context, SEED_BUTTON, SEED_DELAY);
+    set_seed_after_delay(context, SEED_BUTTON, BLACKOUT_BUTTON, SEED_DELAY);
     load_game_after_delay(context, CONTINUE_SCREEN_DELAY);
     if (TEACHY_DELAY > 0){
         wait_with_teachy_tv(context, TEACHY_DELAY);

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_BlindNavigation.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_BlindNavigation.h
@@ -52,6 +52,12 @@ namespace PokemonFRLG{
         L
     };
 
+    enum class BlackoutButton{
+        None,
+        L,
+        R
+    };
+
     // checks seed, continue screen, and in-game timings for the specificed RNG manipulation target
     // and fires an error if any of the timings are too short.
     void check_timings(
@@ -68,6 +74,7 @@ namespace PokemonFRLG{
         ProControllerContext& context, 
         PokemonFRLG_RngTarget TARGET,
         SeedButton SEED_BUTTON,
+        BlackoutButton BLACKOUT_BUTTON,
         uint64_t SEED_DELAY,
         uint64_t CONTINUE_SCREEN_DELAY, 
         uint64_t TEACHY_DELAY, 

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_HardReset.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_HardReset.cpp
@@ -152,6 +152,7 @@ void reset_and_perform_blind_sequence(
     ProControllerContext& context, 
     PokemonFRLG_RngTarget TARGET,
     SeedButton SEED_BUTTON,
+    BlackoutButton BLACKOUT_BUTTON,
     uint64_t SEED_DELAY, 
     uint64_t CONTINUE_SCREEN_DELAY, 
     uint64_t TEACHY_DELAY, 
@@ -185,8 +186,8 @@ void reset_and_perform_blind_sequence(
         context.wait_for_all_requests();
         int ret = run_until<ProControllerContext>(
             console, context,
-            [TARGET, SEED_BUTTON, SEED_DELAY, CONTINUE_SCREEN_DELAY, TEACHY_DELAY, INGAME_DELAY, SAFARI_ZONE](ProControllerContext& context) {
-                perform_blind_sequence(context, TARGET, SEED_BUTTON, SEED_DELAY, CONTINUE_SCREEN_DELAY, TEACHY_DELAY, INGAME_DELAY, SAFARI_ZONE);
+            [TARGET, SEED_BUTTON, BLACKOUT_BUTTON, SEED_DELAY, CONTINUE_SCREEN_DELAY, TEACHY_DELAY, INGAME_DELAY, SAFARI_ZONE](ProControllerContext& context) {
+                perform_blind_sequence(context, TARGET, SEED_BUTTON, BLACKOUT_BUTTON, SEED_DELAY, CONTINUE_SCREEN_DELAY, TEACHY_DELAY, INGAME_DELAY, SAFARI_ZONE);
             },
             { update_detector, user_selection_detector },
             1000ms

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_HardReset.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_HardReset.h
@@ -20,6 +20,7 @@ void reset_and_perform_blind_sequence(
     ProControllerContext& context, 
     PokemonFRLG_RngTarget TARGET,
     SeedButton SEED_BUTTON,
+    BlackoutButton BLACKOUT_BUTTON,
     uint64_t SEED_DELAY, 
     uint64_t CONTINUE_SCREEN_DELAY, 
     uint64_t TEACHY_DELAY, 

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngHelper.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngHelper.cpp
@@ -104,6 +104,17 @@ RngHelper::RngHelper()
         LockMode::LOCK_WHILE_RUNNING,
         SeedButton::A
     )
+    , EXTRA_BUTTON(
+        "<b>Extra Button:</b><br>"
+        "Additional button presses that affect the seed.",
+        {
+            {BlackoutButton::None, "None", "None"},
+            {BlackoutButton::L, "L", "Blackout L"},
+            {BlackoutButton::R, "R", "Blackout R"},
+        },
+        LockMode::LOCK_WHILE_RUNNING,
+        BlackoutButton::None
+    )
     , SEED_DELAY(
         "<b>Seed Delay Time (ms):</b><br>"
         "The delay between starting the game and advancing past the title screen. Set this to match your target seed.",
@@ -187,6 +198,7 @@ RngHelper::RngHelper()
     PA_ADD_OPTION(TARGET);
     PA_ADD_OPTION(NUM_RESETS);
     PA_ADD_OPTION(SEED_BUTTON);
+    PA_ADD_OPTION(EXTRA_BUTTON);
     PA_ADD_OPTION(SEED_DELAY);
     PA_ADD_OPTION(SEED_CALIBRATION);
     PA_ADD_OPTION(CONTINUE_SCREEN_FRAMES);
@@ -261,9 +273,9 @@ void RngHelper::program(SingleSwitchProgramEnvironment& env, ProControllerContex
         if (USE_COPYRIGHT_TEXT){
             reset_and_detect_copyright_text(env.console, context, PROFILE);
             env.log("Starting blind button presses...");
-            perform_blind_sequence(context, TARGET, SEED_BUTTON, TOTAL_SEED_DELAY, CONTINUE_SCREEN_DELAY, TEACHY_DELAY, INGAME_DELAY, SAFARI_ZONE);
+            perform_blind_sequence(context, TARGET, SEED_BUTTON, EXTRA_BUTTON, TOTAL_SEED_DELAY, CONTINUE_SCREEN_DELAY, TEACHY_DELAY, INGAME_DELAY, SAFARI_ZONE);
         }else{
-            reset_and_perform_blind_sequence(env.console, context, TARGET, SEED_BUTTON, TOTAL_SEED_DELAY, CONTINUE_SCREEN_DELAY, TEACHY_DELAY, INGAME_DELAY, SAFARI_ZONE, PROFILE);
+            reset_and_perform_blind_sequence(env.console, context, TARGET, SEED_BUTTON, EXTRA_BUTTON, TOTAL_SEED_DELAY, CONTINUE_SCREEN_DELAY, TEACHY_DELAY, INGAME_DELAY, SAFARI_ZONE, PROFILE);
         }
         env.log("Blind button presses complete.");
         stats.resets++;

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngHelper.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngHelper.h
@@ -40,8 +40,10 @@ private:
     SimpleIntegerOption<uint64_t> NUM_RESETS;
 
     EnumDropdownOption<SeedButton> SEED_BUTTON;
+    EnumDropdownOption<BlackoutButton> EXTRA_BUTTON;
     SimpleIntegerOption<uint64_t> SEED_DELAY;
     SimpleIntegerOption<int64_t> SEED_CALIBRATION;
+
 
     SimpleIntegerOption<uint64_t> CONTINUE_SCREEN_FRAMES;
     FloatingPointOption CONTINUE_SCREEN_CALIBRATION;

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StarterRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StarterRng.cpp
@@ -133,6 +133,17 @@ StarterRng::StarterRng()
         LockMode::LOCK_WHILE_RUNNING,
         SeedButton::A
     )
+    , EXTRA_BUTTON(
+        "<b>Extra Button:</b><br>"
+        "Additional button presses that affect the seed.",
+        {
+            {BlackoutButton::None, "None", "None"},
+            {BlackoutButton::L, "L", "Blackout L"},
+            {BlackoutButton::R, "R", "Blackout R"},
+        },
+        LockMode::LOCK_WHILE_RUNNING,
+        BlackoutButton::None
+    )
     , SEED_DELAY(
         "<b>Seed Delay Time (ms):</b><br>The delay between starting the game and advancing past the title screen. Set this to match your target seed.",
         LockMode::LOCK_WHILE_RUNNING,
@@ -191,6 +202,7 @@ StarterRng::StarterRng()
     PA_ADD_OPTION(SEED);
     PA_ADD_OPTION(SEED_LIST);
     PA_ADD_OPTION(SEED_BUTTON);
+    PA_ADD_OPTION(EXTRA_BUTTON);
     PA_ADD_OPTION(SEED_DELAY);
     PA_ADD_OPTION(ADVANCES);
     // PA_ADD_OPTION(CONTINUE_SCREEN_FRAMES);
@@ -1053,10 +1065,10 @@ void StarterRng::program(SingleSwitchProgramEnvironment& env, ProControllerConte
         if (USE_COPYRIGHT_TEXT){
             reset_and_detect_copyright_text(env.console, context, PROFILE);
             env.log("Starting blind button presses.");
-            perform_blind_sequence(context, PokemonFRLG_RngTarget::starters, SEED_BUTTON, CALIBRATED_SEED_DELAY, CONTINUE_SCREEN_DELAY, 0, INGAME_DELAY, false);
+            perform_blind_sequence(context, PokemonFRLG_RngTarget::starters, SEED_BUTTON, EXTRA_BUTTON, CALIBRATED_SEED_DELAY, CONTINUE_SCREEN_DELAY, 0, INGAME_DELAY, false);
         }else{
             reset_and_perform_blind_sequence(
-                env.console, context, PokemonFRLG_RngTarget::starters, SEED_BUTTON, CALIBRATED_SEED_DELAY, CONTINUE_SCREEN_DELAY, 0, INGAME_DELAY, false, PROFILE);
+                env.console, context, PokemonFRLG_RngTarget::starters, SEED_BUTTON, EXTRA_BUTTON, CALIBRATED_SEED_DELAY, CONTINUE_SCREEN_DELAY, 0, INGAME_DELAY, false, PROFILE);
         }
         stats.resets++; 
 

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StarterRng.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StarterRng.h
@@ -133,6 +133,7 @@ private:
     StringOption SEED; 
     TextEditOption SEED_LIST;
     EnumDropdownOption<SeedButton> SEED_BUTTON;
+    EnumDropdownOption<BlackoutButton> EXTRA_BUTTON;
     SimpleIntegerOption<uint64_t> SEED_DELAY;
     
     SimpleIntegerOption<uint64_t>ADVANCES;


### PR DESCRIPTION
The ten-lines tool recently added "Extra Button" seeds to its lists for Switch FRLG, where buttons are held during resets to modify seed values.

This implements the "blackout" button presses for seeds.