### PR TITLE
Add Sorting by Origin Mark

### DIFF
--- a/SerialPrograms/Source/Pokemon/Options/Pokemon_BoxSortingTable.cpp
+++ b/SerialPrograms/Source/Pokemon/Options/Pokemon_BoxSortingTable.cpp
@@ -18,6 +18,7 @@ const EnumDropdownDatabase<SortingRuleType>& SortingRuleType_Database(){
         {SortingRuleType::Alpha, "alpha", "Alpha"},
         {SortingRuleType::Ball_Slug,    "ball_slug",    "Ball Type"},
         {SortingRuleType::Gender,    "gender",    "Gender (Male, Female, Genderless)"},
+        {SortingRuleType::Origin_Mark, "origin_mark", "Origin Mark"},
         //{SortingRuleType::Type,    "type",    "Types"}, Mainly used for testing. The order of the PokemonType Enum is not the most intuitive for sorting.
     });
     return database;

--- a/SerialPrograms/Source/Pokemon/Options/Pokemon_BoxSortingTable.h
+++ b/SerialPrograms/Source/Pokemon/Options/Pokemon_BoxSortingTable.h
@@ -25,6 +25,7 @@ enum class SortingRuleType
     Gender,
     Type,
     Tera_Type,
+    Origin_Mark,
 };
 
 struct SortingRule

--- a/SerialPrograms/Source/Pokemon/Pokemon_CollectedPokemonInfo.cpp
+++ b/SerialPrograms/Source/Pokemon/Pokemon_CollectedPokemonInfo.cpp
@@ -30,7 +30,8 @@ bool operator==(const CollectedPokemonInfo& lhs, const CollectedPokemonInfo& rhs
            lhs.ot_name == rhs.ot_name &&
            lhs.primary_type == rhs.primary_type &&
            lhs.secondary_type == rhs.secondary_type &&
-           lhs.tera_type == rhs.tera_type;
+           lhs.tera_type == rhs.tera_type &&
+           lhs.origin_mark == rhs.origin_mark;
 }
 
 
@@ -89,6 +90,11 @@ bool operator<(const std::optional<CollectedPokemonInfo>& lhs, const std::option
                 return (lhs->tera_type < rhs->tera_type) != preference.reverse;
             }
             break;
+        case SortingRuleType::Origin_Mark:
+            if (lhs->origin_mark != rhs->origin_mark){
+                return (lhs->origin_mark < rhs->origin_mark) != preference.reverse;
+            }
+            break;
         default:
             throw InternalProgramError(nullptr, PA_CURRENT_FUNCTION, "unknown SortingRuleType");
         } // end switch
@@ -114,6 +120,7 @@ std::ostream& operator<<(std::ostream& os, const std::optional<CollectedPokemonI
         os << "primaryType:" << POKEMON_TYPE_SLUGS().get_string(pokemon->primary_type) << " ";
         os << "secondaryType:" << POKEMON_TYPE_SLUGS().get_string(pokemon->secondary_type) << " ";
         os << "teraType:" << POKEMON_TERA_TYPE_SLUGS().get_string(pokemon->tera_type) << " ";
+        os << "originMark:" << ORIGIN_MARK_SLUGS().get_string(pokemon->origin_mark) << " ";
         os << ")";
     }else{
         os << "(empty)";
@@ -168,6 +175,7 @@ void save_boxes_data_to_json(const std::vector<std::optional<CollectedPokemonInf
             pokemon["primary_type"] = POKEMON_TYPE_SLUGS().get_string(current_pokemon->primary_type);
             pokemon["secondary_type"] = POKEMON_TYPE_SLUGS().get_string(current_pokemon->secondary_type);
             pokemon["tera_type"] = POKEMON_TERA_TYPE_SLUGS().get_string(current_pokemon->tera_type);
+            pokemon["origin_mark"] = ORIGIN_MARK_SLUGS().get_string(current_pokemon->origin_mark);
         }
         pokemon_data.push_back(std::move(pokemon));
     }

--- a/SerialPrograms/Source/Pokemon/Pokemon_CollectedPokemonInfo.h
+++ b/SerialPrograms/Source/Pokemon/Pokemon_CollectedPokemonInfo.h
@@ -14,6 +14,7 @@
 #include <ostream>
 #include "Pokemon/Options/Pokemon_StatsHuntFilter.h"
 #include "Pokemon/Options/Pokemon_BoxSortingTable.h"
+#include "Pokemon_OriginMarks.h"
 #include "Pokemon_Types.h"
 
 namespace PokemonAutomation{
@@ -36,6 +37,7 @@ struct CollectedPokemonInfo{
     PokemonType primary_type = PokemonType::NONE;
     PokemonType secondary_type = PokemonType::NONE;
     PokemonTeraType tera_type = PokemonTeraType::NONE;
+    OriginMark origin_mark = OriginMark::NONE;
 };
 
 bool operator==(const CollectedPokemonInfo& lhs, const CollectedPokemonInfo& rhs);

--- a/SerialPrograms/Source/PokemonHome/Inference/PokemonHome_OriginMarkReader.cpp
+++ b/SerialPrograms/Source/PokemonHome/Inference/PokemonHome_OriginMarkReader.cpp
@@ -83,6 +83,20 @@ const MarkIconMatcher& MarkIcon_Alola(){
     return ret;
 }
 
+const MarkIconMatcher& MarkIcon_GameBoy(){
+    static MarkIconMatcher ret(
+        "PokemonHome/OriginMarks/gameboy.png",
+        "gameboy",
+        Color(0xff61645b), Color(0xff646664),
+        10,
+        30.0,
+        {
+            {0xff61645b, 0xff646664},
+        }
+        );
+    return ret;
+}
+
 const MarkIconMatcher& MarkIcon_Go(){
     static MarkIconMatcher ret(
         "PokemonHome/OriginMarks/go.png",
@@ -187,6 +201,7 @@ const std::vector<const MarkIconMatcher*>& ALL_ORIGIN_MARK_MATCHERS(){
     static const std::vector<const MarkIconMatcher*> matchers = {
         &MarkIcon_Kalos(),
         &MarkIcon_Alola(),
+        &MarkIcon_GameBoy(),
         &MarkIcon_Go(),
         &MarkIcon_Lgpe(),
         &MarkIcon_Galar(),
@@ -204,6 +219,8 @@ const MarkIconMatcher& get_mark_icon_matcher(OriginMark mark){
         return MarkIcon_Kalos();
     case OriginMark::ALOLA:
         return MarkIcon_Alola();
+    case OriginMark::GAMEBOY:
+        return MarkIcon_GameBoy();
     case OriginMark::GO:
         return MarkIcon_Go();
     case OriginMark::LGPE:

--- a/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxNavigation.cpp
+++ b/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxNavigation.cpp
@@ -29,6 +29,7 @@
 #include "PokemonHome/Inference/PokemonHome_BallReader.h"
 #include "PokemonHome/Inference/PokemonHome_BoxGenderDetector.h"
 #include "PokemonHome/Inference/PokemonHome_GigantamaxDetector.h"
+#include "PokemonHome/Inference/PokemonHome_OriginMarkReader.h"
 #include "PokemonHome/Inference/PokemonHome_TeraTypeReader.h"
 #include "PokemonHome_BoxNavigation.h"
 
@@ -229,7 +230,7 @@ void read_summary_screen(
     ImageFloatBox national_dex_number_box(0.448, 0.245, 0.049, 0.04); //pokemon national dex number pos
     ImageFloatBox shiny_symbol_box(0.702, 0.09, 0.04, 0.06); // shiny symbol pos
     ImageFloatBox gmax_tera_symbol_box(0.463, 0.09, 0.04, 0.06); // gmax OR tera symbol pos
-    ImageFloatBox origin_symbol_box(0.623, 0.095, 0.033, 0.05); // origin symbol pos
+    ImageFloatBox origin_symbol_box(0.617, 0.084, 0.044, 0.069); // origin symbol pos
     ImageFloatBox pokemon_box(0.69, 0.18, 0.28, 0.46); // pokemon render pos
     ImageFloatBox level_box(0.546, 0.099, 0.044, 0.041); // Level
     ImageFloatBox ot_id_box(0.782, 0.719, 0.193, 0.046); // OT ID
@@ -332,6 +333,8 @@ void read_summary_screen(
         env.log("Normalized trainer name: " + normalized);
         cur_pokemon_info.ot_name = normalized;
     }
+
+    cur_pokemon_info.origin_mark = OriginMarkReader().read_mark(screen, origin_symbol_box);
 
     env.add_overlay_log(create_overlay_info(cur_pokemon_info));
     video_overlay_set.clear();


### PR DESCRIPTION
New feature for regular Home Sorter - Sorting by Origin Mark. 
Added detection for the Virtual Console "GameBoy" mark.

Resources PR https://github.com/PokemonAutomation/Packages/pull/67