### PR TITLE
Make PaddleOCR the default

### DIFF
--- a/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.cpp
+++ b/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.cpp
@@ -148,7 +148,7 @@ GlobalSettings::GlobalSettings()
             {OcrLibrary::TESSERACT,            "tesseract",              "Tesseract"},
         },
         LockMode::LOCK_WHILE_RUNNING,
-        OcrLibrary::TESSERACT
+        OcrLibrary::PADDLE_OCR
     )
     , OCR_WARNING(
         "WARNING: If you change the OCR library away from the default (PaddleOCR), you must ensure that you have the necessary resource downloaded. "

--- a/SerialPrograms/Source/ML/Inference/ML_PaddleOCRPipeline.cpp
+++ b/SerialPrograms/Source/ML/Inference/ML_PaddleOCRPipeline.cpp
@@ -20,7 +20,7 @@ namespace ML{
 
 
 std::pair<std::string, std::string> PaddleOCRPipeline::get_paths(Language language){
-    std::string base = DOWNLOADED_RESOURCE_PATH() + "PaddleOCR/";
+    std::string base = RESOURCE_PATH() + "PaddleOCR/";
     switch(language){
     case Language::None:
         throw InternalProgramError(nullptr, PA_CURRENT_FUNCTION, "Attempted to call OCR without a language.");


### PR DESCRIPTION
Don't merge until the migration is ready.
The tests will fail until PaddleOCR is merged into Resources.