### PR TITLE
ZA Stats Reset: Add Hoopa

### DIFF
--- a/SerialPrograms/Source/PokemonLZA/Programs/NonShinyHunting/PokemonLZA_StatsReset.cpp
+++ b/SerialPrograms/Source/PokemonLZA/Programs/NonShinyHunting/PokemonLZA_StatsReset.cpp
@@ -458,7 +458,7 @@ void StatsReset::program(SingleSwitchProgramEnvironment& env, ProControllerConte
             pbf_move_left_joystick(context, {0.05, 1}, 4800ms, 0ms);
             pbf_mash_button(context, BUTTON_A, 1s);
             context.wait_for_all_requests();
-            wait_until_overworld(env.console, context);
+            wait_until_overworld(env.console, context, 10s);
 
             // run to the right of roof
             pbf_press_button(context, BUTTON_Y, 100ms, 1s);
@@ -485,21 +485,21 @@ void StatsReset::program(SingleSwitchProgramEnvironment& env, ProControllerConte
             ssf_press_button(context, BUTTON_B, 0ms, 1s, 0ms);
             pbf_move_left_joystick(context, {-0.2, 1}, 4s, 0ms);
             ssf_press_button(context, BUTTON_B, 0ms, 1s, 0ms);
-            pbf_move_left_joystick(context, {-0.8, 1}, 1500ms, 500ms);
+            pbf_move_left_joystick(context, {-0.8, 1}, 1500ms, 0ms);
 
             // climb ladder
             pbf_mash_button(context, BUTTON_A, 500ms);
             pbf_move_left_joystick(context, {0, 1}, 8s, 1500ms);
 
             ssf_press_button(context, BUTTON_B, 0ms, 1s, 0ms);
-            pbf_move_left_joystick(context, {-1, 0}, 2s, 500ms);
+            pbf_move_left_joystick(context, {-1, 0}, 2s, 0ms);
 
             enter_portal(env, context);
             context.wait_for(100ms);
 
             // run toward hoopa to start battle
             ssf_press_button(context, BUTTON_B, 0ms, 1s, 0ms);
-            pbf_move_left_joystick(context, {0, +1}, 8s, 0ms);
+            pbf_move_left_joystick(context, {0, 1}, 8s, 0ms);
 
             RunFromBattleWatcher battle_menu(COLOR_GREEN, &env.console.overlay(), 10ms);
             OverworldPartySelectionWatcher overworld(COLOR_WHITE, &env.console.overlay(), 100ms);
@@ -560,7 +560,7 @@ void StatsReset::program(SingleSwitchProgramEnvironment& env, ProControllerConte
                         pbf_mash_button(context, BUTTON_A, 60s);
                     }else if (POKEMON == GiftPokemon::MAGEARNA){
                         pbf_mash_button(context, BUTTON_A, 60s);
-                    }else if (POKEMON == GiftPokemon::HOOPA) {
+                    }else if (POKEMON == GiftPokemon::HOOPA){
                         pbf_mash_button(context, BUTTON_A, 120s);
                     }else{
                         pbf_mash_button(context, BUTTON_A, 30s);

--- a/SerialPrograms/Source/PokemonLZA/Programs/NonShinyHunting/PokemonLZA_StatsReset.cpp
+++ b/SerialPrograms/Source/PokemonLZA/Programs/NonShinyHunting/PokemonLZA_StatsReset.cpp
@@ -23,6 +23,7 @@
 #include "PokemonLZA/Programs/PokemonLZA_BasicNavigation.h"
 #include "PokemonLZA/Programs/PokemonLZA_FastTravelNavigation.h"
 #include "PokemonLZA/Programs/PokemonLZA_MenuNavigation.h"
+#include "PokemonLZA/Programs/PokemonLZA_TrainerBattle.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
@@ -80,6 +81,7 @@ StatsReset::StatsReset()
             {GiftPokemon::MELTAN,   "meltan",   "Meltan"  },
             {GiftPokemon::MELMETAL, "melmetal", "Melmetal"},
             {GiftPokemon::VOLCANION,"volcanion","Volcanion"},
+            {GiftPokemon::HOOPA, "hoopa", "Hoopa"},
         },
         LockMode::LOCK_WHILE_RUNNING,
         GiftPokemon::FLOETTE
@@ -134,6 +136,7 @@ StatsReset::StatsReset()
     PA_ADD_OPTION(SCROLL_RELEASE);
     PA_ADD_OPTION(POST_THROW_WAIT);
     PA_ADD_OPTION(DOWN_SCROLLS);
+    PA_ADD_OPTION(BATTLE_AI);
     PA_ADD_OPTION(HP);
     PA_ADD_OPTION(ATTACK);
     PA_ADD_OPTION(DEFENSE);
@@ -154,13 +157,16 @@ StatsReset::~StatsReset(){
 void StatsReset::on_config_value_changed(void* object){
     ConfigOptionState state_ball  = (POKEMON == GiftPokemon::GENESECT || POKEMON == GiftPokemon::MELTAN || POKEMON == GiftPokemon::VOLCANION)
                                     ? ConfigOptionState::ENABLED : ConfigOptionState::HIDDEN;
-    ConfigOptionState state_donut = (POKEMON == GiftPokemon::GENESECT || POKEMON == GiftPokemon::MELMETAL)
+    ConfigOptionState state_donut = (POKEMON == GiftPokemon::GENESECT || POKEMON == GiftPokemon::MELMETAL || POKEMON == GiftPokemon::HOOPA)
                                     ? ConfigOptionState::ENABLED : ConfigOptionState::HIDDEN;
+    ConfigOptionState state_battle = (POKEMON == GiftPokemon::HOOPA)
+                                     ? ConfigOptionState::ENABLED : ConfigOptionState::HIDDEN;
     RIGHT_SCROLLS.set_visibility(state_ball);
     SCROLL_HOLD.set_visibility(state_ball);
     SCROLL_RELEASE.set_visibility(state_ball);
     POST_THROW_WAIT.set_visibility(state_ball);
     DOWN_SCROLLS.set_visibility(state_donut);
+    BATTLE_AI.set_visibility(state_battle);
 }
 
 void StatsReset::enter_portal(SingleSwitchProgramEnvironment& env, ProControllerContext& context){
@@ -441,6 +447,122 @@ void StatsReset::program(SingleSwitchProgramEnvironment& env, ProControllerConte
             pbf_mash_button(context, BUTTON_A, 20s);
         }
 
+        if (POKEMON == GiftPokemon::HOOPA){
+            // fly to cafe soleil
+            FastTravelState travel_status = open_map_and_fly_to(env.console, context, LANGUAGE, Location::CAFE_SOLEIL);
+            if (travel_status != FastTravelState::SUCCESS){
+                stats.errors++;
+                env.update_stats();
+                OperationFailedException::fire(
+                    ErrorReport::SEND_ERROR_REPORT,
+                    "Failed to travel to Café Soleil",
+                    env.console
+                );
+            }
+            context.wait_for(100ms);
+            env.log("Detected overworld. Fast traveled to Café Soleil");
+
+            // run to holovator
+            pbf_move_left_joystick(context, {1, 0.12}, 200ms, 500ms);
+            pbf_press_button(context, BUTTON_L, 50ms, 500ms);
+            ssf_press_button(context, BUTTON_B, 0ms, 1s, 0ms);
+            pbf_move_left_joystick(context, {0, 1}, 6500ms, 500ms);
+            pbf_mash_button(context, BUTTON_A, 1s);
+            context.wait_for_all_requests();
+            wait_until_overworld(env.console, context);
+
+            // run to the right of roof
+            pbf_press_button(context, BUTTON_Y, 100ms, 1s);
+            pbf_move_left_joystick(context, {1, 0.12}, 200ms, 500ms);
+            for (int i = 0; i < 6; ++i){
+                pbf_press_button(context, BUTTON_Y, 100ms, 1s);
+            }
+
+            ssf_press_button(context, BUTTON_B, 0ms, 1s, 0ms);
+            pbf_move_left_joystick(context, {1, 0.12}, 1s, 500ms);
+
+            // run forward to the ladder
+            pbf_move_left_joystick(context, {0, 1}, 200ms, 500ms);
+            for (int i = 0; i < 5; ++i){
+                pbf_press_button(context, BUTTON_Y, 100ms, 1s);
+            }
+
+            ssf_press_button(context, BUTTON_B, 0ms, 1s, 0ms);
+            pbf_move_left_joystick(context, {0, 1}, 1s, 500ms);
+
+            pbf_press_button(context, BUTTON_Y, 100ms, 1s);
+            pbf_press_button(context, BUTTON_Y, 100ms, 1s);
+
+            ssf_press_button(context, BUTTON_B, 0ms, 1s, 0ms);
+            pbf_move_left_joystick(context, {-0.2, 1}, 4s, 0ms);
+            ssf_press_button(context, BUTTON_B, 0ms, 1s, 0ms);
+            pbf_move_left_joystick(context, {-0.8, 1}, 1500ms, 500ms);
+
+            // climb ladder
+            pbf_mash_button(context, BUTTON_A, 500ms);
+            pbf_move_left_joystick(context, {0, 1}, 8s, 1500ms);
+
+            ssf_press_button(context, BUTTON_B, 0ms, 1s, 0ms);
+            pbf_move_left_joystick(context, {-1, 0}, 2s, 500ms);
+
+            enter_portal(env, context);
+            context.wait_for(100ms);
+
+            // run toward hoopa to start battle
+            ssf_press_button(context, BUTTON_B, 0ms, 1s, 0ms);
+            pbf_move_left_joystick(context, {0, +1}, 8s, 0ms);
+
+            RunFromBattleWatcher battle_menu(COLOR_GREEN, &env.console.overlay(), 10ms);
+            OverworldPartySelectionWatcher overworld(COLOR_WHITE, &env.console.overlay(), 100ms);
+            TrainerBattleState battle_state(BATTLE_AI);
+            context.wait_for_all_requests();
+            bool has_error = false;
+            while (true){
+                int ret = run_until<ProControllerContext>(
+                    env.console, context,
+                    [](ProControllerContext& context){
+                        pbf_mash_button(context, BUTTON_B, 120s);
+                    },
+                    {
+                        battle_menu,
+                        overworld,
+                    }
+                );
+
+                switch (ret){
+                case 0:
+                    env.log("Detected battle menu.");
+                    if (!battle_state.attempt_one_attack(env, env.console, context)){
+                        pbf_press_button(context, BUTTON_UP, 500ms, 1s);
+                    }
+                    continue;
+                case 1:
+                    env.log("Detected overworld.");
+                    break;
+                default:
+                    has_error = true;
+                    break;
+                }
+                break;
+            }
+            if (has_error){
+                stats.errors++;
+                env.log("Error during battle.", COLOR_RED);
+                // fail safely and start over
+                go_home(env.console, context);
+                reset_game_from_home(env, env.console, context, true);
+                continue;
+            }
+            context.wait_for(100ms);
+            // run toward hoopa to catch
+            ssf_press_button(context, BUTTON_B, 0ms, 2s, 0ms);
+            pbf_move_left_joystick(context, {0.05, +1}, 1500ms, 0ms);
+            pbf_mash_button(context, BUTTON_A, 1s);
+            // incase did not run
+            pbf_move_left_joystick(context, {0.05, +1}, 500ms, 0ms);
+            pbf_mash_button(context, BUTTON_A, 1s);
+        }
+
         context.wait_for_all_requests();
         {
             BlackScreenOverWatcher detector;
@@ -453,6 +575,8 @@ void StatsReset::program(SingleSwitchProgramEnvironment& env, ProControllerConte
                         pbf_mash_button(context, BUTTON_A, 60s);
                     }else if (POKEMON == GiftPokemon::MAGEARNA){
                         pbf_mash_button(context, BUTTON_A, 60s);
+                    }else if (POKEMON == GiftPokemon::HOOPA) {
+                        pbf_mash_button(context, BUTTON_A, 120s);
                     }else{
                         pbf_mash_button(context, BUTTON_A, 30s);
                     }

--- a/SerialPrograms/Source/PokemonLZA/Programs/NonShinyHunting/PokemonLZA_StatsReset.cpp
+++ b/SerialPrograms/Source/PokemonLZA/Programs/NonShinyHunting/PokemonLZA_StatsReset.cpp
@@ -448,25 +448,14 @@ void StatsReset::program(SingleSwitchProgramEnvironment& env, ProControllerConte
         }
 
         if (POKEMON == GiftPokemon::HOOPA){
-            // fly to cafe soleil
-            FastTravelState travel_status = open_map_and_fly_to(env.console, context, LANGUAGE, Location::CAFE_SOLEIL);
-            if (travel_status != FastTravelState::SUCCESS){
-                stats.errors++;
-                env.update_stats();
-                OperationFailedException::fire(
-                    ErrorReport::SEND_ERROR_REPORT,
-                    "Failed to travel to Café Soleil",
-                    env.console
-                );
-            }
-            context.wait_for(100ms);
-            env.log("Detected overworld. Fast traveled to Café Soleil");
-
-            // run to holovator
-            pbf_move_left_joystick(context, {1, 0.12}, 200ms, 500ms);
+            // run to holovator from bleu pokemon center
+            pbf_move_left_joystick(context, {1, -0.5}, 200ms, 500ms);
+            pbf_press_button(context, BUTTON_Y, 100ms, 1s);
+            pbf_move_left_joystick(context, {-0.14, -1}, 200ms, 500ms);
             pbf_press_button(context, BUTTON_L, 50ms, 500ms);
             ssf_press_button(context, BUTTON_B, 0ms, 1s, 0ms);
-            pbf_move_left_joystick(context, {0, 1}, 6500ms, 500ms);
+            pbf_move_left_joystick(context, {0, 1}, 6s, 0ms);
+            pbf_move_left_joystick(context, {0.05, 1}, 4800ms, 0ms);
             pbf_mash_button(context, BUTTON_A, 1s);
             context.wait_for_all_requests();
             wait_until_overworld(env.console, context);

--- a/SerialPrograms/Source/PokemonLZA/Programs/NonShinyHunting/PokemonLZA_StatsReset.cpp
+++ b/SerialPrograms/Source/PokemonLZA/Programs/NonShinyHunting/PokemonLZA_StatsReset.cpp
@@ -555,11 +555,7 @@ void StatsReset::program(SingleSwitchProgramEnvironment& env, ProControllerConte
             }
             context.wait_for(100ms);
             // run toward hoopa to catch
-            ssf_press_button(context, BUTTON_B, 0ms, 2s, 0ms);
-            pbf_move_left_joystick(context, {0.05, +1}, 1500ms, 0ms);
-            pbf_mash_button(context, BUTTON_A, 1s);
-            // incase did not run
-            pbf_move_left_joystick(context, {0.05, +1}, 500ms, 0ms);
+            run_towards_gate_with_A_button(env.console, context, 0.063, 1, 2s);
             pbf_mash_button(context, BUTTON_A, 1s);
         }
 

--- a/SerialPrograms/Source/PokemonLZA/Programs/NonShinyHunting/PokemonLZA_StatsReset.h
+++ b/SerialPrograms/Source/PokemonLZA/Programs/NonShinyHunting/PokemonLZA_StatsReset.h
@@ -16,6 +16,7 @@
 #include "Pokemon/Options/Pokemon_IvJudgeOption.h"
 #include "Common/Cpp/Options/TimeDurationOption.h"
 #include "Common/Cpp/Options/SimpleIntegerOption.h"
+#include "PokemonLZA/Options/PokemonLZA_BattleAIOption.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
@@ -57,6 +58,7 @@ private:
         MELTAN,
         MELMETAL,
         VOLCANION,
+        HOOPA,
     };
     EnumDropdownOption<GiftPokemon> POKEMON;
 
@@ -66,6 +68,8 @@ private:
     MillisecondsOption POST_THROW_WAIT;
 
     SimpleIntegerOption<int8_t> DOWN_SCROLLS;
+
+    BattleAIOption BATTLE_AI;
 
     IVJudgeFilterOption HP;
     IVJudgeFilterOption ATTACK;


### PR DESCRIPTION
I had been waiting a long time for Hoopa reset, so I decided to implement it myself. Hope this is not offensive.

Tested on Switch OLED with PABotBase2 for ~100 rounds with 1 recoverable error and no unrecoverable error. I don't have Switch 2, so I can't test on it.

Here is some instruction to run the program:

Preparation for Hoopa:
1. Start Side Mission 196 until the portal appears.
2. Have a Level Boost (100+) donut ready (alternatively, Attack Power or Bug-type Move Power). Configure Donut Down Scrolls in settings so it scrolls to the correct donut.
3. Make room on the top left slot in the box system, make sure that this is where the cursor is when opening the box system from the main menu.
4. Select Use Plus Moves in Battle AI.
5. Lead with a Level 100 Heracross (252+ Atk, Life Orb) with Megahorn on top slot (button X). Hoopa Unbound is 4× weak to Bug type and has low Def, so with right donut and plus move, a one-hit KO is guaranteed. The program can still execute multiple moves if needed.
6. Start the program in game.

<img width="1920" height="1080" alt="20260509-161125869227" src="https://github.com/user-attachments/assets/cc37ef2a-c1f6-483c-a407-3e669f18e355" />
