### PR TITLE
Tweak FRLG StartMenuDetector

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_StartMenuDetector.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_StartMenuDetector.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "Common/Cpp/Color.h"
+#include "CommonTools/Images/SolidColorTest.h"
 #include "CommonFramework/ImageTypes/ImageViewRGB32.h"
 #include "CommonFramework/VideoPipeline/VideoOverlayScopes.h"
 #include "PokemonFRLG/PokemonFRLG_Settings.h"
@@ -17,13 +18,24 @@ namespace PokemonFRLG{
 
 StartMenuDetector::StartMenuDetector(Color color)
     : m_selection_arrow(color, nullptr, MENU_ARROW_BOX)
+    , m_menu_top_box(0.728365, 0.043509, 0.238462, 0.006490)
+    , m_menu_left_box(0.728365, 0.050000, 0.003365, 0.427644)
 {}
 void StartMenuDetector::make_overlays(VideoOverlaySet& items) const{
     const BoxOption& GAME_BOX = GameSettings::instance().GAME_BOX;
     items.add(COLOR_RED, GAME_BOX.inner_to_outer(MENU_ARROW_BOX));
+    items.add(COLOR_RED, GAME_BOX.inner_to_outer(m_menu_top_box));
+    items.add(COLOR_RED, GAME_BOX.inner_to_outer(m_menu_left_box));
 }
 bool StartMenuDetector::detect(const ImageViewRGB32& screen){
-    return m_selection_arrow.detect(screen);
+    ImageViewRGB32 game_screen = extract_box_reference(screen, GameSettings::instance().GAME_BOX);
+    ImageViewRGB32 menu_top_image = extract_box_reference(game_screen, m_menu_top_box);
+    ImageViewRGB32 menu_left_image = extract_box_reference(game_screen, m_menu_left_box);
+    return (
+        m_selection_arrow.detect(screen)
+        && is_white(menu_top_image)
+        && is_white(menu_left_image)
+    );
 }
 
 

--- a/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_StartMenuDetector.h
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_StartMenuDetector.h
@@ -29,6 +29,8 @@ public:
 
 private:
     SelectionArrowDetector m_selection_arrow;
+    ImageFloatBox m_menu_top_box;
+    ImageFloatBox m_menu_left_box;
 };
 class StartMenuWatcher : public DetectorToFinder<StartMenuDetector>{
 public:

--- a/SerialPrograms/Source/PokemonFRLG/Programs/PokemonFRLG_StartMenuNavigation.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/PokemonFRLG_StartMenuNavigation.cpp
@@ -36,6 +36,7 @@ void open_start_menu(ConsoleHandle& console, ProControllerContext& context){
         int ret = run_until<ProControllerContext>(
             console, context,
             [](ProControllerContext& context){
+                pbf_wait(context, 500ms);
                 pbf_press_button(context, BUTTON_PLUS, 200ms, 1800ms);
             },
             { start_menu }


### PR DESCRIPTION
This adds `is_white()` checks for the menu background to the `StartMenuDetector` to try to avoid false positives from certain overworld backgrounds (probably only Navel Rock, but possibly others).

Also adds a short pause before the + button press in `open_start_menu()` to give the watcher some time to detect if the menu is already open. 