### PR TITLE
Return of the Revenge of the FRLG RNG Bugfix

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_GiftRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_GiftRng.cpp
@@ -327,8 +327,8 @@ void GiftRng::program(SingleSwitchProgramEnvironment& env, ProControllerContext&
 
     RngCalibrations calibrations = {
         RNG_CALIBRATION.seed_calibration / FRLG_FRAME_DURATION,
-        RNG_CALIBRATION.advances_calibration,
-        RNG_CALIBRATION.csf_calibration
+        RNG_CALIBRATION.csf_calibration,
+        RNG_CALIBRATION.advances_calibration
     };
 
     AdvRngSearcher searcher(TARGET_SEED, ADVANCES, AdvRngMethod::Method1);

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngCalibration.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngCalibration.cpp
@@ -121,11 +121,45 @@ RngTimings prepare_timings(
         TEACHY_ADVANCES = uint64_t((int)std::floor((modified_ingame_advances - TEACHY_TV_BUFFER + 7500) / 313) * 313);
     }
 
+    double seed_delay = SEED_DELAY + calibrations.seed_offset + FIXED_SEED_OFFSET;
+    double csf_delay = (CONTINUE_SCREEN_FRAMES + calibrations.csf_offset) * FRLG_FRAME_DURATION;
+    double teachy_delay = TEACHY_ADVANCES * FRLG_FRAME_DURATION / 313;
+    double ingame_delay = (modified_ingame_advances - TEACHY_ADVANCES) * FRLG_FRAME_DURATION / 2 - (should_use_teachy_tv ? 14067 : 0);
+
+    if (seed_delay < 0){
+        OperationFailedException::fire(
+            ErrorReport::NO_ERROR_REPORT,
+            "prepare_timings(): seed delay cannot be negative. Check your calibration values.",
+            console
+        ); 
+    }
+        if (csf_delay < 0){
+        OperationFailedException::fire(
+            ErrorReport::NO_ERROR_REPORT,
+            "prepare_timings(): CSF duration cannot be negative. Check your calibration values.",
+            console
+        ); 
+    }
+        if (teachy_delay < 0){
+        OperationFailedException::fire(
+            ErrorReport::NO_ERROR_REPORT,
+            "prepare_timings(): Teachy TV duration cannot be negative. Check your calibration values.",
+            console
+        ); 
+    }
+    if (ingame_delay < 0){
+        OperationFailedException::fire(
+            ErrorReport::NO_ERROR_REPORT,
+            "prepare_timings(): in-game duration cannot be negative. Check your calibration values.",
+            console
+        ); 
+    }
+
     RngTimings timings;
-    timings.seed_delay   = uint64_t(SEED_DELAY + calibrations.seed_offset + FIXED_SEED_OFFSET);
-    timings.csf_delay    = uint64_t((CONTINUE_SCREEN_FRAMES + calibrations.csf_offset) * FRLG_FRAME_DURATION);
-    timings.teachy_delay = uint64_t(TEACHY_ADVANCES * FRLG_FRAME_DURATION / 313);
-    timings.ingame_delay = uint64_t((modified_ingame_advances - TEACHY_ADVANCES) * FRLG_FRAME_DURATION / 2) - (should_use_teachy_tv ? 14067 : 0);
+    timings.seed_delay   = uint64_t(seed_delay);
+    timings.csf_delay    = uint64_t(csf_delay);
+    timings.teachy_delay = uint64_t(teachy_delay);
+    timings.ingame_delay = uint64_t(ingame_delay);
 
     console.log("Seed delay: " + std::to_string(timings.seed_delay) + "ms");
     console.log("Continue Screen delay: " + std::to_string(timings.csf_delay) + "ms");
@@ -209,7 +243,7 @@ std::vector<std::pair<AdvRngState,AdvRngState>> get_egg_search_results(
     uint16_t tid_xor_sid
 ){
     std::vector<std::pair<AdvRngState,AdvRngState>> search_hits;
-    for (int i=0; i<4; i++){
+    for (int i=0; i<1; i++){
         uint64_t held_adv_radius = held_advances_radius * (uint64_t(1) << i);
         uint64_t held_min_adv = HELD_ADVANCES - std::min(uint64_t(HELD_ADVANCES), held_adv_radius);    
         uint64_t held_max_adv = HELD_ADVANCES + held_adv_radius;

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StarterRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StarterRng.cpp
@@ -600,8 +600,8 @@ void StarterRng::program(SingleSwitchProgramEnvironment& env, ProControllerConte
 
     RngCalibrations calibrations = {
         RNG_CALIBRATION.seed_calibration / FRLG_FRAME_DURATION,
-        RNG_CALIBRATION.advances_calibration,
-        RNG_CALIBRATION.csf_calibration
+        RNG_CALIBRATION.csf_calibration,
+        RNG_CALIBRATION.advances_calibration
     };
 
 

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StaticRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StaticRng.cpp
@@ -310,8 +310,8 @@ void StaticRng::program(SingleSwitchProgramEnvironment& env, ProControllerContex
 
     RngCalibrations calibrations = {
         RNG_CALIBRATION.seed_calibration / FRLG_FRAME_DURATION,
-        RNG_CALIBRATION.advances_calibration,
-        RNG_CALIBRATION.csf_calibration
+        RNG_CALIBRATION.csf_calibration,
+        RNG_CALIBRATION.advances_calibration
     };
 
     AdvRngSearcher searcher(TARGET_SEED, ADVANCES, AdvRngMethod::Method1);

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_WildRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_WildRng.cpp
@@ -359,8 +359,8 @@ void WildRng::program(SingleSwitchProgramEnvironment& env, ProControllerContext&
 
     RngCalibrations calibrations = {
         RNG_CALIBRATION.seed_calibration / FRLG_FRAME_DURATION,
-        RNG_CALIBRATION.advances_calibration,
-        RNG_CALIBRATION.csf_calibration
+        RNG_CALIBRATION.csf_calibration,
+        RNG_CALIBRATION.advances_calibration
     };
 
     AdvRngWildSearcher searcher(TARGET_SEED, ADVANCES, ENCOUNTER_SLOTS, AdvRngMethod::Any);


### PR DESCRIPTION
I managed to accidentally swap CSF and in-game calibration values from inputs, but didn't notice in testing because I started from 0 each time.

This fixes the issue (reported by Sheep Punter) and adds a check to make sure the conversion to uint is clean