### PR TITLE
FRLG party empty slot detector

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyEmptySlotDetector.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyEmptySlotDetector.cpp
@@ -35,11 +35,9 @@ ImageFloatBox PartyEmptySlotDetector::box_for_slot(PartySlot slot){
 
 PartyEmptySlotDetector::PartyEmptySlotDetector(
     Color color,
-    VideoOverlay* overlay,
     PartySlot slot
 )
     : m_color(color)
-    , m_overlay(overlay)
     , m_box(box_for_slot(slot))
 {}
 void PartyEmptySlotDetector::make_overlays(VideoOverlaySet& items) const{

--- a/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyEmptySlotDetector.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyEmptySlotDetector.cpp
@@ -6,6 +6,7 @@
 
 #include "Common/Cpp/Exceptions.h"
 #include "CommonTools/Images/SolidColorTest.h"
+#include "PokemonFRLG/PokemonFRLG_Settings.h"
 #include "PokemonFRLG_PartyEmptySlotDetector.h"
 
 namespace PokemonAutomation{
@@ -50,6 +51,7 @@ bool PartyEmptySlotDetector::detect(const ImageViewRGB32& screen){
     ImageViewRGB32 game_screen = extract_box_reference(screen, GAME_BOX);
     const auto stats = image_stats(extract_box_reference(game_screen, m_box));
     return stats.stddev.sum() < 20.0;
+}
 }
 }
 }

--- a/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyEmptySlotDetector.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyEmptySlotDetector.cpp
@@ -1,0 +1,55 @@
+/*  Party Empty Slot Detector
+ *
+ *  From: https://github.com/PokemonAutomation/
+ *
+ */
+
+#include "Common/Cpp/Exceptions.h"
+#include "CommonTools/Images/SolidColorTest.h"
+#include "PokemonFRLG_PartyEmptySlotDetector.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonFRLG{
+
+ImageFloatBox PartyEmptySlotDetector::box_for_slot(PartySlot slot){
+    switch (slot){
+    case PartySlot::ONE:
+        throw InternalProgramError(nullptr, PA_CURRENT_FUNCTION, "Invalid FRLG Party Empty Slot. Slot 1 should always be occupied.");
+    case PartySlot::TWO:
+        return ImageFloatBox(0.432, 0.150, 0.025, 0.050);
+    case PartySlot::THREE:
+        return ImageFloatBox(0.432, 0.3, 0.025, 0.050);
+    case PartySlot::FOUR:
+        return ImageFloatBox(0.432, 0.45, 0.025, 0.050);
+    case PartySlot::FIVE:
+        return ImageFloatBox(0.432, 0.6, 0.025, 0.050);
+    case PartySlot::SIX:
+        return ImageFloatBox(0.432, 0.725, 0.025, 0.050);
+    default:
+        break;
+    }
+    throw InternalProgramError(nullptr, PA_CURRENT_FUNCTION, "Invalid FRLG Party Empty Slot.");
+}
+
+PartyEmptySlotDetector::PartyEmptySlotDetector(
+    Color color,
+    VideoOverlay* overlay,
+    PartySlot slot
+)
+    : m_color(color)
+    , m_overlay(overlay)
+    , m_box(box_for_slot(slot))
+{}
+void PartyEmptySlotDetector::make_overlays(VideoOverlaySet& items) const{
+    const BoxOption& GAME_BOX = GameSettings::instance().GAME_BOX;
+    items.add(m_color, GAME_BOX.inner_to_outer(m_box));
+}
+bool PartyEmptySlotDetector::detect(const ImageViewRGB32& screen){
+    const BoxOption& GAME_BOX = GameSettings::instance().GAME_BOX;
+    ImageViewRGB32 game_screen = extract_box_reference(screen, GAME_BOX);
+    const auto stats = image_stats(extract_box_reference(game_screen, m_box));
+    return stats.stddev.sum() < 20.0;
+}
+}
+}

--- a/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyEmptySlotDetector.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyEmptySlotDetector.cpp
@@ -18,15 +18,15 @@ ImageFloatBox PartyEmptySlotDetector::box_for_slot(PartySlot slot){
     case PartySlot::ONE:
         throw InternalProgramError(nullptr, PA_CURRENT_FUNCTION, "Invalid FRLG Party Empty Slot. Slot 1 should always be occupied.");
     case PartySlot::TWO:
-        return ImageFloatBox(0.432, 0.150, 0.025, 0.050);
+        return ImageFloatBox(0.709, 0.078, 0.01, 0.018);
     case PartySlot::THREE:
-        return ImageFloatBox(0.432, 0.3, 0.025, 0.050);
+        return ImageFloatBox(0.709, 0.228, 0.01, 0.018);
     case PartySlot::FOUR:
-        return ImageFloatBox(0.432, 0.45, 0.025, 0.050);
+        return ImageFloatBox(0.709, 0.378, 0.01, 0.018);
     case PartySlot::FIVE:
-        return ImageFloatBox(0.432, 0.6, 0.025, 0.050);
+        return ImageFloatBox(0.709, 0.527, 0.01, 0.018);
     case PartySlot::SIX:
-        return ImageFloatBox(0.432, 0.725, 0.025, 0.050);
+        return ImageFloatBox(0.709, 0.677, 0.01, 0.018);
     default:
         break;
     }
@@ -48,7 +48,7 @@ bool PartyEmptySlotDetector::detect(const ImageViewRGB32& screen){
     const BoxOption& GAME_BOX = GameSettings::instance().GAME_BOX;
     ImageViewRGB32 game_screen = extract_box_reference(screen, GAME_BOX);
     const auto stats = image_stats(extract_box_reference(game_screen, m_box));
-    return stats.stddev.sum() < 20.0;
+    return stats.stddev.sum() > 20.0;
 }
 }
 }

--- a/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyEmptySlotDetector.h
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyEmptySlotDetector.h
@@ -7,9 +7,10 @@
 #ifndef PokemonAutomation_PokemonFRLG_PartyEmptySlotDetector_H
 #define PokemonAutomation_PokemonFRLG_PartyEmptySlotDetector_H
 
+#include <chrono>
 #include "CommonFramework/VideoPipeline/VideoOverlayScopes.h"
 #include "CommonTools/VisualDetector.h"
-#include "PokemonFRLG_PartyMenuDetector.h"
+#include "PokemonFRLG_PartySlot.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{

--- a/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyEmptySlotDetector.h
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyEmptySlotDetector.h
@@ -1,0 +1,50 @@
+/*  Party Empty Slot Detector
+ *
+ *  From: https://github.com/PokemonAutomation/
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonFRLG_PartyEmptySlotDetector_H
+#define PokemonAutomation_PokemonFRLG_PartyEmptySlotDetector_H
+
+#include "CommonFramework/VideoPipeline/VideoOverlayScopes.h"
+#include "CommonTools/VisualDetector.h"
+#include "PokemonFRLG_PartyMenuDetector.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonFRLG{
+
+class PartyEmptySlotDetector : public StaticScreenDetector{
+public:
+    PartyEmptySlotDetector(
+        Color color,
+        VideoOverlay* overlay,
+        PartySlot slot
+    );
+    static ImageFloatBox box_for_slot(PartySlot slot);
+    virtual void make_overlays(VideoOverlaySet& items) const override;
+    // This is not const so that detectors can save/cache state.
+    virtual bool detect(const ImageViewRGB32& screen) override;
+
+private:
+    Color m_color;
+    VideoOverlay* m_overlay;
+    ImageFloatBox m_box;
+};
+class PartyEmptySlotWatcher : public DetectorToFinder<PartyEmptySlotDetector>{
+public:
+    PartyEmptySlotWatcher(
+        Color color,
+        VideoOverlay* overlay,
+        PartySlot slot,
+        std::chrono::milliseconds hold_duration = std::chrono::milliseconds(250)
+    )
+        : DetectorToFinder("PartyEmptySlotWatcher", hold_duration, color, overlay, slot)
+    {}
+};
+
+}
+}
+}
+#endif

--- a/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyEmptySlotDetector.h
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyEmptySlotDetector.h
@@ -20,7 +20,6 @@ class PartyEmptySlotDetector : public StaticScreenDetector{
 public:
     PartyEmptySlotDetector(
         Color color,
-        VideoOverlay* overlay,
         PartySlot slot
     );
     static ImageFloatBox box_for_slot(PartySlot slot);
@@ -30,19 +29,7 @@ public:
 
 private:
     Color m_color;
-    VideoOverlay* m_overlay;
     ImageFloatBox m_box;
-};
-class PartyEmptySlotWatcher : public DetectorToFinder<PartyEmptySlotDetector>{
-public:
-    PartyEmptySlotWatcher(
-        Color color,
-        VideoOverlay* overlay,
-        PartySlot slot,
-        std::chrono::milliseconds hold_duration = std::chrono::milliseconds(250)
-    )
-        : DetectorToFinder("PartyEmptySlotWatcher", hold_duration, color, overlay, slot)
-    {}
 };
 
 }

--- a/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyHeldItemDetector.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyHeldItemDetector.cpp
@@ -37,19 +37,19 @@ public:
     }
 };
 
-ImageFloatBox PartyHeldItemDetector::box_for_slot(PartyHeldItemSlot slot){
+ImageFloatBox PartyHeldItemDetector::box_for_slot(PartySlot slot){
     switch (slot){
-    case PartyHeldItemSlot::SLOT_1:
+    case PartySlot::ONE:
         return ImageFloatBox(0.069, 0.285, 0.025, 0.050);
-    case PartyHeldItemSlot::SLOT_2:
+    case PartySlot::TWO:
         return ImageFloatBox(0.432, 0.150, 0.025, 0.050);
-    case PartyHeldItemSlot::SLOT_3:
+    case PartySlot::THREE:
         return ImageFloatBox(0.432, 0.3, 0.025, 0.050);
-    case PartyHeldItemSlot::SLOT_4:
+    case PartySlot::FOUR:
         return ImageFloatBox(0.432, 0.45, 0.025, 0.050);
-    case PartyHeldItemSlot::SLOT_5:
+    case PartySlot::FIVE:
         return ImageFloatBox(0.432, 0.6, 0.025, 0.050);
-    case PartyHeldItemSlot::SLOT_6:
+    case PartySlot::SIX:
         return ImageFloatBox(0.432, 0.725, 0.025, 0.050);
     default:
         break;
@@ -60,7 +60,7 @@ ImageFloatBox PartyHeldItemDetector::box_for_slot(PartyHeldItemSlot slot){
 PartyHeldItemDetector::PartyHeldItemDetector(
     Color color,
     VideoOverlay* overlay,
-    PartyHeldItemSlot slot
+    PartySlot slot
 )
     : m_color(color)
     , m_overlay(overlay)

--- a/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyHeldItemDetector.h
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyHeldItemDetector.h
@@ -7,22 +7,14 @@
 #ifndef PokemonAutomation_PokemonFRLG_PartyHeldItemDetector_H
 #define PokemonAutomation_PokemonFRLG_PartyHeldItemDetector_H
 
+#include <chrono>
 #include "CommonFramework/VideoPipeline/VideoOverlayScopes.h"
 #include "CommonTools/VisualDetector.h"
+#include "PokemonFRLG_PartySlot.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
 namespace PokemonFRLG{
-
-
-enum class PartyHeldItemSlot{
-    SLOT_1,
-    SLOT_2,
-    SLOT_3,
-    SLOT_4,
-    SLOT_5,
-    SLOT_6
-};
 
 class PartyHeldItemDetector : public StaticScreenDetector{
 public:
@@ -34,10 +26,10 @@ public:
     PartyHeldItemDetector(
         Color color,
         VideoOverlay* overlay,
-        PartyHeldItemSlot slot
+        PartySlot slot
     );
 
-    static ImageFloatBox box_for_slot(PartyHeldItemSlot slot);
+    static ImageFloatBox box_for_slot(PartySlot slot);
 
     const ImageFloatBox& last_detected() const { return m_last_detected; }
 
@@ -69,7 +61,7 @@ public:
     PartyHeldItemWatcher(
         Color color,
         VideoOverlay* overlay,
-        PartyHeldItemSlot slot,
+        PartySlot slot,
         std::chrono::milliseconds hold_duration = std::chrono::milliseconds(250)
     )
         : DetectorToFinder("PartyHeldItemWatcher", hold_duration, color, overlay, box_for_slot(slot))

--- a/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyMenuDetector.h
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyMenuDetector.h
@@ -14,22 +14,13 @@
 #include "CommonTools/VisualDetector.h"
 #include "CommonTools/InferenceCallbacks/VisualInferenceCallback.h"
 #include "PokemonFRLG/PokemonFRLG_Settings.h"
+#include "PokemonFRLG_PartySlot.h"
 
 namespace PokemonAutomation{
     class CancellableScope;
     class VideoFeed;
 namespace NintendoSwitch{
 namespace PokemonFRLG{
-
-enum class PartySlot{
-    ONE,
-    TWO,
-    THREE,
-    FOUR,
-    FIVE,
-    SIX
-    //CXL
-};
 
 // The Party menu has a white box on the bottom
 // The background around the edges is dark teal/navy

--- a/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartySlot.h
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartySlot.h
@@ -1,0 +1,27 @@
+/*  Party Slot
+ *
+ *  From: https://github.com/PokemonAutomation/
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonFRLG_PartySlot_H
+#define PokemonAutomation_PokemonFRLG_PartySlot_H
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonFRLG{
+
+enum class PartySlot{
+    ONE,
+    TWO,
+    THREE,
+    FOUR,
+    FIVE,
+    SIX
+    //CXL
+};
+
+}
+}
+}
+#endif

--- a/SerialPrograms/Source/PokemonFRLG/PokemonFRLG_Navigation.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/PokemonFRLG_Navigation.cpp
@@ -25,16 +25,16 @@
 #include "PokemonFRLG/Inference/Dialogs/PokemonFRLG_BattleDialogs.h"
 #include "PokemonFRLG/Inference/Dialogs/PokemonFRLG_PartyDialogs.h"
 #include "PokemonFRLG/Inference/Sounds/PokemonFRLG_ShinySoundDetector.h"
+#include "PokemonFRLG/Inference/Menus/PokemonFRLG_BagDetector.h"
 #include "PokemonFRLG/Inference/Menus/PokemonFRLG_StartMenuDetector.h"
 #include "PokemonFRLG/Inference/Menus/PokemonFRLG_LoadMenuDetector.h"
 #include "PokemonFRLG/Inference/Menus/PokemonFRLG_SummaryDetector.h"
+#include "PokemonFRLG/Inference/Menus/PokemonFRLG_PartyEmptySlotDetector.h"
 #include "PokemonFRLG/Inference/Menus/PokemonFRLG_PartyMenuDetector.h"
-#include "PokemonFRLG/Inference/Menus/PokemonFRLG_BagDetector.h"
 #include "PokemonFRLG/Inference/Map/PokemonFRLG_MapDetector.h"
 #include "PokemonFRLG/Inference/PokemonFRLG_BattlePokemonDetector.h"
 #include "PokemonFRLG/Programs/PokemonFRLG_StartMenuNavigation.h"
 #include "PokemonFRLG_Navigation.h"
-#include "Inference/Menus/PokemonFRLG_PartyEmptySlotDetector.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{

--- a/SerialPrograms/Source/PokemonFRLG/PokemonFRLG_Navigation.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/PokemonFRLG_Navigation.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <array>
 #include "CommonFramework/Exceptions/OperationFailedException.h"
 #include "CommonFramework/VideoPipeline/VideoFeed.h"
 #include "CommonTools/Random.h"
@@ -33,6 +34,7 @@
 #include "PokemonFRLG/Inference/PokemonFRLG_BattlePokemonDetector.h"
 #include "PokemonFRLG/Programs/PokemonFRLG_StartMenuNavigation.h"
 #include "PokemonFRLG_Navigation.h"
+#include "Inference/Menus/PokemonFRLG_PartyEmptySlotDetector.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
@@ -753,6 +755,26 @@ void open_party_menu_from_overworld(ConsoleHandle& console, ProControllerContext
             continue;
         }
     }
+}
+
+PartySlot detect_last_occupied_party_slot(ConsoleHandle& console){
+    const auto snapshot = console.video().snapshot();
+    constexpr std::array slots{
+        PartySlot::SIX,
+        PartySlot::FIVE,
+        PartySlot::FOUR,
+        PartySlot::THREE,
+        PartySlot::TWO,
+    };
+
+    for (PartySlot slot : slots){
+        PartyEmptySlotDetector empty_slot_detector(COLOR_RED, slot);
+        if (!empty_slot_detector.detect(snapshot)){
+            return slot;
+        }
+    }
+
+    return PartySlot::ONE;
 }
 
 void open_bag_from_overworld(ConsoleHandle& console, ProControllerContext& context, StartMenuContext menu_context){

--- a/SerialPrograms/Source/PokemonFRLG/PokemonFRLG_Navigation.h
+++ b/SerialPrograms/Source/PokemonFRLG/PokemonFRLG_Navigation.h
@@ -11,7 +11,7 @@
 
 #include "CommonFramework/Tools/VideoStream.h"
 #include "NintendoSwitch/Controllers/Procon/NintendoSwitch_ProController.h"
-#include "Inference/Menus/PokemonFRLG_PartySlot.h"
+#include "PokemonFRLG/Inference/Menus/PokemonFRLG_PartySlot.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{

--- a/SerialPrograms/Source/PokemonFRLG/PokemonFRLG_Navigation.h
+++ b/SerialPrograms/Source/PokemonFRLG/PokemonFRLG_Navigation.h
@@ -11,6 +11,7 @@
 
 #include "CommonFramework/Tools/VideoStream.h"
 #include "NintendoSwitch/Controllers/Procon/NintendoSwitch_ProController.h"
+#include "Inference/Menus/PokemonFRLG_PartySlot.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
@@ -79,6 +80,9 @@ enum class StartMenuContext {
     NO_DEX,
 };
 void open_party_menu_from_overworld(ConsoleHandle& console, ProControllerContext& context, StartMenuContext menu_context = StartMenuContext::STANDARD);
+
+// Starting from the party menu, detect the last occupied party slot
+PartySlot detect_last_occupied_party_slot(ConsoleHandle& console);
 
 // Starting from the start menu, a sub-screen of the start menu, or the overworld, navigate to the bag
 void open_bag_from_overworld(ConsoleHandle& console, ProControllerContext& context, StartMenuContext menu_context = StartMenuContext::STANDARD);

--- a/SerialPrograms/Source/PokemonFRLG/Programs/Farming/PokemonFRLG_ItemDuplication.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/Farming/PokemonFRLG_ItemDuplication.cpp
@@ -86,7 +86,7 @@ void ItemDuplication::program(SingleSwitchProgramEnvironment& env, ProController
     ImageFloatBox mail_arrow_box{ 0.3670769231, 0.06373076639, 0.028, 0.077 };
     ImageFloatBox mail_confirmation_arrow_box{ 0.7289230769, 0.4604230588, 0.029, 0.076 };
     SelectionArrowWatcher mail_selection_arrow(COLOR_BLUE, &env.console.overlay(), mail_arrow_box);
-    PartyHeldItemWatcher farfetchd_held_item(COLOR_BLUE, &env.console.overlay(), PartyHeldItemSlot::SLOT_1);
+    PartyHeldItemWatcher farfetchd_held_item(COLOR_BLUE, &env.console.overlay(), PartySlot::ONE);
     AdvanceWhiteDialogWatcher item_description(COLOR_BLUE);
     SelectionArrowWatcher confirmation_arrow(COLOR_BLUE, &env.console.overlay(), SelectionArrowPositionConfirmationMenu::YES);
     SelectionArrowWatcher mail_confirmation_arrow(COLOR_BLUE, &env.console.overlay(), mail_confirmation_arrow_box);

--- a/SerialPrograms/cmake/SourceFiles.cmake
+++ b/SerialPrograms/cmake/SourceFiles.cmake
@@ -1478,6 +1478,7 @@ file(GLOB LIBRARY_SOURCES
     Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyHeldItemDetector.h
     Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyMenuDetector.cpp
     Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyMenuDetector.h
+    Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartySlot.h
     Source/PokemonFRLG/Inference/Menus/PokemonFRLG_TrainerCardDetector.cpp
     Source/PokemonFRLG/Inference/Menus/PokemonFRLG_TrainerCardDetector.h
     Source/PokemonFRLG/Inference/Menus/PokemonFRLG_DexRegistrationDetector.cpp

--- a/SerialPrograms/cmake/SourceFiles.cmake
+++ b/SerialPrograms/cmake/SourceFiles.cmake
@@ -1472,6 +1472,8 @@ file(GLOB LIBRARY_SOURCES
     Source/PokemonFRLG/Inference/Menus/PokemonFRLG_BagDetector.h
     Source/PokemonFRLG/Inference/Menus/PokemonFRLG_LoadMenuDetector.cpp
     Source/PokemonFRLG/Inference/Menus/PokemonFRLG_LoadMenuDetector.h
+    Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyEmptySlotDetector.cpp
+    Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyEmptySlotDetector.h
     Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyHeldItemDetector.cpp
     Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyHeldItemDetector.h
     Source/PokemonFRLG/Inference/Menus/PokemonFRLG_PartyMenuDetector.cpp


### PR DESCRIPTION
Detector and helper method for determining occupied party slots.
Empty slots have a striped background.
Occupied slots have a solid background. Continues to work if the selector is hovering over one of the party members.
Noticed there were multiple Party Slot enums. Condensed them to a single enum in a separate file.