### PR TITLE
Cram-o-matic: Increase wait time between dialog checks

### DIFF
--- a/SerialPrograms/Source/PokemonSwSh/Inference/RNG/PokemonSwSh_OrbeetleAttackAnimationDetector.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Inference/RNG/PokemonSwSh_OrbeetleAttackAnimationDetector.cpp
@@ -89,7 +89,7 @@ OrbeetleAttackAnimationDetector::Detection OrbeetleAttackAnimationDetector::run(
         return Detection::SPECIAL;
     }
     if (save_screenshot){
-        animation_image->save("orbeetle-attack-physical-" + now_to_filestring() + ".png");
+        //animation_image->save("orbeetle-attack-physical-" + now_to_filestring() + ".png");
         dump_debug_image(m_stream.logger(), "rng", "orbeetle-physical", animation_image);
     }
     m_stream.log("Orbeetle Attack Animation: Physical animation detected.");

--- a/SerialPrograms/Source/PokemonSwSh/Programs/RNG/PokemonSwSh_CramomaticRNG.cpp
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/RNG/PokemonSwSh_CramomaticRNG.cpp
@@ -146,6 +146,13 @@ CramomaticRNG::CramomaticRNG()
         LockMode::LOCK_WHILE_RUNNING,
         "80 ms"
     )
+    , DIALOG_RELEASE_DURATION(
+        "<b>Dialog Release Duration:</b><br>"
+        "After releasing the button, wait this long before checking the dialog.<br>"
+        "<font color=\"red\">For tick-imprecise controllers, this number will be increased automatically.</font>",
+        LockMode::LOCK_WHILE_RUNNING,
+        "1840 ms"
+    )
     , SAVE_SCREENSHOTS(
         "<b>Save Debug Screenshots:</b>",
         LockMode::LOCK_WHILE_RUNNING,
@@ -174,6 +181,7 @@ CramomaticRNG::CramomaticRNG()
     PA_ADD_OPTION(MAX_UNKNOWN_ADVANCES);
     PA_ADD_OPTION(ADVANCE_PRESS_DURATION);
     PA_ADD_OPTION(ADVANCE_RELEASE_DURATION);
+    PA_ADD_OPTION(DIALOG_RELEASE_DURATION);
     PA_ADD_OPTION(SAVE_SCREENSHOTS);
     PA_ADD_OPTION(LOG_VALUES);
 }
@@ -348,7 +356,7 @@ std::pair<bool, std::string> CramomaticRNG::receive_ball(SingleSwitchProgramEnvi
 
     while (presses < 30 && !arrow_detected){
         presses++;
-        pbf_press_button(context, BUTTON_B, 80ms, 1320ms);
+        pbf_press_button(context, BUTTON_B, 80ms, DIALOG_RELEASE_DURATION);
         context.wait_for_all_requests();
 
         VideoSnapshot screen = env.console.video().snapshot();

--- a/SerialPrograms/Source/PokemonSwSh/Programs/RNG/PokemonSwSh_CramomaticRNG.h
+++ b/SerialPrograms/Source/PokemonSwSh/Programs/RNG/PokemonSwSh_CramomaticRNG.h
@@ -62,6 +62,7 @@ private:
     SimpleIntegerOption<uint16_t> MAX_UNKNOWN_ADVANCES;
     MillisecondsOption ADVANCE_PRESS_DURATION;
     MillisecondsOption ADVANCE_RELEASE_DURATION;
+    MillisecondsOption DIALOG_RELEASE_DURATION;
     BooleanCheckBoxOption SAVE_SCREENSHOTS;
     BooleanCheckBoxOption LOG_VALUES;
 


### PR DESCRIPTION
Added an (advanced) option for the release time of the B press in the receive dialog sequence. 
Increased the default value and therefore the wait time between dialog checks.
Should help with longer delay capture cards.