### PR TITLE
Fix Switch 1 timings for RNG resets

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_BlindNavigation.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_BlindNavigation.cpp
@@ -17,7 +17,17 @@ namespace NintendoSwitch{
 namespace PokemonFRLG{
 
 
-void set_seed_after_delay(ProControllerContext& context, SeedButton SEED_BUTTON, BlackoutButton BLACKOUT_BUTTON, int64_t SEED_DELAY){
+void set_seed_after_delay(ProControllerContext& context, SeedButton SEED_BUTTON, BlackoutButton BLACKOUT_BUTTON, int64_t SEED_DELAY, ConsoleType console_type){
+    // be warned: not tested with all console types
+    switch (console_type){
+    case ConsoleType::Switch1:
+        // Switch 1 enters the game a little bit earlier
+        pbf_wait(context, 755ms);
+        break;
+    default:
+        break;
+    }
+
     // wait on title screen for the specified delay    
     // hold the "blackout" button starting from the black screen after the copyright text until getting to the continue screen
     if (BLACKOUT_BUTTON != BlackoutButton::None){
@@ -598,10 +608,11 @@ void perform_blind_sequence(
     uint64_t CONTINUE_SCREEN_DELAY, 
     uint64_t TEACHY_DELAY, 
     uint64_t INGAME_DELAY, 
-    bool SAFARI_ZONE
+    bool SAFARI_ZONE,
+    ConsoleType console_type
 ){
     pbf_press_button(context, BUTTON_A, 80ms, 0ms); // start the game from the Home screen
-    set_seed_after_delay(context, SEED_BUTTON, BLACKOUT_BUTTON, SEED_DELAY);
+    set_seed_after_delay(context, SEED_BUTTON, BLACKOUT_BUTTON, SEED_DELAY, console_type);
     load_game_after_delay(context, CONTINUE_SCREEN_DELAY);
     if (TEACHY_DELAY > 0){
         wait_with_teachy_tv(context, TEACHY_DELAY);

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_BlindNavigation.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_BlindNavigation.h
@@ -8,6 +8,7 @@
 #define PokemonAutomation_PokemonFRLG_BlindNavigation_H
 
 #include "NintendoSwitch/Controllers/Procon/NintendoSwitch_ProController.h"
+#include "NintendoSwitch/NintendoSwitch_ConsoleState.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
@@ -93,7 +94,8 @@ namespace PokemonFRLG{
         uint64_t CONTINUE_SCREEN_DELAY, 
         uint64_t TEACHY_DELAY, 
         uint64_t INGAME_DELAY, 
-        bool SAFARI_ZONE
+        bool SAFARI_ZONE,
+        ConsoleType console_type
     );
 
 }

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_GiftRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_GiftRng.cpp
@@ -156,7 +156,7 @@ GiftRng::GiftRng()
     , SEED_DELAY(
         "<b>Seed Delay Time (ms):</b><br>The delay between starting the game and advancing past the title screen. Set this to match your target seed.",
         LockMode::LOCK_WHILE_RUNNING,
-        31338, 30470 // default, min
+        31338, 30400 // default, min
     )
     , ADVANCES(
         "<b>Advances:</b><br>The total number of RNG advances for your target.<br>This should be the combined amount of continue screen and in-game advances.",

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_HardReset.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_HardReset.cpp
@@ -36,8 +36,7 @@ void rng_reset_and_return_home(
     close_game_from_home(console, context);
 
     // console specific delays between opening the game and returning to the Home screen
-    ConsoleType console_type = console.state().console_type(); // go_home() has already been called, so this should already be detected
-    Milliseconds launch_delay = (console_type == ConsoleType::Switch1) ? 450ms : 950ms;
+    Milliseconds launch_delay = 950ms;
 
     bool update_popup = false;
     bool connect_popup = false;
@@ -215,6 +214,7 @@ void reset_and_perform_blind_sequence(
     uint8_t PROFILE
 ){
     rng_reset_and_return_home(console, context, PROFILE); 
+    ConsoleType console_type = console.state().console_type();
 
     // attempt to resume the game and perform the blind sequence
     // by this point, the license check should be over, so we don't need to worry about it when resuming the game
@@ -234,8 +234,8 @@ void reset_and_perform_blind_sequence(
         context.wait_for_all_requests();
         int ret = run_until<ProControllerContext>(
             console, context,
-            [TARGET, SEED_BUTTON, BLACKOUT_BUTTON, SEED_DELAY, CONTINUE_SCREEN_DELAY, TEACHY_DELAY, INGAME_DELAY, SAFARI_ZONE](ProControllerContext& context) {
-                perform_blind_sequence(context, TARGET, SEED_BUTTON, BLACKOUT_BUTTON, SEED_DELAY, CONTINUE_SCREEN_DELAY, TEACHY_DELAY, INGAME_DELAY, SAFARI_ZONE);
+            [TARGET, SEED_BUTTON, BLACKOUT_BUTTON, SEED_DELAY, CONTINUE_SCREEN_DELAY, TEACHY_DELAY, INGAME_DELAY, SAFARI_ZONE, console_type](ProControllerContext& context) {
+                perform_blind_sequence(context, TARGET, SEED_BUTTON, BLACKOUT_BUTTON, SEED_DELAY, CONTINUE_SCREEN_DELAY, TEACHY_DELAY, INGAME_DELAY, SAFARI_ZONE, console_type);
             },
             { update_detector, user_selection_detector },
             1000ms

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngHelper.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngHelper.cpp
@@ -119,7 +119,7 @@ RngHelper::RngHelper()
         "<b>Seed Delay Time (ms):</b><br>"
         "The delay between starting the game and advancing past the title screen. Set this to match your target seed.",
         LockMode::LOCK_WHILE_RUNNING,
-        35000, 30470 // default, min
+        35000, 30400 // default, min
     )
     , SEED_CALIBRATION(
          "<b>Seed Calibration (ms):</b>"
@@ -220,7 +220,7 @@ void RngHelper::program(SingleSwitchProgramEnvironment& env, ProControllerContex
     double FRAMERATE = 59.999977; // FPS
     double FRAME_DURATION = 1000 / FRAMERATE;
 
-    int64_t FIXED_SEED_OFFSET = -845; // milliseconds. approximate
+    const int64_t FIXED_SEED_OFFSET = -845; // milliseconds. approximate
 
     while (!shiny_found){
         // prepare timings
@@ -257,7 +257,7 @@ void RngHelper::program(SingleSwitchProgramEnvironment& env, ProControllerContex
         env.log("Continue Screen delay: " + std::to_string(CONTINUE_SCREEN_DELAY) + "ms");
         env.log("In-game delay: " + std::to_string(INGAME_DELAY) + "ms");
         env.log("Teachy TV delay: " + std::to_string(TEACHY_DELAY) + "ms");
-        env.log("Total time: " + std::to_string(SEED_DELAY + SEED_CALIBRATION + FIXED_SEED_OFFSET + CONTINUE_SCREEN_DELAY + INGAME_DELAY + TEACHY_DELAY) + "ms");
+        env.log("Total time: " + std::to_string(TOTAL_SEED_DELAY + CONTINUE_SCREEN_DELAY + INGAME_DELAY + TEACHY_DELAY) + "ms");
 
         check_timings(env.console, TARGET, TOTAL_SEED_DELAY, CONTINUE_SCREEN_DELAY, INGAME_DELAY, SAFARI_ZONE);
 

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StarterRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StarterRng.cpp
@@ -143,7 +143,7 @@ StarterRng::StarterRng()
     , SEED_DELAY(
         "<b>Seed Delay Time (ms):</b><br>The delay between starting the game and advancing past the title screen. Set this to match your target seed.",
         LockMode::LOCK_WHILE_RUNNING,
-        31338, 30470 // default, min
+        31338, 30400 // default, min
     )
     , ADVANCES(
         "<b>Advances:</b><br>The total number of RNG advances for your target.<br>This should be the combined amount of continue screen and in-game advances.",

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StaticRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StaticRng.cpp
@@ -163,7 +163,7 @@ StaticRng::StaticRng()
     , SEED_DELAY(
         "<b>Seed Delay Time (ms):</b><br>The delay between starting the game and advancing past the title screen. Set this to match your target seed.",
         LockMode::LOCK_WHILE_RUNNING,
-        31338, 28000 // default, min
+        31338, 30400 // default, min
     )
     , ADVANCES(
         "<b>Advances:</b><br>The total number of RNG advances for your target.<br>This should be the combined amount of continue screen and in-game advances.",


### PR DESCRIPTION
Apologies for the PR spam...

I hadn't thoroughly tested Switch 1 resets after some of the recent changes -- it turns out that the only real difference is that, after the reset sequence, my Switch 1 resumes the game at a point roughly 750ms earlier than my Switch 2.

This PR adds a delay to account for this difference, and it was successfully tested on both consoles. With luck, this will be the last of the fixes for blind resets.