### PR TITLE
Make PaddleOCR a default resource and the default.

### DIFF
--- a/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.cpp
+++ b/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.cpp
@@ -141,11 +141,11 @@ GlobalSettings::GlobalSettings()
 #endif
     )
     , THEME(CONSTRUCT_TOKEN)
-    , USE_PADDLE_OCR(
+    , USE_PADDLE_OCR0(
         "<b>Enable PaddleOCR:</b><br>"
         "Use PaddleOCR instead of Tesseract for OCR.",
         LockMode::UNLOCK_WHILE_RUNNING,
-        false
+        true
     )
     , USE_GPU_FOR_ML_INFERENCE(
         "<b>Use GPU for Machine learning inference:</b><br>"
@@ -277,7 +277,7 @@ GlobalSettings::GlobalSettings()
     PA_ADD_OPTION(USE_GPU_FOR_ML_INFERENCE);
 
     // gated behind Dev mode. see GlobalSettings::load_json
-    PA_ADD_OPTION(USE_PADDLE_OCR);
+    PA_ADD_OPTION(USE_PADDLE_OCR0);
     PA_ADD_OPTION(RESOURCE_DOWNLOAD_TABLE);
     PA_ADD_OPTION(DOWNLOAD_ERROR);
 
@@ -326,7 +326,7 @@ GlobalSettings::GlobalSettings()
 
     PA_ADD_OPTION(DEVELOPER_TOKEN);
 
-    USE_PADDLE_OCR.set_visibility(ConfigOptionState::HIDDEN);
+    USE_PADDLE_OCR0.set_visibility(ConfigOptionState::HIDDEN);
     RESOURCE_DOWNLOAD_TABLE.set_visibility(ConfigOptionState::HIDDEN);
     DOWNLOAD_ERROR.set_visibility(ConfigOptionState::HIDDEN);
     SAVE_DEBUG_VIDEOS_ON_SWITCH.set_visibility(ConfigOptionState::HIDDEN);
@@ -350,7 +350,7 @@ void GlobalSettings::load_json(const JsonValue& json){
     ConfigOptionState devmode_visibility = developer_mode
         ? ConfigOptionState::ENABLED
         : ConfigOptionState::HIDDEN;
-    USE_PADDLE_OCR.set_visibility(devmode_visibility);
+    USE_PADDLE_OCR0.set_visibility(devmode_visibility);
     RESOURCE_DOWNLOAD_TABLE.set_visibility(devmode_visibility);
     DOWNLOAD_ERROR.set_visibility(devmode_visibility);
     SAVE_DEBUG_VIDEOS_ON_SWITCH.set_visibility(devmode_visibility);

--- a/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.h
+++ b/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.h
@@ -127,7 +127,7 @@ public:
     FolderInputOption TEMP_FOLDER;
 
     Pimpl<ThemeSelectorOption> THEME;
-    BooleanCheckBoxOption USE_PADDLE_OCR;
+    BooleanCheckBoxOption USE_PADDLE_OCR0;
     BooleanCheckBoxOption USE_GPU_FOR_ML_INFERENCE;
     SettingsResourceDownloadTable RESOURCE_DOWNLOAD_TABLE;
     SettingsDownloadError DOWNLOAD_ERROR;

--- a/SerialPrograms/Source/CommonTools/OCR/OCR_Routines.cpp
+++ b/SerialPrograms/Source/CommonTools/OCR/OCR_Routines.cpp
@@ -28,7 +28,7 @@ namespace OCR{
 // that all the other languages are downloaded too, since they're all downloaded
 // as a bundle.
 bool use_paddle_ocr(){
-    static bool use_paddle_ocr = GlobalSettings::instance().USE_PADDLE_OCR && paddle_ocr_language_available(Language::English);
+    static bool use_paddle_ocr = GlobalSettings::instance().USE_PADDLE_OCR0 && paddle_ocr_language_available(Language::English);
 
     return use_paddle_ocr;
 }

--- a/SerialPrograms/Source/ML/Inference/ML_PaddleOCRPipeline.cpp
+++ b/SerialPrograms/Source/ML/Inference/ML_PaddleOCRPipeline.cpp
@@ -5,9 +5,7 @@
  *  
  */
 
-#include <iostream>
 #include <fstream>
-#include <numeric>
 #include <limits>
 #include "CommonFramework/Globals.h"
 #include "CommonFramework/GlobalSettingsPanel.h"
@@ -20,7 +18,7 @@ namespace ML{
 
 
 std::pair<std::string, std::string> PaddleOCRPipeline::get_paths(Language language){
-    std::string base = DOWNLOADED_RESOURCE_PATH() + "PaddleOCR/";
+    std::string base = RESOURCE_PATH() + "PaddleOCR/";
     switch(language){
     case Language::None:
         throw InternalProgramError(nullptr, PA_CURRENT_FUNCTION, "Attempted to call OCR without a language.");

--- a/SerialPrograms/Source/PokemonFRLG/Inference/PokemonFRLG_BattleLevelUpReader.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/PokemonFRLG_BattleLevelUpReader.cpp
@@ -55,7 +55,7 @@ StatReads BattleLevelUpReader::read_stats(Logger &logger, const ImageViewRGB32& 
     auto read_stat = [&](const ImageFloatBox &box, const std::string &name){
         ImageViewRGB32 stat_region = extract_box_reference(game_screen, box);
 
-        if (!GlobalSettings::instance().USE_PADDLE_OCR){
+        if (!GlobalSettings::instance().USE_PADDLE_OCR0){
             // Tesseract-free path: waterfill segmentation + template matching
             // against the PokemonFRLG/Digits/0-9.png templates.
             return read_digits_waterfill_template(logger, stat_region);

--- a/SerialPrograms/Source/PokemonFRLG/Inference/PokemonFRLG_PartyLevelUpReader.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/PokemonFRLG_PartyLevelUpReader.cpp
@@ -55,7 +55,7 @@ StatReads PartyLevelUpReader::read_stats(Logger &logger, const ImageViewRGB32& f
     auto read_stat = [&](const ImageFloatBox &box, const std::string &name){
         ImageViewRGB32 stat_region = extract_box_reference(game_screen, box);
 
-        if (!GlobalSettings::instance().USE_PADDLE_OCR){
+        if (!GlobalSettings::instance().USE_PADDLE_OCR0){
             // Tesseract-free path: waterfill segmentation + template matching
             // against the PokemonFRLG/Digits/0-9.png templates.
             return read_digits_waterfill_template(logger, stat_region);

--- a/SerialPrograms/Source/PokemonFRLG/Inference/PokemonFRLG_StatsReader.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/PokemonFRLG_StatsReader.cpp
@@ -191,7 +191,7 @@ void StatsReader::read_level(
 
     ImageViewRGB32 level_box = extract_box_reference(game_screen, jpn ? m_box_level_jpn : m_box_level);
 
-    if (!GlobalSettings::instance().USE_PADDLE_OCR){
+    if (!GlobalSettings::instance().USE_PADDLE_OCR0){
         // The level uses white text with dark shadow on a lilac background.
         // The digit reader's binarizer captures dark pixels (<=190 on all channels)
         // but NOT the white text (all channels 255 -> excluded). This leaves the
@@ -335,7 +335,7 @@ void StatsReader::read_page2(
     auto read_stat = [&](const ImageFloatBox& box, const std::string& name){
         ImageViewRGB32 stat_region = extract_box_reference(game_screen, box);
 
-        if (!GlobalSettings::instance().USE_PADDLE_OCR){
+        if (!GlobalSettings::instance().USE_PADDLE_OCR0){
             // Tesseract-free path: waterfill segmentation + template matching
             // against the PokemonFRLG/Digits/0-9.png templates.
             return read_digits_waterfill_template(logger, stat_region);

--- a/SerialPrograms/Source/PokemonFRLG/Inference/PokemonFRLG_TrainerIdReader.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/PokemonFRLG_TrainerIdReader.cpp
@@ -43,7 +43,7 @@ uint16_t TrainerIdReader::read_tid(
     
     ImageViewRGB32 tid_region = extract_box_reference(game_screen, language == Language::Japanese ? m_box_tid_jpn : m_box_tid);
 
-    if (!GlobalSettings::instance().USE_PADDLE_OCR){
+    if (!GlobalSettings::instance().USE_PADDLE_OCR0){
         // Tesseract-free path: waterfill segmentation + template matching
         // against the PokemonFRLG/Digits/0-9.png templates.
         return uint16_t(read_digits_waterfill_template(logger, tid_region));


### PR DESCRIPTION
Don't merge until we are ready to do this migration. This means the multi-line changes exceptions for Tesseract need to go in first.

Also: https://github.com/PokemonAutomation/Packages/pull/77

The renaming of the parameter is just to override everyone's configs which will already have been set to false.