### PR TITLE
small FRLG RNG tweaks and fixes

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/Inference/Dialogs/PokemonFRLG_PartyDialogs.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/Dialogs/PokemonFRLG_PartyDialogs.cpp
@@ -48,7 +48,7 @@ PartyLevelUpDetector::PartyLevelUpDetector(Color color, PartyLevelUpDialog dialo
     , m_border_right_box(0.982692, 0.025923, 0.001923, 0.597115)
     , m_dialog_top_box(0.626282, 0.042492, 0.341026, 0.006175)  // white
     , m_dialog_right_box(0.967949, 0.050923, 0.003846, 0.550962)
-    , m_plus_box(0.862663, 0.051852, 0.034267, 0.553560)
+    , m_plus_box(0.862663, 0.051852, 0.017788, 0.553560)
     , m_plus_box_jpn(0.895663, 0.051852, 0.021267, 0.553560)
 {}
 void PartyLevelUpDetector::make_overlays(VideoOverlaySet& items) const{

--- a/SerialPrograms/Source/PokemonFRLG/Inference/PokemonFRLG_WildEncounterReader.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/PokemonFRLG_WildEncounterReader.cpp
@@ -41,7 +41,7 @@ void WildEncounterReader::make_overlays(VideoOverlaySet& items) const {
 PokemonFRLG_WildEncounter WildEncounterReader::read_encounter(
     Logger& logger, Language language,
     const ImageViewRGB32& frame, 
-    std::set<std::string>& subset,
+    const std::set<std::string>& subset,
     double max_log10p
 ){
     const bool jpn = language == Language::Japanese;

--- a/SerialPrograms/Source/PokemonFRLG/Inference/PokemonFRLG_WildEncounterReader.h
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/PokemonFRLG_WildEncounterReader.h
@@ -42,7 +42,7 @@ public:
     PokemonFRLG_WildEncounter read_encounter(
         Logger& logger, Language language,
         const ImageViewRGB32& frame, 
-        std::set<std::string>& subset,
+        const std::set<std::string>& subset,
         double max_log10p = MAX_LOG10P
     );
 

--- a/SerialPrograms/Source/PokemonFRLG/PokemonFRLG_Navigation.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/PokemonFRLG_Navigation.cpp
@@ -880,7 +880,7 @@ void fly_from_kanto_map(ConsoleHandle& console, ProControllerContext& context, K
         // blindly move the cursor to the specified fly spot
         switch (destination){
         case KantoFlyLocation::pallettown:
-            pbf_move_left_joystick(context, {0, -1}, 850ms, 100ms);
+            pbf_move_left_joystick(context, {0, -1}, 900ms, 100ms);
             pbf_move_left_joystick(context, {+1, 0}, 317ms, 100ms);
             break;
         case KantoFlyLocation::viridiancity:

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_GiftRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_GiftRng.cpp
@@ -174,7 +174,7 @@ GiftRng::GiftRng()
         "The number of rare candies in your bag. Make sure these are at the top position of the bag.<br>"
         "Rare candies used during calibration will be restored after resetting.",
         LockMode::UNLOCK_WHILE_RUNNING,
-        0, 0, 999 // default, min, max
+        0, 0, 95 // default, min, max
     )
     , PROFILE(
         "<b>User Profile Position:</b><br>"
@@ -484,7 +484,11 @@ void GiftRng::program(SingleSwitchProgramEnvironment& env, ProControllerContext&
             search_hits = get_search_results(env.console, searcher, filters, SEED_VALUES, ADVANCES, advances_radius, GENDER_THRESHOLD);
             RNG_CALIBRATION.set_hits(search_hits);     
 
-            bool force_finish = failed || (i == (MAX_RARE_CANDIES - 1));
+            bool force_finish = (
+                   failed 
+                || (i == (MAX_RARE_CANDIES - 1))
+                || all_indistinguishable(search_hits, searcher, GENDER_THRESHOLD)
+            );
             finished = update_history(
                 env.console, advance_history, 
                 calibration_history, MAX_HISTORY_LENGTH, 

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngHelper.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngHelper.cpp
@@ -285,7 +285,7 @@ void RngHelper::program(SingleSwitchProgramEnvironment& env, ProControllerContex
         stats.resets++;
 
         // detect shinies
-        shiny_found = check_for_shiny(env.console, context, TARGET, LANGUAGE);
+        shiny_found = check_for_shiny(env.console, context, TARGET);
         if (shiny_found){
             env.log("Shiny found!");
             stats.shinies++;

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngHelper.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngHelper.cpp
@@ -285,7 +285,7 @@ void RngHelper::program(SingleSwitchProgramEnvironment& env, ProControllerContex
         stats.resets++;
 
         // detect shinies
-        shiny_found = check_for_shiny(env.console, context, TARGET);
+        shiny_found = check_for_shiny(env.console, context, TARGET, LANGUAGE);
         if (shiny_found){
             env.log("Shiny found!");
             stats.shinies++;

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngNavigation.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngNavigation.cpp
@@ -208,6 +208,7 @@ int auto_catch(
                 return catch_detected ? static_cast<int>(i) : 0;
             case 3:
                 console.log("Black screen detected. Battle exited.");
+                pbf_mash_button(context, BUTTON_B, 2500ms);
                 return catch_detected ? static_cast<int>(i) : 0;
             case 4: 
                 console.log("Catch detected!", COLOR_BLUE);
@@ -299,6 +300,9 @@ bool use_rare_candy(
         pbf_move_left_joystick(context, {-1, 0}, 200ms, 800ms);
         pbf_move_left_joystick(context, {-1, 0}, 200ms, 800ms);
         pbf_move_left_joystick(context, {-1, 0}, 200ms, 800ms);
+        pbf_move_left_joystick(context, {0, +1}, 200ms, 300ms);
+        pbf_move_left_joystick(context, {0, +1}, 200ms, 300ms);
+        pbf_move_left_joystick(context, {0, +1}, 200ms, 300ms);
     }
 
     // use rare candy and watch for the party screen

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StarterRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StarterRng.cpp
@@ -798,7 +798,7 @@ void StarterRng::program(SingleSwitchProgramEnvironment& env, ProControllerConte
                 env.log("RNG search not complete after 3 level-ups.");
                 finished = update_history(
                     env.console, advance_history, calibration_history, 
-                    MAX_HISTORY_LENGTH, calibrations, search_hits, 5
+                    MAX_HISTORY_LENGTH, calibrations, search_hits, 5, 2, true
                 );         
                 break;
             }

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StaticRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StaticRng.cpp
@@ -166,14 +166,14 @@ StaticRng::StaticRng()
         "The number of rare candies in your bag. Make sure these are at the top position of the bag.<br>"
         "Rare candies used during calibration will be restored after resetting.",
         LockMode::UNLOCK_WHILE_RUNNING,
-        0, 0, 999 // default, min, max
+        0, 0, 70 // default, min, max
     )
     , MAX_BALL_THROWS(
         "<b>Max Balls Thrown:</b><br>"
         "The number of " + STRING_POKEBALL + "s in your bag to attempt to throw. Make sure these are at the top position of the bag.<br>"
         "Balls thrown during calibration will be restored after resetting.",
         LockMode::UNLOCK_WHILE_RUNNING,
-        20, 1, 999 // default, min, max
+        30, 1, 999 // default, min, max
     )
     , PROFILE(
         "<b>User Profile Position:</b><br>"
@@ -477,7 +477,11 @@ void StaticRng::program(SingleSwitchProgramEnvironment& env, ProControllerContex
             search_hits = get_search_results(env.console, searcher, filters, SEED_VALUES, ADVANCES, advances_radius, GENDER_THRESHOLD);
             RNG_CALIBRATION.set_hits(search_hits);    
 
-            bool force_finish = failed || (i == (MAX_RARE_CANDIES - 1));
+            bool force_finish = (
+                   failed 
+                || (i == (MAX_RARE_CANDIES - 1))
+                || all_indistinguishable(search_hits, searcher, GENDER_THRESHOLD)
+            );
             finished = update_history(
                 env.console, advance_history, 
                 calibration_history, MAX_HISTORY_LENGTH, 

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_WildRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_WildRng.cpp
@@ -195,14 +195,14 @@ WildRng::WildRng()
         "The number of rare candies in your bag. Make sure these are at the top position of the bag.<br>"
         "Rare candies used during calibration will be restored after resetting.",
         LockMode::UNLOCK_WHILE_RUNNING,
-        0, 0, 999 // default, min, max
+        0, 0, 98 // default, min, max
     )
     , MAX_BALL_THROWS(
         "<b>Max Balls Thrown:</b><br>"
         "The number of " + STRING_POKEBALL + "s in your bag to attempt to throw. Make sure these are at the top position of the bag.<br>"
         "Balls thrown during calibration will be restored after resetting.",
         LockMode::UNLOCK_WHILE_RUNNING,
-        20, 1, 999 // default, min, max
+        30, 1, 999 // default, min, max
     )
     , PROFILE(
         "<b>User Profile Position:</b><br>"
@@ -559,14 +559,17 @@ void WildRng::program(SingleSwitchProgramEnvironment& env, ProControllerContext&
             search_hits = get_wild_search_results(env.console, searcher, filters, SEED_VALUES, ADVANCES, advances_radius, gender_threshold, SUPER_ROD);
             RNG_CALIBRATION.set_hits(search_hits);         
 
-            bool force_finish = failed || (i == (MAX_RARE_CANDIES - 1));
+            bool force_finish = (
+                   failed 
+                || (i == (MAX_RARE_CANDIES - 1))
+                || all_indistinguishable(search_hits, searcher, gender_threshold, SUPER_ROD)
+            );
             finished = update_history(
                 env.console, advance_history, 
                 calibration_history, MAX_HISTORY_LENGTH,
                 calibrations, search_hits, 
                 1, 2, force_finish
             );
-            finished = finished || all_indistinguishable(search_hits, searcher, gender_threshold, SUPER_ROD);
         }
 
         env.log("RNG search finished.");


### PR DESCRIPTION
This makes a few small changes that are mostly relevant to the Roaming Legendary RNG program
- small fix for flying to Pallet Town (unused by other programs up to now)
- small stability improvement when exiting a battle in auto_catch()
- better box placement in PartyLevelUpDetector (avoids issues with 3-digit stat totals)
- fixed bug preventing RNG history updates when hits are all_indistinguishable()
- changed default ball throws to 30 to match Safari game
- reduced max values for Rare Candies in RNG programs