### PR TITLE
Home Fix Y position calculation

### DIFF
--- a/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxNavigation.cpp
+++ b/SerialPrograms/Source/PokemonHome/Programs/PokemonHome_BoxNavigation.cpp
@@ -185,7 +185,7 @@ std::array<size_t, 2> find_occupied_slots_in_box(
     int num_empty_slots = 0;
     for (size_t row = 0; row < BOX_ROWS; row++) {
         for (size_t col = 0; col < BOX_COLS; col++) {
-            ImageFloatBox slot_box(0.06 + (0.072 * col), 0.2 + (0.1035 * row), 0.03, 0.057);
+            ImageFloatBox slot_box(0.06 + (0.072 * col), 0.2 + (0.105 * row), 0.03, 0.057);
             int current_box_value = (int)image_stddev(extract_box_reference(screen, slot_box)).sum();
 
             ss << current_box_value;


### PR DESCRIPTION
The current y position calculation was slightly off. This was causing missed detections for the bottom row.
Current state Maushold and other short sprites would be too low for detection.

Top row box:
<img width="804" height="666" alt="Screenshot 2026-06-02 220205" src="https://github.com/user-attachments/assets/c9fc1a76-a4f9-4175-b163-84335bef1d4d" />

Bottom row box:
<img width="753" height="644" alt="Screenshot 2026-06-02 220329" src="https://github.com/user-attachments/assets/3c8eda7e-e2b8-4461-b686-f168083b3e7c" />

Updated bottom row
<img width="745" height="623" alt="Screenshot 2026-06-03 213112" src="https://github.com/user-attachments/assets/0a58fcfc-4f40-4390-8708-34a2263f249a" />
