### PR TITLE
FRLG Calibration Tweaks

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_GiftRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_GiftRng.cpp
@@ -461,9 +461,14 @@ void GiftRng::program(SingleSwitchProgramEnvironment& env, ProControllerContext&
 
         std::vector<AdvRngState> search_hits = get_search_results(env.console, searcher, filters, SEED_VALUES, ADVANCES, advances_radius, GENDER_THRESHOLD);
         RNG_CALIBRATION.set_hits(search_hits);       
+        bool force_finish = (
+              (MAX_RARE_CANDIES == 0) 
+            || all_equal(search_hits) 
+            || all_indistinguishable(search_hits, searcher, GENDER_THRESHOLD)  
+        );
         bool finished = update_history(
             env.console, uncertain_history, calibration_history, MAX_HISTORY_LENGTH, 
-            calibrations, search_hits, 1, 2, MAX_RARE_CANDIES == 0
+            calibrations, search_hits, 1, 2, force_finish
         );
 
         for (uint64_t i=0; i<MAX_RARE_CANDIES; i++){
@@ -486,11 +491,12 @@ void GiftRng::program(SingleSwitchProgramEnvironment& env, ProControllerContext&
             RNG_FILTERS.set(filters);
 
             search_hits = get_search_results(env.console, searcher, filters, SEED_VALUES, ADVANCES, advances_radius, GENDER_THRESHOLD);
-            RNG_CALIBRATION.set_hits(search_hits);     
+            RNG_CALIBRATION.set_hits(search_hits);
 
-            bool force_finish = (
+            force_finish = (
                    failed 
                 || (i == (MAX_RARE_CANDIES - 1))
+                || all_equal(search_hits)
                 || all_indistinguishable(search_hits, searcher, GENDER_THRESHOLD)
             );
             finished = update_history(

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngCalibration.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngCalibration.cpp
@@ -414,17 +414,17 @@ RngCalibrations get_calibrations(
                 calibrations.csf_offset = prev_csf_offset + 0.5;
             }
             calibrations.csf_offset = fmod(calibrations.csf_offset, 2);
-            calibrations.ingame_offset = prev_ingame_offset; // leave unchanged
+            calibrations.ingame_offset = get_advances_calibration(history, advances) - calibrations.csf_offset;
         }else if(csf_first){
             // adjust the csf, putting anything beyond +/-2 frames into the in-game calibration
             double new_advances_calibration = get_advances_calibration(history, advances);
             double total_diff = new_advances_calibration - prev_ingame_offset - prev_csf_offset;
             calibrations.csf_offset = fmod(prev_csf_offset + total_diff, 2);
-            double csf_diff = calibrations.csf_offset - prev_csf_offset;
-            calibrations.ingame_offset = prev_ingame_offset + total_diff - csf_diff;
+            calibrations.ingame_offset = new_advances_calibration - calibrations.csf_offset;
         }else{
             // only adjust the in-game offset
-            calibrations.ingame_offset = get_advances_calibration(history, advances);
+            calibrations.csf_offset = prev_csf_offset;
+            calibrations.ingame_offset = get_advances_calibration(history, advances) - prev_csf_offset;
         }
     }
 
@@ -448,74 +448,63 @@ bool update_history(
         return true;
     }
 
-    if (!force_finish && search_hits.size() > max_advance_possibilities){
+    if (!force_finish && search_hits.size() > max_advance_possibilities && !all_equal(search_hits)){
         return false;
     }
-
-    if (search_hits.size() == 1){
-        console.log("Hit " + to_hex_string(search_hits[0].seed) + " / " + std::to_string(search_hits[0].advance));
-        console.log("Updating calibrations...");
-        calibration_history.calibrations.emplace_back(calibrations);
-        calibration_history.results.emplace_back(search_hits[0]);
-        if (calibration_history.results.size() > max_history_length){
-            calibration_history.calibrations.erase(calibration_history.calibrations.begin());
-            calibration_history.results.erase(calibration_history.results.begin());
-        }
-        uncertain_history.results.clear();
-        uncertain_history.calibrations.clear();
-        return true;
-    }
     
-    std::vector<int64_t> uncal_advances;
+    std::vector<int64_t> uncal_advances; // hit advance - calibrations
     std::vector<AdvRngState> hits;
     for(auto hit : search_hits) {
         uncal_advances.emplace_back(int64_t(std::round(hit.advance - calibrations.csf_offset - calibrations.ingame_offset)));
         hits.emplace_back(hit);
     }
     
-    // get unique advances
+    // get unique advances from new search results
     std::sort(uncal_advances.begin(), uncal_advances.end());
     std::vector<int64_t>::iterator iter;
     iter = std::unique(uncal_advances.begin(), uncal_advances.begin() + uncal_advances.size());
     uncal_advances.resize(std::distance(uncal_advances.begin(), iter));
 
+    int64_t mode = 0;
     uncertain_history.calibrations.emplace_back(calibrations);
     uncertain_history.results.emplace_back(hits);
-    
-    // check advance history for repeated values
-    std::vector<uint64_t> counts;
-    uint64_t best = 0;
-    int64_t mode = 0; // sum of calibration and hit advance
-    bool tie = false;
-    for (int64_t& uadv : uncal_advances){
-        uint64_t count = 0;
-        for (size_t i=0; i<uncertain_history.results.size(); i++){
-            auto& cals = uncertain_history.calibrations[i];
-            auto& res = uncertain_history.results[i];
-            for (auto& state : res){
-                if (std::abs(int64_t(std::round(state.advance - cals.csf_offset - cals.ingame_offset)) - uadv) <= advance_radius){
-                    count++;
-                    break; // only count one possible hit from each attempt
+
+    if (uncal_advances.size() == 1){
+        mode = uncal_advances[0];
+    }else {        
+        // check advance history for repeated values
+        std::vector<uint64_t> counts;
+        uint64_t best = 0;
+        bool tie = false;
+        for (int64_t& uadv : uncal_advances){
+            uint64_t count = 0;
+            for (size_t i=0; i<uncertain_history.results.size(); i++){
+                auto& cals = uncertain_history.calibrations[i];
+                auto& res = uncertain_history.results[i];
+                for (auto& state : res){
+                    if (std::abs(int64_t(std::round(state.advance - cals.csf_offset - cals.ingame_offset)) - uadv) <= advance_radius){
+                        count++;
+                        break; // only count one possible hit from each attempt
+                    }
                 }
             }
+            if (count > best){
+                mode = uadv;
+                best = count;
+                tie = false;
+            }else if (count == best){
+                tie = true;
+            }
         }
-        if (count > best){
-            mode = uadv;
-            best = count;
-            tie = false;
-        }else if (count == best){
-            tie = true;
+
+        if (tie){
+            console.log("More than 1 possible advances value hit.");
+            return true;
         }
     }
-
-    if (tie){
-        console.log("More than 1 possible advances value hit.");
-        return true;
-    }
-
-
+    
     // add the closest possibility to the advances mode for each attempt to the calibration history
-    console.log("Inferred hits from previous " + std::to_string(uncertain_history.results.size()) + " attempts: ");
+    console.log("Hits from previous " + std::to_string(uncertain_history.results.size()) + " attempt(s): ");
     for (size_t i=0; i<uncertain_history.results.size(); i++){
         auto& cals = uncertain_history.calibrations[i];
         auto& res = uncertain_history.results[i];
@@ -545,6 +534,18 @@ bool update_history(
     return true;
 }
 
+bool all_equal(const std::vector<AdvRngState>& search_hits){
+    if (search_hits.size() < 2){ return true; }
+    const AdvRngState& first = search_hits[0];
+    for (size_t i=1; i<search_hits.size(); i++){
+        if (search_hits[i].seed != first.seed
+         || search_hits[i].advance != first.advance
+        ){
+            return false;
+        }
+    }
+    return true;
+}
 
 
 bool are_indistinguishable(AdvPokemonResult res1, AdvPokemonResult res2, const int16_t& gender_threshold){

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngCalibration.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngCalibration.h
@@ -158,6 +158,8 @@ bool update_history(
     bool force_finish = false
 );
 
+bool all_equal(const std::vector<AdvRngState>& search_hits);
+
 bool all_indistinguishable(const std::vector<AdvRngState>& hits, AdvRngSearcher& searcher, const int16_t& gender_threshold);
 bool all_indistinguishable(const std::vector<AdvRngState>& hits, AdvRngWildSearcher& searcher, const int16_t& gender_threshold, bool super_rod);
 bool all_indistinguishable(

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RoamingLegendaryRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RoamingLegendaryRng.cpp
@@ -431,12 +431,16 @@ void RoamingLegendaryRng::program(SingleSwitchProgramEnvironment& env, ProContro
         RNG_FILTERS.set(filters);
 
         std::vector<AdvRngState> search_hits = get_search_results(env.console, searcher, filters, SEED_VALUES, ADVANCES, advances_radius, GENDER_THRESHOLD);
-        RNG_CALIBRATION.set_hits(search_hits);       
+        RNG_CALIBRATION.set_hits(search_hits);      
+        bool force_finish = (
+               (MAX_RARE_CANDIES == 0) 
+            || all_equal(search_hits) 
+            || all_indistinguishable(search_hits, searcher, GENDER_THRESHOLD)
+        );
         bool finished = update_history(
             env.console, uncertain_history, calibration_history, MAX_HISTORY_LENGTH, 
-            calibrations, search_hits, 1, 2, MAX_RARE_CANDIES == 0
+            calibrations, search_hits, 1, 2, force_finish
         );
-        finished = finished || all_indistinguishable(search_hits, searcher, GENDER_THRESHOLD);
 
         for (uint64_t i=0; i<MAX_RARE_CANDIES; i++){
             if (finished){
@@ -460,9 +464,10 @@ void RoamingLegendaryRng::program(SingleSwitchProgramEnvironment& env, ProContro
             search_hits = get_search_results(env.console, searcher, filters, SEED_VALUES, ADVANCES, advances_radius, GENDER_THRESHOLD);
             RNG_CALIBRATION.set_hits(search_hits);     
 
-            bool force_finish = (
+            force_finish = (
                    failed 
                 || (i == (MAX_RARE_CANDIES - 1)) 
+                || all_equal(search_hits)
                 || all_indistinguishable(search_hits, searcher, GENDER_THRESHOLD)
             );
             finished = update_history(

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StaticRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StaticRng.cpp
@@ -454,10 +454,15 @@ void StaticRng::program(SingleSwitchProgramEnvironment& env, ProControllerContex
         RNG_FILTERS.set(filters);
 
         std::vector<AdvRngState> search_hits = get_search_results(env.console, searcher, filters, SEED_VALUES, ADVANCES, advances_radius, GENDER_THRESHOLD);
-        RNG_CALIBRATION.set_hits(search_hits);      
+        RNG_CALIBRATION.set_hits(search_hits);    
+        bool force_finish = (
+               (MAX_RARE_CANDIES == 0) 
+            || all_equal(search_hits) 
+            || all_indistinguishable(search_hits, searcher, GENDER_THRESHOLD)
+        );  
         bool finished = update_history(
             env.console, uncertain_history, calibration_history, MAX_HISTORY_LENGTH, 
-            calibrations, search_hits, 1, 2, MAX_RARE_CANDIES == 0
+            calibrations, search_hits, 1, 2, force_finish
         );
 
         for (uint64_t i=0; i<MAX_RARE_CANDIES; i++){
@@ -481,9 +486,10 @@ void StaticRng::program(SingleSwitchProgramEnvironment& env, ProControllerContex
             search_hits = get_search_results(env.console, searcher, filters, SEED_VALUES, ADVANCES, advances_radius, GENDER_THRESHOLD);
             RNG_CALIBRATION.set_hits(search_hits);    
 
-            bool force_finish = (
+            force_finish = (
                    failed 
                 || (i == (MAX_RARE_CANDIES - 1))
+                || all_equal(search_hits)
                 || all_indistinguishable(search_hits, searcher, GENDER_THRESHOLD)
             );
             finished = update_history(

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_WildRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_WildRng.cpp
@@ -539,9 +539,13 @@ void WildRng::program(SingleSwitchProgramEnvironment& env, ProControllerContext&
         RNG_FILTERS.set(filters);
 
         std::vector<AdvRngState> search_hits = get_wild_search_results(env.console, searcher, filters, SEED_VALUES, ADVANCES, advances_radius, gender_threshold, SUPER_ROD);
-        RNG_CALIBRATION.set_hits(search_hits);           
-        bool finished = update_history(env.console, uncertain_history, calibration_history, MAX_HISTORY_LENGTH, calibrations, search_hits, 1, 2, MAX_RARE_CANDIES == 0);
-        finished = finished || all_indistinguishable(search_hits, searcher, gender_threshold, SUPER_ROD);
+        RNG_CALIBRATION.set_hits(search_hits);  
+        bool force_finish = (
+               (MAX_RARE_CANDIES == 0) 
+            || all_equal(search_hits) 
+            || all_indistinguishable(search_hits, searcher, gender_threshold, SUPER_ROD)
+        );      
+        bool finished = update_history(env.console, uncertain_history, calibration_history, MAX_HISTORY_LENGTH, calibrations, search_hits, 1, 2, force_finish);
 
         for (uint64_t i=0; i<MAX_RARE_CANDIES; i++){
             if (finished){
@@ -563,9 +567,10 @@ void WildRng::program(SingleSwitchProgramEnvironment& env, ProControllerContext&
             search_hits = get_wild_search_results(env.console, searcher, filters, SEED_VALUES, ADVANCES, advances_radius, gender_threshold, SUPER_ROD);
             RNG_CALIBRATION.set_hits(search_hits);         
 
-            bool force_finish = (
+            force_finish = (
                    failed 
                 || (i == (MAX_RARE_CANDIES - 1))
+                || all_equal(search_hits)
                 || all_indistinguishable(search_hits, searcher, gender_threshold, SUPER_ROD)
             );
             finished = update_history(


### PR DESCRIPTION
This reverts one of the changes in #1283 that might have resulted in worse calibration performance in some cases.

It also makes a small change to ensure that `update_history()` never ends up wasting calibration information if all possible hits are identical before rare candy is used.