### PR TITLE
update show_update_nag()

### DIFF
--- a/SerialPrograms/Source/CommonFramework/Startup/NewVersionCheck.cpp
+++ b/SerialPrograms/Source/CommonFramework/Startup/NewVersionCheck.cpp
@@ -74,7 +74,7 @@ struct ProgramVersion{
             return false;
         }
         std::string skip_version = GlobalSettings::instance().CHECK_FOR_UPDATES->SKIP_VERSION;
-        return version_text != skip_version;
+        return version_text > skip_version;
     }
 };
 


### PR DESCRIPTION
Updates the logic to cover for the case where your current version is behind both the public and private beta version.
In this case, "Skip this version" doesn't work since the saved version to skip will alternate between the public and private beta version number. e.g. If your current version number is 0.63.7, the pop-up will alternate between 0.63.8 (the beta) and 0.63.9 (public release).