### PR TITLE
Fix Cloud Island Run Forever Condition

### DIFF
--- a/SerialPrograms/Source/PokemonPokopia/Programs/PokemonPokopia_CloudIslandReset.cpp
+++ b/SerialPrograms/Source/PokemonPokopia/Programs/PokemonPokopia_CloudIslandReset.cpp
@@ -419,7 +419,7 @@ void CloudIslandReset::program(SingleSwitchProgramEnvironment& env, ProControlle
     bool all_stamps_mew = false;
     bool spend_limit_reached = false;
 
-    while (NUM_RESETS != 0 && stats.resets < NUM_RESETS){
+    while (NUM_RESETS == 0 || stats.resets < NUM_RESETS){
         delete_cloud_island_save(env, context);
         create_cloud_island_after_delete(env, context);
         stats.resets++;


### PR DESCRIPTION
Fix no limit condition for when 0 is specified as number of resets