### PR TITLE
FRLG Item Dupe Faster

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/Programs/Farming/PokemonFRLG_ItemDuplication.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/Farming/PokemonFRLG_ItemDuplication.cpp
@@ -178,9 +178,7 @@ void ItemDuplication::program(SingleSwitchProgramEnvironment& env, ProController
 
         // Dectect "???" screen?
 
-        pbf_press_dpad(context, DPAD_UP, 200ms, 100ms);
-        pbf_press_dpad(context, DPAD_LEFT, 200ms, 100ms);
-        pbf_press_button(context, BUTTON_A, 200ms, 100ms);
+        pbf_press_button(context, BUTTON_PLUS, 200ms, 100ms);
 
         // Confirmation prompt in "???" screen
         int ret5 = wait_until(


### PR DESCRIPTION
The START button skips the ??? screen. Removing the need to navigate to OK.
~10 minutes faster for a stack of 900 items.
Suggested by Arc

<img width="1134" height="705" alt="image" src="https://github.com/user-attachments/assets/ecd046be-dd0b-4830-ad2e-f089b55aa803" />
