### PR TITLE
Add blur for FRLG name OCR

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/Inference/PokemonFRLG_StatsReader.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/PokemonFRLG_StatsReader.cpp
@@ -85,26 +85,38 @@ void StatsReader::read_page1(
 
 
     const bool jpn = language == Language::Japanese;
-    // Read Name (white text on lilac background).
-    // Use multifiltered OCR across multiple narrow white bands. This tolerates
-    // brightness shifts (down to ~0xc0) while still preferring cleaner bands.
+
+    ImageViewRGB32 name_box = extract_box_reference(game_screen, jpn ? m_box_name_jpn : m_box_name);
+
+    // remove shadow
+    ImageRGB32 name_filtered = filter_rgb32_range(
+        name_box, 0xff000000, 0xffc7c7c7, Color(0xffc3c3c3), true
+    );
+    // make text black
+    name_filtered = filter_rgb32_range(
+        name_filtered, 0xffc8c8c8, 0xffffffff, Color(0xff000000), true
+    );
+
+    ImageRGB32 name_ready = preprocess_for_ocr(
+        name_filtered, "name", 7, 2, true, 
+        combine_rgb(0, 0, 0), jpn ? combine_rgb(160, 160, 160) : combine_rgb(120, 120, 120)
+    );
+
     const std::vector<OCR::TextColorRange> name_text_color_ranges{
-        {combine_rgb(224, 224, 224), combine_rgb(255, 255, 255)},
-        {combine_rgb(208, 208, 208), combine_rgb(255, 255, 255)},
-        {combine_rgb(192, 192, 192), combine_rgb(255, 255, 255)},
+        {combine_rgb(0, 0, 0), combine_rgb(120, 120, 120)}
     };
 
     if (subset.size() > 0){
         auto name_result = Pokemon::PokemonNameReader(subset).read_substring(
-                logger, language, extract_box_reference(game_screen, jpn ? m_box_name_jpn : m_box_name),
-                name_text_color_ranges);
+                logger, language, name_ready, name_text_color_ranges
+        );
         if (!name_result.results.empty()){
             stats.name = name_result.results.begin()->second.token;
         }
     }else{
         auto name_result = Pokemon::PokemonNameReader::instance().read_substring(
-                logger, language, extract_box_reference(game_screen, jpn ? m_box_name_jpn : m_box_name),
-                name_text_color_ranges);
+                logger, language, name_ready, name_text_color_ranges
+        );
         if (!name_result.results.empty()){
             stats.name = name_result.results.begin()->second.token;
         }

--- a/SerialPrograms/Source/PokemonFRLG/Inference/PokemonFRLG_WildEncounterReader.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/PokemonFRLG_WildEncounterReader.cpp
@@ -26,13 +26,15 @@ namespace PokemonFRLG {
 
 
 WildEncounterReader::WildEncounterReader(Color color)
-    : m_box_name(0.075, 0.120, 0.265, 0.063) 
+    : m_box_name(0.075, 0.120, 0.260, 0.063) 
+    , m_box_name_jpn(0.075, 0.120, 0.232, 0.063)
     // , m_box_level(0.325, 0.120, 0.092, 0.063)
     {}
 
 void WildEncounterReader::make_overlays(VideoOverlaySet& items) const {
     const BoxOption& GAME_BOX = GameSettings::instance().GAME_BOX;
     items.add(m_color, GAME_BOX.inner_to_outer(m_box_name));
+    items.add(m_color, GAME_BOX.inner_to_outer(m_box_name_jpn));
     // items.add(m_color, GAME_BOX.inner_to_outer(m_box_level));
 }
 
@@ -42,19 +44,26 @@ PokemonFRLG_WildEncounter WildEncounterReader::read_encounter(
     std::set<std::string>& subset,
     double max_log10p
 ){
+    const bool jpn = language == Language::Japanese;
+
     PokemonFRLG_WildEncounter encounter; 
     ImageViewRGB32 game_screen =
             extract_box_reference(frame, GameSettings::instance().GAME_BOX);
 
-    // Read Name (black text on off-white background).
+    ImageViewRGB32 name_box = extract_box_reference(game_screen, jpn ? m_box_name_jpn : m_box_name);
+
+    ImageRGB32 name_ready = preprocess_for_ocr(
+        name_box, "name", 7, 2, true, 
+        combine_rgb(0, 0, 0), combine_rgb(190, 190, 190)
+    );
+
     const std::vector<OCR::TextColorRange> name_text_color_ranges{
-        {combine_rgb(0, 0, 0), combine_rgb(64, 64, 64)},
-        {combine_rgb(0, 0, 0), combine_rgb(96, 96, 96)},
-        {combine_rgb(0, 0, 0), combine_rgb(128, 128, 128)},
+        {combine_rgb(0, 0, 0), combine_rgb(120, 120, 120)}
     };
+
     // auto name_result = Pokemon::PokemonNameReader::instance().read_substring(    
     auto name_result = Pokemon::PokemonNameReader(subset).read_substring(
-            logger, language, extract_box_reference(game_screen, m_box_name),
+            logger, language, name_ready,
             name_text_color_ranges,
             0.01, 0.50, max_log10p);
     if (!name_result.results.empty()){

--- a/SerialPrograms/Source/PokemonFRLG/Inference/PokemonFRLG_WildEncounterReader.h
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/PokemonFRLG_WildEncounterReader.h
@@ -49,6 +49,7 @@ public:
 private:
     Color m_color;
     ImageFloatBox m_box_name;
+    ImageFloatBox m_box_name_jpn;
     // ImageFloatBox m_box_level;
 };
 


### PR DESCRIPTION
This adds a blur prior to OCR for reading species in FRLG. 

I suspect this will fix the EV Trainer issues for Japanese mentioned by Nymphea 