### PR TITLE
Alpha sorting was actually using the gmax field

### DIFF
--- a/SerialPrograms/Source/Pokemon/Pokemon_CollectedPokemonInfo.cpp
+++ b/SerialPrograms/Source/Pokemon/Pokemon_CollectedPokemonInfo.cpp
@@ -64,7 +64,7 @@ bool operator<(const std::optional<CollectedPokemonInfo>& lhs, const std::option
             break;
         case SortingRuleType::Alpha:
             if (lhs->alpha != rhs->alpha){
-                return lhs->gmax != preference.reverse;
+                return lhs->alpha != preference.reverse;
             }
             break;
         case SortingRuleType::Ball_Slug:


### PR DESCRIPTION
This fix affects PLZA Box Sorter and Home Box Sorter.

Reported by Maxxetto
https://ptb.discord.com/channels/695809740428673034/711649658220314635/1514370130363154504