### PR TITLE
add FRLG SeedsDatabase and simplify RNG program UI

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_EggRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_EggRng.cpp
@@ -143,6 +143,16 @@ EggRng::EggRng()
         LockMode::LOCK_WHILE_RUNNING,
         GameVersion::firered
         )
+    , SOUND(
+        "<b>Sound:</b><br>"
+        "Your in-game sound setting. This affects the possible seeds.",
+        {
+            {SoundSetting::Mono, "mono", "Mono"},
+            {SoundSetting::Stereo, "stereo", "Stereo"}
+        },
+        LockMode::LOCK_WHILE_RUNNING,
+        SoundSetting::Mono
+        )
     , m_target_settings("Target Settings")
     , EGG_SPECIES(
         "<b>Egg Species:</b>",
@@ -166,42 +176,6 @@ EggRng::EggRng()
         "70FE", "70FE",
         true
         )
-    , HELD_SEED_LIST(
-        "<b>Nearby Held Seeds:</b><br>"
-        "This box should contain a list of seeds (in order) around and including your held seed, with one seed on each line",
-        LockMode::LOCK_WHILE_RUNNING,
-        "D000\n199A\n77A1\nAABC\n280C\n70FE\nB573\n02F2\n8084\nA533\nED1E",
-        "D000\n199A\n77A1\nAABC\n280C\n70FE\nB573\n02F2\n8084\nA533\nED1E",
-        true
-        )
-    , HELD_SEED_BUTTON(
-        "<b>Held Seed Button:</b><br>",
-        {
-            {SeedButton::A, "A", "A"},
-            {SeedButton::Start, "Start", "Start"},
-            {SeedButton::L, "L", "L (L=A)"},
-        },
-        LockMode::LOCK_WHILE_RUNNING,
-        SeedButton::A
-        )
-    , HELD_EXTRA_BUTTON(
-        "<b>Held Seed Extra Button:</b><br>"
-        "Additional button presses that affect the seed.",
-        {
-            {BlackoutButton::None, "None", "None"},
-            {BlackoutButton::L, "L", "Blackout L"},
-            {BlackoutButton::R, "R", "Blackout R"},
-        },
-        LockMode::LOCK_WHILE_RUNNING,
-        BlackoutButton::None
-        )
-    , HELD_SEED_DELAY(
-        "<b>Held Seed Delay Time (ms):</b><br>"
-        "The delay between starting the game and advancing past the title screen. Set this to match your held seed.<br>"
-        "<i>If using Ten Lines, select <b>Nintendo Switch 1</b> as your console even if using a Switch 2.</i>",
-        LockMode::LOCK_WHILE_RUNNING,
-        31338, 30400 // default, min
-        )
     , HELD_ADVANCES(
         "<b>Held Advances:</b><br>The total number of RNG advances for your held target.",
         LockMode::LOCK_WHILE_RUNNING,
@@ -215,48 +189,18 @@ EggRng::EggRng()
         "70FE", "70FE",
         true
         )
-    , PICKUP_SEED_LIST(
-        "<b>Nearby Pickup Seeds:</b><br>"
-        "This box should contain a list of seeds (in order) around and including your held seed, with one seed on each line",
-        LockMode::LOCK_WHILE_RUNNING,
-        "D000\n199A\n77A1\nAABC\n280C\n70FE\nB573\n02F2\n8084\nA533\nED1E",
-        "D000\n199A\n77A1\nAABC\n280C\n70FE\nB573\n02F2\n8084\nA533\nED1E",
-        true
-        )
-    , PICKUP_SEED_BUTTON(
-        "<b>Pickup Seed Button:</b><br>",
-        {
-            {SeedButton::A, "A", "A"},
-            {SeedButton::Start, "Start", "Start"},
-            {SeedButton::L, "L", "L (L=A)"},
-        },
-        LockMode::LOCK_WHILE_RUNNING,
-        SeedButton::A
-        )
-    , PICKUP_EXTRA_BUTTON(
-        "<b>Pickup Seed Extra Button:</b><br>"
-        "Additional button presses that affect the seed.",
-        {
-            {BlackoutButton::None, "None", "None"},
-            {BlackoutButton::L, "L", "Blackout L"},
-            {BlackoutButton::R, "R", "Blackout R"},
-        },
-        LockMode::LOCK_WHILE_RUNNING,
-        BlackoutButton::None
-        )
-    , PICKUP_SEED_DELAY(
-        "<b>Pickup Seed Delay Time (ms):</b><br>"
-        "The delay between starting the game and advancing past the title screen. Set this to match your held seed.<br>"
-        "<i>If using Ten Lines, select <b>Nintendo Switch 1</b> as your console even if using a Switch 2.</i>",
-        LockMode::LOCK_WHILE_RUNNING,
-        31338, 30400 // default, min
-        )
     , PICKUP_ADVANCES(
         "<b>Pickup Advances:</b><br>The total number of RNG advances for your pickup target.",
         LockMode::LOCK_WHILE_RUNNING,
         10000, 700, 1000000000 // default, min
         )
     , m_program_settings("Program Settings")
+    , SEED_RADIUS(
+        "<b>Nearby Seed Radius:</b><br>"
+        "The number of nearby seeds on each side of the target to search when identifying which seed was hit.",
+        LockMode::LOCK_WHILE_RUNNING,
+        5, 1 // default, min
+        )
     , STARTING_POINT(
         "<b>Starting Point:</b>",
         {
@@ -319,25 +263,19 @@ EggRng::EggRng()
     PA_ADD_OPTION(m_game_info);
     PA_ADD_OPTION(LANGUAGE);
     PA_ADD_OPTION(GAME_VERSION);
+    PA_ADD_OPTION(SOUND);
     PA_ADD_OPTION(m_target_settings);
     PA_ADD_OPTION(EGG_SPECIES);
     PA_ADD_OPTION(COMPATIBILITY);
     PA_ADD_OPTION(PARENT_IVS);
     PA_ADD_OPTION(m_held_settings);
     PA_ADD_OPTION(HELD_SEED);
-    PA_ADD_OPTION(HELD_SEED_LIST);
-    PA_ADD_OPTION(HELD_SEED_BUTTON);
-    PA_ADD_OPTION(HELD_EXTRA_BUTTON);
-    PA_ADD_OPTION(HELD_SEED_DELAY);
     PA_ADD_OPTION(HELD_ADVANCES);
     PA_ADD_OPTION(m_pickup_settings);
     PA_ADD_OPTION(PICKUP_SEED);
-    PA_ADD_OPTION(PICKUP_SEED_LIST);
-    PA_ADD_OPTION(PICKUP_SEED_BUTTON);
-    PA_ADD_OPTION(PICKUP_EXTRA_BUTTON);
-    PA_ADD_OPTION(PICKUP_SEED_DELAY);
     PA_ADD_OPTION(PICKUP_ADVANCES);
     PA_ADD_OPTION(m_program_settings);
+    PA_ADD_OPTION(SEED_RADIUS);
     PA_ADD_OPTION(STARTING_POINT);
     PA_ADD_OPTION(MAX_RESETS);
     PA_ADD_OPTION(MAX_BALL_THROWS);
@@ -404,6 +342,8 @@ bool EggRng::reset_and_check_seed(
     const uint64_t& SEED_DELAY = frame_target.seed_delay;
     const std::vector<uint16_t>& SEED_VALUES = frame_target.seed_values;
     const int16_t& SEED_POSITION = frame_target.seed_position;
+    const SeedButton& SEED_BUTTON = frame_target.seed_button;
+    const BlackoutButton& EXTRA_BUTTON = frame_target.extra_button;
 
     static const int64_t FIXED_SEED_OFFSET = -845; // ms, approximate
     const int64_t FIXED_ADVANCES_OFFSET = pickup_frame ? -246 : 135;    // frames, approximate
@@ -439,9 +379,8 @@ bool EggRng::reset_and_check_seed(
     // Step 1: reset and perform blind sequence
     env.log("Resetting Game...");
     reset_and_perform_blind_sequence(
-        env.console, context, target, 
-        pickup_frame ? PICKUP_SEED_BUTTON : HELD_SEED_BUTTON, 
-        pickup_frame ? PICKUP_EXTRA_BUTTON : HELD_EXTRA_BUTTON,
+        env.console, context, target,
+        SEED_BUTTON, EXTRA_BUTTON,
         timings, launch_delay, false, PROFILE
     );
     stats.resets++; 
@@ -792,35 +731,37 @@ void EggRng::program(SingleSwitchProgramEnvironment& env, ProControllerContext& 
         SPECIES_LIST.emplace(slot.species);
     }
 
+    const SeedsDatabase seeds_db(seeds_json_path(GAME_VERSION == GameVersion::firered, LANGUAGE));
+
     // held timings
     const uint16_t TARGET_HELD_SEED = parse_seed(env.console, HELD_SEED);
-    const std::vector<uint16_t> HELD_SEED_VALUES = parse_seed_list(env.console, HELD_SEED_LIST);
-    const int16_t HELD_SEED_POSITION = seed_position_in_list(TARGET_HELD_SEED, HELD_SEED_VALUES);
-    if (HELD_SEED_POSITION == -1){
+    const SeedMatch held_match = seeds_db.find_seed(TARGET_HELD_SEED, SOUND, SEED_RADIUS);
+    if (!held_match.found){
         OperationFailedException::fire(
             ErrorReport::SEND_ERROR_REPORT,
-            "EggRng(): Held Seed is missing from the list of nearby seeds.",
+            "EggRng(): Held Seed was not found in the seed database for this game version, language, and sound setting.",
             env.console
-        ); 
+        );
     }
-    env.log("Target Held Seed Value: " + to_hex_string(TARGET_HELD_SEED));
+    env.log("Target Held Seed Value: " + to_hex_string(TARGET_HELD_SEED)
+        + " (delay " + std::to_string(held_match.seed_delay) + "ms, button mode " + held_match.button_mode + ")");
 
     // pickup timings
     const uint16_t TARGET_PICKUP_SEED = parse_seed(env.console, PICKUP_SEED);
-    const std::vector<uint16_t> PICKUP_SEED_VALUES = parse_seed_list(env.console, PICKUP_SEED_LIST);
-    const int16_t PICKUP_SEED_POSITION = seed_position_in_list(TARGET_PICKUP_SEED, PICKUP_SEED_VALUES);
-    if (PICKUP_SEED_POSITION == -1){
+    const SeedMatch pickup_match = seeds_db.find_seed(TARGET_PICKUP_SEED, SOUND, SEED_RADIUS);
+    if (!pickup_match.found){
         OperationFailedException::fire(
             ErrorReport::SEND_ERROR_REPORT,
-            "EggRng(): Pickup Seed is missing from the list of nearby seeds.",
+            "EggRng(): Pickup Seed was not found in the seed database for this game version, language, and sound setting.",
             env.console
-        ); 
+        );
     }
-    env.log("Target Pickup Seed Value: " + to_hex_string(TARGET_PICKUP_SEED));
+    env.log("Target Pickup Seed Value: " + to_hex_string(TARGET_PICKUP_SEED)
+        + " (delay " + std::to_string(pickup_match.seed_delay) + "ms, button mode " + pickup_match.button_mode + ")");
 
     EggFrameTargets frame_targets{
-        { HELD_SEED_DELAY, HELD_SEED_VALUES, HELD_SEED_POSITION },
-        { PICKUP_SEED_DELAY, PICKUP_SEED_VALUES, PICKUP_SEED_POSITION }
+        { held_match.seed_delay, held_match.seed_values, held_match.seed_position, held_match.seed_button, held_match.extra_button },
+        { pickup_match.seed_delay, pickup_match.seed_values, pickup_match.seed_position, pickup_match.seed_button, pickup_match.extra_button }
     };
 
     // searchers

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_EggRng.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_EggRng.h
@@ -23,6 +23,7 @@
 #include "PokemonFRLG_RngStatsDatabase.h"
 #include "PokemonFRLG_RngDisplays.h"
 #include "PokemonFRLG_RngLoopRoutines.h"
+#include "PokemonFRLG_SeedsDatabase.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
@@ -146,6 +147,7 @@ private:
     SectionDividerOption m_game_info;
     OCR::LanguageOCROption LANGUAGE;
     EnumDropdownOption<GameVersion> GAME_VERSION;
+    EnumDropdownOption<SoundSetting> SOUND;
 
     SectionDividerOption m_target_settings;
     PokemonNameSelectOption EGG_SPECIES;
@@ -153,22 +155,15 @@ private:
     ParentIVsTable PARENT_IVS;
 
     SectionDividerOption m_held_settings;
-    StringOption HELD_SEED; 
-    TextEditOption HELD_SEED_LIST;
-    EnumDropdownOption<SeedButton> HELD_SEED_BUTTON;
-    EnumDropdownOption<BlackoutButton> HELD_EXTRA_BUTTON;
-    SimpleIntegerOption<uint64_t> HELD_SEED_DELAY;
+    StringOption HELD_SEED;
     SimpleIntegerOption<uint64_t>HELD_ADVANCES;
 
     SectionDividerOption m_pickup_settings;
-    StringOption PICKUP_SEED; 
-    TextEditOption PICKUP_SEED_LIST;
-    EnumDropdownOption<SeedButton> PICKUP_SEED_BUTTON;
-    EnumDropdownOption<BlackoutButton> PICKUP_EXTRA_BUTTON;
-    SimpleIntegerOption<uint64_t> PICKUP_SEED_DELAY;
+    StringOption PICKUP_SEED;
     SimpleIntegerOption<uint64_t>PICKUP_ADVANCES;
 
     SectionDividerOption m_program_settings;
+    SimpleIntegerOption<uint16_t> SEED_RADIUS;
     EnumDropdownOption<EggProgramState> STARTING_POINT;
     SimpleIntegerOption<uint64_t> MAX_RESETS;
     SimpleIntegerOption<uint64_t> MAX_RARE_CANDIES;

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_GiftRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_GiftRng.cpp
@@ -67,6 +67,15 @@ GiftRng::GiftRng()
     , m_game_info(
         "<font size=4><b>Game Information</b></font>"
     )
+    , GAME_VERSION(
+        "<b>Game Version:</b>",
+        {
+            {GameVersion::firered, "firered", "FireRed"},
+            {GameVersion::leafgreen, "leafgreen", "LeafGreen"}
+        },
+        LockMode::LOCK_WHILE_RUNNING,
+        GameVersion::firered
+    )
     , LANGUAGE(
         "<b>Game Language:</b>",
         {
@@ -79,6 +88,16 @@ GiftRng::GiftRng()
         },
         LockMode::LOCK_WHILE_RUNNING,
         true
+    )
+    , SOUND(
+        "<b>Sound:</b><br>"
+        "Your in-game sound setting. This affects the possible seeds.",
+        {
+            {SoundSetting::Mono, "mono", "Mono"},
+            {SoundSetting::Stereo, "stereo", "Stereo"}
+        },
+        LockMode::LOCK_WHILE_RUNNING,
+        SoundSetting::Mono
     )
     , m_target_settings(
         "<font size=4><b>Target Settings</b></font> — Get these from an RNG search tool"
@@ -113,43 +132,6 @@ GiftRng::GiftRng()
         "70FE", "70FE",
         true
     )
-    , SEED_LIST(
-        "<b>Nearby Seeds:</b><br>"
-        "This box should contain a list of seeds (in order) around and including your target seed, with one seed on each line",
-        LockMode::LOCK_WHILE_RUNNING,
-        "D000\n199A\n77A1\nAABC\n280C\n70FE\nB573\n02F2\n8084\nA533\nED1E", 
-        "D000\n199A\n77A1\nAABC\n280C\n70FE\nB573\n02F2\n8084\nA533\nED1E",
-        true
-    )
-    , SEED_BUTTON(
-        "<b>Seed Button:</b>",
-        {
-            {SeedButton::A, "A", "A"},
-            {SeedButton::Start, "Start", "Start"},
-            {SeedButton::L, "L", "L (L=A)"},
-        },
-        LockMode::LOCK_WHILE_RUNNING,
-        SeedButton::A
-    )
-    , EXTRA_BUTTON(
-        "<b>Extra Button:</b><br>"
-        "Additional button presses that affect the seed.",
-        {
-            {BlackoutButton::None, "None", "None"},
-            {BlackoutButton::L, "L", "Blackout L"},
-            {BlackoutButton::R, "R", "Blackout R"},
-        },
-        LockMode::LOCK_WHILE_RUNNING,
-        BlackoutButton::None
-    )
-    , SEED_DELAY(
-        "<b>Seed Delay Time (ms):</b><br>"
-        "The delay between starting the game and advancing past the title screen. Set this to match your target seed.<br>"
-        "<i>If using Ten Lines for seed info, select <b>Nintendo Switch 1</b> as your console even if using a Switch 2.</i><br>"
-        "<b>Warning: values close to 30500ms can sometimes cause problems, and you may need to manually increase your initial seed calibration or pick a new target.</b>",
-        LockMode::LOCK_WHILE_RUNNING,
-        31338, 30400 // default, min
-    )
     , ADVANCES(
         "<b>Advances:</b><br>The total number of RNG advances for your target.",
         LockMode::LOCK_WHILE_RUNNING,
@@ -164,6 +146,12 @@ GiftRng::GiftRng()
         "<i>Warning: can result in larger misses.</i>",
         LockMode::LOCK_WHILE_RUNNING,
         false // default
+    )
+    , SEED_RADIUS(
+        "<b>Nearby Seed Radius:</b><br>"
+        "The number of nearby seeds on each side of the target to search when identifying which seed was hit.",
+        LockMode::LOCK_WHILE_RUNNING,
+        5, 1 // default, min
     )
     , MAX_RESETS(
         "<b>Max Resets:</b>",
@@ -207,17 +195,16 @@ GiftRng::GiftRng()
     PA_ADD_OPTION(RNG_FILTERS);
     PA_ADD_OPTION(RNG_CALIBRATION);
     PA_ADD_OPTION(m_game_info);
+    PA_ADD_OPTION(GAME_VERSION);
     PA_ADD_OPTION(LANGUAGE);
+    PA_ADD_OPTION(SOUND);
     PA_ADD_OPTION(m_target_settings);
     PA_ADD_OPTION(TARGET);
     PA_ADD_OPTION(SEED);
-    PA_ADD_OPTION(SEED_LIST);
-    PA_ADD_OPTION(SEED_BUTTON);
-    PA_ADD_OPTION(EXTRA_BUTTON);
-    PA_ADD_OPTION(SEED_DELAY);
     PA_ADD_OPTION(ADVANCES);
     PA_ADD_OPTION(m_program_settings);
     PA_ADD_OPTION(USE_TEACHY_TV);
+    PA_ADD_OPTION(SEED_RADIUS);
     PA_ADD_OPTION(MAX_RESETS);
     PA_ADD_OPTION(MAX_RARE_CANDIES);
     PA_ADD_OPTION(PROFILE);
@@ -241,12 +228,18 @@ void GiftRng::program(SingleSwitchProgramEnvironment& env, ProControllerContext&
     RNG_CALIBRATION.reset_hits();
 
     const uint16_t TARGET_SEED = parse_seed(env.console, SEED);
-    const std::vector<uint16_t> SEED_VALUES = parse_seed_list(env.console, SEED_LIST);
-    const int16_t SEED_POSITION = seed_position_in_list(TARGET_SEED, SEED_VALUES);
-
-    if (SEED_POSITION == -1){
-        throw UserSetupError(env.console, "The target Seed is missing from the list of nearby seeds.");
+    SeedsDatabase seeds_db(seeds_json_path(GAME_VERSION == GameVersion::firered, LANGUAGE));
+    const SeedMatch seed_match = seeds_db.find_seed(TARGET_SEED, SOUND, SEED_RADIUS);
+    if (!seed_match.found){
+        throw UserSetupError(env.console, "The target Seed was not found in the seed database for this game version, language, and sound setting.");
     }
+    const std::vector<uint16_t> SEED_VALUES = seed_match.seed_values;
+    const int16_t SEED_POSITION = seed_match.seed_position;
+    const uint64_t SEED_DELAY = seed_match.seed_delay;
+    const SeedButton SEED_BUTTON = seed_match.seed_button;
+    const BlackoutButton EXTRA_BUTTON = seed_match.extra_button;
+    env.log("Seed delay: " + std::to_string(SEED_DELAY) + "ms, button mode: " + seed_match.button_mode
+        + ", column: " + seed_match.column_name);
 
     BaseStats BASE_STATS;
     int16_t GENDER_THRESHOLD = -1;

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_GiftRng.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_GiftRng.h
@@ -21,6 +21,7 @@
 #include "PokemonFRLG_BlindNavigation.h"
 #include "PokemonFRLG_RngCalibration.h"
 #include "PokemonFRLG_RngDisplays.h"
+#include "PokemonFRLG_SeedsDatabase.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
@@ -43,6 +44,10 @@ public:
     ) override{}
 
 private:
+    enum class GameVersion{
+        firered,
+        leafgreen
+    };
 
     SectionDividerOption m_calibration_displays;
     RngTargetDisplay RNG_TARGET;
@@ -50,19 +55,18 @@ private:
     RngCalibrationDisplay RNG_CALIBRATION;
 
     SectionDividerOption m_game_info;
+    EnumDropdownOption<GameVersion> GAME_VERSION;
     OCR::LanguageOCROption LANGUAGE;
+    EnumDropdownOption<SoundSetting> SOUND;
 
     SectionDividerOption m_target_settings;
     EnumDropdownOption<PokemonFRLG_RngTarget> TARGET;
-    StringOption SEED; 
-    TextEditOption SEED_LIST;
-    EnumDropdownOption<SeedButton> SEED_BUTTON;
-    EnumDropdownOption<BlackoutButton> EXTRA_BUTTON;
-    SimpleIntegerOption<uint64_t> SEED_DELAY;
+    StringOption SEED;
     SimpleIntegerOption<uint64_t>ADVANCES;
 
     SectionDividerOption m_program_settings;
     BooleanCheckBoxOption USE_TEACHY_TV;
+    SimpleIntegerOption<uint16_t> SEED_RADIUS;
     SimpleIntegerOption<uint64_t> MAX_RESETS;
     SimpleIntegerOption<uint64_t> MAX_RARE_CANDIES;
     SimpleIntegerOption<uint8_t> PROFILE;

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngLoopRoutines.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngLoopRoutines.h
@@ -17,6 +17,7 @@
 #include "CommonFramework/Notifications/EventNotificationOption.h"
 #include "NintendoSwitch/NintendoSwitch_SingleSwitchProgram.h"
 #include "Pokemon/Pokemon_AdvRng.h"
+#include "PokemonFRLG_BlindNavigation.h"
 #include "PokemonFRLG_RngCalibration.h"
 #include "PokemonFRLG_RngStatsDatabase.h"
 
@@ -50,11 +51,14 @@ struct EggCalibrationHistories{
     }
 };
 
-// Per-frame seed configuration: the nearby-seed list, the target's position in it, and the seed delay.
+// Per-frame seed configuration: the nearby-seed list, the target's position in it, the seed
+// delay, and the button combination (derived from the seed database) that reaches the seed.
 struct EggFrameTarget{
     uint64_t seed_delay;
     std::vector<uint16_t> seed_values;
     int16_t seed_position;
+    SeedButton seed_button;
+    BlackoutButton extra_button;
 };
 struct EggFrameTargets{
     EggFrameTarget held;

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RoamingLegendaryRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RoamingLegendaryRng.cpp
@@ -67,6 +67,15 @@ RoamingLegendaryRng::RoamingLegendaryRng()
     , m_game_info(
         "<font size=4><b>Game Information</b></font>"
     )
+    , GAME_VERSION(
+        "<b>Game Version:</b>",
+        {
+            {GameVersion::firered, "firered", "FireRed"},
+            {GameVersion::leafgreen, "leafgreen", "LeafGreen"}
+        },
+        LockMode::LOCK_WHILE_RUNNING,
+        GameVersion::firered
+    )
     , LANGUAGE(
         "<b>Game Language:</b>",
         {
@@ -79,6 +88,16 @@ RoamingLegendaryRng::RoamingLegendaryRng()
         },
         LockMode::LOCK_WHILE_RUNNING,
         true
+    )
+    , SOUND(
+        "<b>Sound:</b><br>"
+        "Your in-game sound setting. This affects the possible seeds.",
+        {
+            {SoundSetting::Mono, "mono", "Mono"},
+            {SoundSetting::Stereo, "stereo", "Stereo"}
+        },
+        LockMode::LOCK_WHILE_RUNNING,
+        SoundSetting::Mono
     )
     , m_target_settings(
         "<font size=4><b>Target Settings</b></font> — Get these from an RNG search tool"
@@ -100,43 +119,6 @@ RoamingLegendaryRng::RoamingLegendaryRng()
         "70FE", "70FE",
         true
     )
-    , SEED_LIST(
-        "<b>Nearby Seeds:</b><br>"
-        "This box should contain a list of seeds (in order) around and including your target seed, with one seed on each line",
-        LockMode::LOCK_WHILE_RUNNING,
-        "D000\n199A\n77A1\nAABC\n280C\n70FE\nB573\n02F2\n8084\nA533\nED1E", 
-        "D000\n199A\n77A1\nAABC\n280C\n70FE\nB573\n02F2\n8084\nA533\nED1E",
-        true
-    )
-    , SEED_BUTTON(
-        "<b>Seed Button:</b>",
-        {
-            {SeedButton::A, "A", "A"},
-            {SeedButton::Start, "Start", "Start"},
-            {SeedButton::L, "L", "L (L=A)"},
-        },
-        LockMode::LOCK_WHILE_RUNNING,
-        SeedButton::A
-    )
-    , EXTRA_BUTTON(
-        "<b>Extra Button:</b><br>"
-        "Additional button presses that affect the seed.",
-        {
-            {BlackoutButton::None, "None", "None"},
-            {BlackoutButton::L, "L", "Blackout L"},
-            {BlackoutButton::R, "R", "Blackout R"},
-        },
-        LockMode::LOCK_WHILE_RUNNING,
-        BlackoutButton::None
-    )
-    , SEED_DELAY(
-        "<b>Seed Delay Time (ms):</b><br>"
-        "The delay between starting the game and advancing past the title screen. Set this to match your target seed.<br>"
-        "<i>If using Ten Lines for seed info, select <b>Nintendo Switch 1</b> as your console even if using a Switch 2.</i><br>"
-        "<b>Warning: values close to 30500ms can sometimes cause problems, and you may need to manually increase your initial seed calibration or pick a new target.</b>",
-        LockMode::LOCK_WHILE_RUNNING,
-        31338, 30400 // default, min
-    )
     , ADVANCES(
         "<b>Advances:</b><br>The total number of RNG advances for your target.",
         LockMode::LOCK_WHILE_RUNNING,
@@ -151,6 +133,12 @@ RoamingLegendaryRng::RoamingLegendaryRng()
         "<i>Warning: can result in larger misses.</i>",
         LockMode::LOCK_WHILE_RUNNING,
         false // default
+    )
+    , SEED_RADIUS(
+        "<b>Nearby Seed Radius:</b><br>"
+        "The number of nearby seeds on each side of the target to search when identifying which seed was hit.",
+        LockMode::LOCK_WHILE_RUNNING,
+        5, 1 // default, min
     )
     , MAX_RESETS(
         "<b>Max Resets:</b>",
@@ -202,17 +190,16 @@ RoamingLegendaryRng::RoamingLegendaryRng()
     PA_ADD_OPTION(RNG_FILTERS);
     PA_ADD_OPTION(RNG_CALIBRATION);
     PA_ADD_OPTION(m_game_info);
+    PA_ADD_OPTION(GAME_VERSION);
     PA_ADD_OPTION(LANGUAGE);
+    PA_ADD_OPTION(SOUND);
     PA_ADD_OPTION(m_target_settings);
     PA_ADD_OPTION(TARGET);
     PA_ADD_OPTION(SEED);
-    PA_ADD_OPTION(SEED_LIST);
-    PA_ADD_OPTION(SEED_BUTTON);
-    PA_ADD_OPTION(EXTRA_BUTTON);
-    PA_ADD_OPTION(SEED_DELAY);
     PA_ADD_OPTION(ADVANCES);
     PA_ADD_OPTION(m_program_settings);
     PA_ADD_OPTION(USE_TEACHY_TV);
+    PA_ADD_OPTION(SEED_RADIUS);
     PA_ADD_OPTION(MAX_RESETS);
     PA_ADD_OPTION(MAX_RARE_CANDIES);
     PA_ADD_OPTION(MAX_BALL_THROWS);
@@ -237,12 +224,18 @@ void RoamingLegendaryRng::program(SingleSwitchProgramEnvironment& env, ProContro
     RNG_CALIBRATION.reset_hits();
 
     const uint16_t TARGET_SEED = parse_seed(env.console, SEED);
-    const std::vector<uint16_t> SEED_VALUES = parse_seed_list(env.console, SEED_LIST);
-    const int16_t SEED_POSITION = seed_position_in_list(TARGET_SEED, SEED_VALUES);
-
-    if (SEED_POSITION == -1){
-        throw UserSetupError(env.console, "The target Seed is missing from the list of nearby seeds.");
+    SeedsDatabase seeds_db(seeds_json_path(GAME_VERSION == GameVersion::firered, LANGUAGE));
+    const SeedMatch seed_match = seeds_db.find_seed(TARGET_SEED, SOUND, SEED_RADIUS);
+    if (!seed_match.found){
+        throw UserSetupError(env.console, "The target Seed was not found in the seed database for this game version, language, and sound setting.");
     }
+    const std::vector<uint16_t> SEED_VALUES = seed_match.seed_values;
+    const int16_t SEED_POSITION = seed_match.seed_position;
+    const uint64_t SEED_DELAY = seed_match.seed_delay;
+    const SeedButton SEED_BUTTON = seed_match.seed_button;
+    const BlackoutButton EXTRA_BUTTON = seed_match.extra_button;
+    env.log("Seed delay: " + std::to_string(SEED_DELAY) + "ms, button mode: " + seed_match.button_mode
+        + ", column: " + seed_match.column_name);
 
     BaseStats BASE_STATS;
     int16_t GENDER_THRESHOLD = -1;

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RoamingLegendaryRng.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RoamingLegendaryRng.h
@@ -21,6 +21,7 @@
 #include "PokemonFRLG_BlindNavigation.h"
 #include "PokemonFRLG_RngCalibration.h"
 #include "PokemonFRLG_RngDisplays.h"
+#include "PokemonFRLG_SeedsDatabase.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
@@ -43,6 +44,10 @@ public:
     ) override{}
 
 private:
+    enum class GameVersion{
+        firered,
+        leafgreen
+    };
 
     SectionDividerOption m_calibration_displays;
     RngTargetDisplay RNG_TARGET;
@@ -50,19 +55,18 @@ private:
     RngCalibrationDisplay RNG_CALIBRATION;
 
     SectionDividerOption m_game_info;
+    EnumDropdownOption<GameVersion> GAME_VERSION;
     OCR::LanguageOCROption LANGUAGE;
+    EnumDropdownOption<SoundSetting> SOUND;
 
     SectionDividerOption m_target_settings;
     EnumDropdownOption<PokemonFRLG_RngTarget> TARGET;
-    StringOption SEED; 
-    TextEditOption SEED_LIST;
-    EnumDropdownOption<SeedButton> SEED_BUTTON;
-    EnumDropdownOption<BlackoutButton> EXTRA_BUTTON;
-    SimpleIntegerOption<uint64_t> SEED_DELAY;
+    StringOption SEED;
     SimpleIntegerOption<uint64_t>ADVANCES;
 
     SectionDividerOption m_program_settings;
     BooleanCheckBoxOption USE_TEACHY_TV;
+    SimpleIntegerOption<uint16_t> SEED_RADIUS;
     SimpleIntegerOption<uint64_t> MAX_RESETS;
     SimpleIntegerOption<uint64_t> MAX_RARE_CANDIES;
     SimpleIntegerOption<uint64_t> MAX_BALL_THROWS;

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_SeedsDatabase.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_SeedsDatabase.cpp
@@ -1,0 +1,182 @@
+/*  Seeds Database
+ *
+ *  From: https://github.com/PokemonAutomation/
+ *
+ */
+
+#include "Common/Cpp/Exceptions.h"
+#include "Common/Cpp/Json/JsonValue.h"
+#include "Common/Cpp/Json/JsonObject.h"
+#include "Common/Cpp/Json/JsonArray.h"
+#include "CommonFramework/Globals.h"
+#include "PokemonFRLG_SeedsDatabase.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonFRLG{
+
+
+std::string seeds_json_path(bool firered, Language language){
+    std::string version = firered ? "FR" : "LG";
+    std::string lang = (language == Language::Japanese) ? "Jpn" : "Eng";
+    return "PokemonFRLG/RngSeeds/" + version + "_" + lang + ".json";
+}
+
+
+namespace{
+
+uint16_t parse_hex_seed(const std::string& text, const std::string& path){
+    try{
+        size_t consumed = 0;
+        unsigned long value = std::stoul(text, &consumed, 16);
+        if (consumed != text.size() || value > 0xFFFF){
+            throw FileException(nullptr, PA_CURRENT_FUNCTION, "Invalid seed value: " + text, path);
+        }
+        return uint16_t(value);
+    }catch (const std::invalid_argument&){
+        throw FileException(nullptr, PA_CURRENT_FUNCTION, "Invalid seed value: " + text, path);
+    }catch (const std::out_of_range&){
+        throw FileException(nullptr, PA_CURRENT_FUNCTION, "Invalid seed value: " + text, path);
+    }
+}
+
+// Column names have the form "<Sound> / <Button Mode> / <Seed Button>"
+void parse_column_name(
+    const std::string& name, const std::string& path,
+    SoundSetting& sound, std::string& button_mode, SeedButton& seed_button
+){
+    std::vector<std::string> parts;
+    size_t start = 0;
+    while (true){
+        size_t sep = name.find(" / ", start);
+        if (sep == std::string::npos){
+            parts.push_back(name.substr(start));
+            break;
+        }
+        parts.push_back(name.substr(start, sep - start));
+        start = sep + 3;
+    }
+    if (parts.size() != 3){
+        throw FileException(nullptr, PA_CURRENT_FUNCTION, "Malformed seed column name: " + name, path);
+    }
+
+    if (parts[0] == "Mono"){
+        sound = SoundSetting::Mono;
+    }else if (parts[0] == "Stereo"){
+        sound = SoundSetting::Stereo;
+    }else{
+        throw FileException(nullptr, PA_CURRENT_FUNCTION, "Unknown sound setting in column: " + name, path);
+    }
+
+    button_mode = parts[1];
+
+    if (parts[2] == "A"){
+        seed_button = SeedButton::A;
+    }else if (parts[2] == "START" || parts[2] == "Start"){
+        seed_button = SeedButton::Start;
+    }else if (parts[2] == "L"){
+        seed_button = SeedButton::L;
+    }else{
+        throw FileException(nullptr, PA_CURRENT_FUNCTION, "Unknown seed button in column: " + name, path);
+    }
+}
+
+}
+
+
+SeedsDatabase::SeedsDatabase(const std::string& json_path){
+    std::string path = RESOURCE_PATH() + json_path;
+    JsonValue json = load_json_file(path);
+    JsonObject& root = json.to_object_throw(path);
+
+    JsonArray& delays = root.get_array_throw("Delay", path);
+    m_delays.reserve(delays.size());
+    for (auto& delay : delays){
+        m_delays.emplace_back(uint64_t(delay.to_integer_throw(path)));
+    }
+
+    for (auto& item : root){
+        const std::string& name = item.first;
+        if (name == "Delay"){
+            continue;
+        }
+        SeedColumn column;
+        column.name = name;
+        parse_column_name(name, path, column.sound, column.button_mode, column.seed_button);
+
+        JsonArray& seeds = item.second.to_array_throw(path);
+        column.seeds.reserve(seeds.size());
+        for (auto& seed : seeds){
+            column.seeds.emplace_back(parse_hex_seed(seed.to_string_throw(path), path));
+        }
+        m_columns.emplace_back(std::move(column));
+    }
+}
+
+
+SeedMatch SeedsDatabase::find_seed(uint16_t target_seed, SoundSetting sound, int radius) const{
+    struct Variant{
+        BlackoutButton extra_button;
+        uint16_t search_value;
+    };
+    const Variant variants[] = {
+        {BlackoutButton::None, target_seed},
+        {BlackoutButton::L, uint16_t(target_seed + BLACKOUT_SEED_OFFSET)},
+    };
+
+    SeedMatch best;
+    uint64_t best_delay = 0xFFFFFFFFFFFFFFFF;
+
+    for (const SeedColumn& column : m_columns){
+        if (column.sound != sound){
+            continue;
+        }
+        // Only the "Help" button mode is supported: seed lists for other button modes
+        // are almost entirely empty, and it is not exposed as a user setting.
+        if (column.button_mode != "Help"){
+            continue;
+        }
+        for (const Variant& variant : variants){
+            for (size_t i = 0; i < column.seeds.size() && i < m_delays.size(); i++){
+                if (column.seeds[i] != variant.search_value){
+                    continue;
+                }
+                if (m_delays[i] >= best_delay){
+                    break;
+                }
+
+                size_t list_start = (i > (size_t)radius) ? i - (size_t)radius : 0;
+                size_t list_end = std::min(column.seeds.size() - 1, i + (size_t)radius);
+                std::vector<uint16_t> seed_values;
+                seed_values.reserve(list_end - list_start + 1);
+                for (size_t j = list_start; j <= list_end; j++){
+                    uint16_t value = column.seeds[j];
+                    if (variant.extra_button != BlackoutButton::None){
+                        value = uint16_t(value - BLACKOUT_SEED_OFFSET);
+                    }
+                    seed_values.emplace_back(value);
+                }
+
+                best_delay = m_delays[i];
+                best.found = true;
+                best.seed_values = std::move(seed_values);
+                best.seed_position = int16_t(i - list_start);
+                best.seed_delay = m_delays[i];
+                best.seed_button = column.seed_button;
+                best.extra_button = variant.extra_button;
+                best.sound = column.sound;
+                best.button_mode = column.button_mode;
+                best.column_name = column.name;
+                break;
+            }
+        }
+    }
+
+    return best;
+}
+
+
+
+}
+}
+}

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_SeedsDatabase.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_SeedsDatabase.h
@@ -1,0 +1,68 @@
+/*  Seeds Database
+ *
+ *  From: https://github.com/PokemonAutomation/
+ *
+ */
+
+#ifndef PokemonAutomation_PokemonFRLG_SeedsDatabase_H
+#define PokemonAutomation_PokemonFRLG_SeedsDatabase_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include "CommonFramework/Language.h"
+#include "PokemonFRLG_BlindNavigation.h"
+
+namespace PokemonAutomation{
+namespace NintendoSwitch{
+namespace PokemonFRLG{
+
+
+enum class SoundSetting{
+    Mono,
+    Stereo,
+};
+
+static const uint16_t BLACKOUT_SEED_OFFSET = 0x0024;
+
+// Only English and Japanese lists exist; other languages fall back to English.
+std::string seeds_json_path(bool firered, Language language);
+
+
+struct SeedMatch{
+    bool found = false;
+    std::vector<uint16_t> seed_values;
+    int16_t seed_position = -1;
+    uint64_t seed_delay = 0;
+    SeedButton seed_button = SeedButton::A;
+    BlackoutButton extra_button = BlackoutButton::None;
+    SoundSetting sound = SoundSetting::Mono;
+    std::string button_mode;
+    std::string column_name;
+};
+
+
+class SeedsDatabase{
+public:
+    SeedsDatabase(const std::string& json_path);
+    SeedMatch find_seed(uint16_t target_seed, SoundSetting sound, int radius) const;
+
+private:
+    struct SeedColumn{
+        std::string name;
+        SoundSetting sound;
+        std::string button_mode;
+        SeedButton seed_button;
+        std::vector<uint16_t> seeds;
+    };
+
+    std::vector<uint64_t> m_delays;
+    std::vector<SeedColumn> m_columns;
+};
+
+
+
+}
+}
+}
+#endif

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StarterRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StarterRng.cpp
@@ -22,6 +22,7 @@
 #include "PokemonFRLG/PokemonFRLG_Navigation.h"
 #include "PokemonFRLG_RngNavigation.h"
 #include "PokemonFRLG_HardReset.h"
+#include "PokemonFRLG_SeedsDatabase.h"
 #include "PokemonFRLG_StarterRng.h"
 
 namespace PokemonAutomation{
@@ -72,6 +73,15 @@ StarterRng::StarterRng()
     , m_game_info(
         "<font size=4><b>Game Information</b></font>"
     )
+    , GAME_VERSION(
+        "<b>Game Version:</b>",
+        {
+            {GameVersion::firered, "firered", "FireRed"},
+            {GameVersion::leafgreen, "leafgreen", "LeafGreen"}
+        },
+        LockMode::LOCK_WHILE_RUNNING,
+        GameVersion::firered
+    )
     , LANGUAGE(
         "<b>Game Language:</b>",
         {
@@ -84,6 +94,16 @@ StarterRng::StarterRng()
         },
         LockMode::LOCK_WHILE_RUNNING,
         true
+    )
+    , SOUND(
+        "<b>Sound:</b><br>"
+        "Your in-game sound setting. This affects the possible seeds.",
+        {
+            {SoundSetting::Mono, "mono", "Mono"},
+            {SoundSetting::Stereo, "stereo", "Stereo"}
+        },
+        LockMode::LOCK_WHILE_RUNNING,
+        SoundSetting::Mono
     )
     , m_target_settings(
         "<font size=4><b>Target Settings</b></font> — Get these from an RNG search tool"
@@ -105,43 +125,6 @@ StarterRng::StarterRng()
         "70FE", "70FE",
         true
     )
-    , SEED_LIST(
-        "<b>Nearby Seeds:</b><br>"
-        "This box should contain a list of seeds (in order) around and including your target seed, with one seed on each line",
-        LockMode::LOCK_WHILE_RUNNING,
-        "D000\n199A\n77A1\nAABC\n280C\n70FE\nB573\n02F2\n8084\nA533\nED1E", 
-        "D000\n199A\n77A1\nAABC\n280C\n70FE\nB573\n02F2\n8084\nA533\nED1E",
-        true
-    )
-    , SEED_BUTTON(
-        "<b>Seed Button:</b>",
-        {
-            {SeedButton::A, "A", "A"},
-            {SeedButton::Start, "Start", "Start"},
-            {SeedButton::L, "L", "L (L=A)"},
-        },
-        LockMode::LOCK_WHILE_RUNNING,
-        SeedButton::A
-    )
-    , EXTRA_BUTTON(
-        "<b>Extra Button:</b><br>"
-        "Additional button presses that affect the seed.",
-        {
-            {BlackoutButton::None, "None", "None"},
-            {BlackoutButton::L, "L", "Blackout L"},
-            {BlackoutButton::R, "R", "Blackout R"},
-        },
-        LockMode::LOCK_WHILE_RUNNING,
-        BlackoutButton::None
-    )
-    , SEED_DELAY(
-        "<b>Seed Delay Time (ms):</b><br>"
-        "The delay between starting the game and advancing past the title screen. Set this to match your target seed.<br>"
-        "<i>If using Ten Lines for seed info, select <b>Nintendo Switch 1</b> as your console even if using a Switch 2.</i><br>"
-        "<b>Warning: values close to 30500ms can sometimes cause problems, and you may need to manually increase your initial seed calibration or pick a new target.</b>",
-        LockMode::LOCK_WHILE_RUNNING,
-        31338, 30400 // default, min
-    )
     , ADVANCES(
         "<b>Advances:</b><br>"
         "The total number of RNG advances for your target.",
@@ -150,6 +133,12 @@ StarterRng::StarterRng()
     )
     , m_program_settings(
         "<font size=4><b>Program Settings</b></font>"
+    )
+    , SEED_RADIUS(
+        "<b>Nearby Seed Radius:</b><br>"
+        "The number of nearby seeds on each side of the target to search when identifying which seed was hit.",
+        LockMode::LOCK_WHILE_RUNNING,
+        5, 1 // default, min
     )
     , MAX_RESETS(
         "<b>Max Resets:</b>",
@@ -193,16 +182,15 @@ StarterRng::StarterRng()
     PA_ADD_OPTION(RNG_FILTERS);
     PA_ADD_OPTION(RNG_CALIBRATION);
     PA_ADD_OPTION(m_game_info);
+    PA_ADD_OPTION(GAME_VERSION);
     PA_ADD_OPTION(LANGUAGE);
+    PA_ADD_OPTION(SOUND);
     PA_ADD_OPTION(m_target_settings);
     PA_ADD_OPTION(STARTER);
     PA_ADD_OPTION(SEED);
-    PA_ADD_OPTION(SEED_LIST);
-    PA_ADD_OPTION(SEED_BUTTON);
-    PA_ADD_OPTION(EXTRA_BUTTON);
-    PA_ADD_OPTION(SEED_DELAY);
     PA_ADD_OPTION(ADVANCES);
     PA_ADD_OPTION(m_program_settings);
+    PA_ADD_OPTION(SEED_RADIUS);
     PA_ADD_OPTION(MAX_RESETS);
     PA_ADD_OPTION(PROFILE);
     PA_ADD_OPTION(TAKE_VIDEO);
@@ -567,12 +555,18 @@ void StarterRng::program(SingleSwitchProgramEnvironment& env, ProControllerConte
     RNG_CALIBRATION.reset_hits();
 
     const uint16_t TARGET_SEED = parse_seed(env.console, SEED);
-    const std::vector<uint16_t> SEED_VALUES = parse_seed_list(env.console, SEED_LIST);
-    const int16_t SEED_POSITION = seed_position_in_list(TARGET_SEED, SEED_VALUES);
-
-    if (SEED_POSITION == -1){
-        throw UserSetupError(env.console, "The target Seed is missing from the list of nearby seeds.");
+    SeedsDatabase seeds_db(seeds_json_path(GAME_VERSION == GameVersion::firered, LANGUAGE));
+    const SeedMatch seed_match = seeds_db.find_seed(TARGET_SEED, SOUND, SEED_RADIUS);
+    if (!seed_match.found){
+        throw UserSetupError(env.console, "The target Seed was not found in the seed database for this game version, language, and sound setting.");
     }
+    const std::vector<uint16_t> SEED_VALUES = seed_match.seed_values;
+    const int16_t SEED_POSITION = seed_match.seed_position;
+    const uint64_t SEED_DELAY = seed_match.seed_delay;
+    const SeedButton SEED_BUTTON = seed_match.seed_button;
+    const BlackoutButton EXTRA_BUTTON = seed_match.extra_button;
+    env.log("Seed delay: " + std::to_string(SEED_DELAY) + "ms, button mode: " + seed_match.button_mode
+        + ", column: " + seed_match.column_name);
 
     BaseStats BASE_STATS;
     switch (STARTER){

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StarterRng.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StarterRng.h
@@ -20,6 +20,7 @@
 #include "Pokemon/Pokemon_AdvRng.h"
 #include "PokemonFRLG_RngCalibration.h"
 #include "PokemonFRLG_RngDisplays.h"
+#include "PokemonFRLG_SeedsDatabase.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
@@ -48,6 +49,11 @@ private:
         charmander
     };
 
+    enum class GameVersion{
+        firered,
+        leafgreen
+    };
+
     bool walk_to_rival_battle(SingleSwitchProgramEnvironment& env, ProControllerContext& context);
     bool auto_battle_rival(
         SingleSwitchProgramEnvironment& env, 
@@ -73,18 +79,17 @@ private:
     RngCalibrationDisplay RNG_CALIBRATION;
 
     SectionDividerOption m_game_info;
+    EnumDropdownOption<GameVersion> GAME_VERSION;
     OCR::LanguageOCROption LANGUAGE;
+    EnumDropdownOption<SoundSetting> SOUND;
 
     SectionDividerOption m_target_settings;
     EnumDropdownOption<Starter> STARTER;
-    StringOption SEED; 
-    TextEditOption SEED_LIST;
-    EnumDropdownOption<SeedButton> SEED_BUTTON;
-    EnumDropdownOption<BlackoutButton> EXTRA_BUTTON;
-    SimpleIntegerOption<uint64_t> SEED_DELAY;
+    StringOption SEED;
     SimpleIntegerOption<uint64_t>ADVANCES;
 
     SectionDividerOption m_program_settings;
+    SimpleIntegerOption<uint16_t> SEED_RADIUS;
     SimpleIntegerOption<uint64_t> MAX_RESETS;
     BooleanCheckBoxOption IGNORE_WILD_SHINIES;
     SimpleIntegerOption<uint8_t> PROFILE;

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StaticRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StaticRng.cpp
@@ -64,6 +64,15 @@ StaticRng::StaticRng()
     , m_game_info(
         "<font size=4><b>Game Information</b></font>"
     )
+    , GAME_VERSION(
+        "<b>Game Version:</b>",
+        {
+            {GameVersion::firered, "firered", "FireRed"},
+            {GameVersion::leafgreen, "leafgreen", "LeafGreen"}
+        },
+        LockMode::LOCK_WHILE_RUNNING,
+        GameVersion::firered
+    )
     , LANGUAGE(
         "<b>Game Language:</b>",
         {
@@ -76,6 +85,16 @@ StaticRng::StaticRng()
         },
         LockMode::LOCK_WHILE_RUNNING,
         true
+    )
+    , SOUND(
+        "<b>Sound:</b><br>"
+        "Your in-game sound setting. This affects the possible seeds.",
+        {
+            {SoundSetting::Mono, "mono", "Mono"},
+            {SoundSetting::Stereo, "stereo", "Stereo"}
+        },
+        LockMode::LOCK_WHILE_RUNNING,
+        SoundSetting::Mono
     )
     , m_target_settings(
         "<font size=4><b>Target Settings</b></font> — Get these from an RNG search tool"
@@ -105,43 +124,6 @@ StaticRng::StaticRng()
         "70FE", "70FE",
         true
     )
-    , SEED_LIST(
-        "<b>Nearby Seeds:</b><br>"
-        "This box should contain a list of seeds (in order) around and including your target seed, with one seed on each line",
-        LockMode::LOCK_WHILE_RUNNING,
-        "D000\n199A\n77A1\nAABC\n280C\n70FE\nB573\n02F2\n8084\nA533\nED1E", 
-        "D000\n199A\n77A1\nAABC\n280C\n70FE\nB573\n02F2\n8084\nA533\nED1E",
-        true
-    )
-    , SEED_BUTTON(
-        "<b>Seed Button:</b>",
-        {
-            {SeedButton::A, "A", "A"},
-            {SeedButton::Start, "Start", "Start"},
-            {SeedButton::L, "L", "L (L=A)"},
-        },
-        LockMode::LOCK_WHILE_RUNNING,
-        SeedButton::A
-    )
-    , EXTRA_BUTTON(
-        "<b>Extra Button:</b><br>"
-        "Additional button presses that affect the seed.",
-        {
-            {BlackoutButton::None, "None", "None"},
-            {BlackoutButton::L, "L", "Blackout L"},
-            {BlackoutButton::R, "R", "Blackout R"},
-        },
-        LockMode::LOCK_WHILE_RUNNING,
-        BlackoutButton::None
-    )
-    , SEED_DELAY(
-        "<b>Seed Delay Time (ms):</b><br>"
-        "The delay between starting the game and advancing past the title screen. Set this to match your target seed.<br>"
-        "<i>If using Ten Lines for seed info, select <b>Nintendo Switch 1</b> as your console even if using a Switch 2.</i><br>"
-        "<b>Warning: values close to 30500ms can sometimes cause problems, and you may need to manually increase your initial seed calibration or pick a new target.</b>",
-        LockMode::LOCK_WHILE_RUNNING,
-        31338, 30400 // default, min
-    )
     , ADVANCES(
         "<b>Advances:</b><br>The total number of RNG advances for your target.",
         LockMode::LOCK_WHILE_RUNNING,
@@ -156,6 +138,12 @@ StaticRng::StaticRng()
         "<i>Warning: can result in larger misses.</i>",
         LockMode::LOCK_WHILE_RUNNING,
         false // default
+    )
+    , SEED_RADIUS(
+        "<b>Nearby Seed Radius:</b><br>"
+        "The number of nearby seeds on each side of the target to search when identifying which seed was hit.",
+        LockMode::LOCK_WHILE_RUNNING,
+        5, 1 // default, min
     )
     , MAX_RESETS(
         "<b>Max Resets:</b>",
@@ -206,17 +194,16 @@ StaticRng::StaticRng()
     PA_ADD_OPTION(RNG_FILTERS);
     PA_ADD_OPTION(RNG_CALIBRATION);
     PA_ADD_OPTION(m_game_info);
+    PA_ADD_OPTION(GAME_VERSION);
     PA_ADD_OPTION(LANGUAGE);
+    PA_ADD_OPTION(SOUND);
     PA_ADD_OPTION(m_target_settings);
     PA_ADD_OPTION(TARGET);
     PA_ADD_OPTION(SEED);
-    PA_ADD_OPTION(SEED_LIST);
-    PA_ADD_OPTION(SEED_BUTTON);
-    PA_ADD_OPTION(EXTRA_BUTTON);
-    PA_ADD_OPTION(SEED_DELAY);
     PA_ADD_OPTION(ADVANCES);
     PA_ADD_OPTION(m_program_settings);
     PA_ADD_OPTION(USE_TEACHY_TV);
+    PA_ADD_OPTION(SEED_RADIUS);
     PA_ADD_OPTION(MAX_RESETS);
     PA_ADD_OPTION(MAX_BALL_THROWS);
     PA_ADD_OPTION(MAX_RARE_CANDIES);
@@ -241,12 +228,18 @@ void StaticRng::program(SingleSwitchProgramEnvironment& env, ProControllerContex
     RNG_CALIBRATION.reset_hits();
 
     const uint16_t TARGET_SEED = parse_seed(env.console, SEED);
-    const std::vector<uint16_t> SEED_VALUES = parse_seed_list(env.console, SEED_LIST);
-    const int16_t SEED_POSITION = seed_position_in_list(TARGET_SEED, SEED_VALUES);
-
-    if (SEED_POSITION == -1){
-        throw UserSetupError(env.console, "The target Seed is missing from the list of nearby seeds.");
+    SeedsDatabase seeds_db(seeds_json_path(GAME_VERSION == GameVersion::firered, LANGUAGE));
+    const SeedMatch seed_match = seeds_db.find_seed(TARGET_SEED, SOUND, SEED_RADIUS);
+    if (!seed_match.found){
+        throw UserSetupError(env.console, "The target Seed was not found in the seed database for this game version, language, and sound setting.");
     }
+    const std::vector<uint16_t> SEED_VALUES = seed_match.seed_values;
+    const int16_t SEED_POSITION = seed_match.seed_position;
+    const uint64_t SEED_DELAY = seed_match.seed_delay;
+    const SeedButton SEED_BUTTON = seed_match.seed_button;
+    const BlackoutButton EXTRA_BUTTON = seed_match.extra_button;
+    env.log("Seed delay: " + std::to_string(SEED_DELAY) + "ms, button mode: " + seed_match.button_mode
+        + ", column: " + seed_match.column_name);
 
     BaseStats BASE_STATS;
     int16_t GENDER_THRESHOLD = -1;

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StaticRng.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_StaticRng.h
@@ -21,6 +21,7 @@
 #include "PokemonFRLG_BlindNavigation.h"
 #include "PokemonFRLG_RngCalibration.h"
 #include "PokemonFRLG_RngDisplays.h"
+#include "PokemonFRLG_SeedsDatabase.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
@@ -43,6 +44,10 @@ public:
     ) override{}
 
 private:
+    enum class GameVersion{
+        firered,
+        leafgreen
+    };
 
     SectionDividerOption m_calibration_displays;
     RngTargetDisplay RNG_TARGET;
@@ -50,19 +55,18 @@ private:
     RngCalibrationDisplay RNG_CALIBRATION;
 
     SectionDividerOption m_game_info;
+    EnumDropdownOption<GameVersion> GAME_VERSION;
     OCR::LanguageOCROption LANGUAGE;
+    EnumDropdownOption<SoundSetting> SOUND;
 
     SectionDividerOption m_target_settings;
     EnumDropdownOption<PokemonFRLG_RngTarget> TARGET;
-    StringOption SEED; 
-    TextEditOption SEED_LIST;
-    EnumDropdownOption<SeedButton> SEED_BUTTON;
-    EnumDropdownOption<BlackoutButton> EXTRA_BUTTON;
-    SimpleIntegerOption<uint64_t> SEED_DELAY;
+    StringOption SEED;
     SimpleIntegerOption<uint64_t>ADVANCES;
 
     SectionDividerOption m_program_settings;
     BooleanCheckBoxOption USE_TEACHY_TV;
+    SimpleIntegerOption<uint16_t> SEED_RADIUS;
     SimpleIntegerOption<uint64_t> MAX_RESETS;
     SimpleIntegerOption<uint64_t> MAX_RARE_CANDIES;
     SimpleIntegerOption<uint64_t> MAX_BALL_THROWS;

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_WildRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_WildRng.cpp
@@ -91,6 +91,16 @@ WildRng::WildRng()
         LockMode::LOCK_WHILE_RUNNING,
         true
     )
+    , SOUND(
+        "<b>Sound:</b><br>"
+        "Your in-game sound setting. This affects the possible seeds.",
+        {
+            {SoundSetting::Mono, "mono", "Mono"},
+            {SoundSetting::Stereo, "stereo", "Stereo"}
+        },
+        LockMode::LOCK_WHILE_RUNNING,
+        SoundSetting::Mono
+    )
     , m_target_settings(
         "<font size=4><b>Target Settings</b></font> — Get these from an RNG search tool"
     )
@@ -134,43 +144,6 @@ WildRng::WildRng()
         "70FE", "70FE",
         true
     )
-    , SEED_LIST(
-        "<b>Nearby Seeds:</b><br>"
-        "This box should contain a list of seeds (in order) around and including your target seed, with one seed on each line",
-        LockMode::LOCK_WHILE_RUNNING,
-        "D000\n199A\n77A1\nAABC\n280C\n70FE\nB573\n02F2\n8084\nA533\nED1E", 
-        "D000\n199A\n77A1\nAABC\n280C\n70FE\nB573\n02F2\n8084\nA533\nED1E",
-        true
-    )
-    , SEED_BUTTON(
-        "<b>Seed Button:</b>",
-        {
-            {SeedButton::A, "A", "A"},
-            {SeedButton::Start, "Start", "Start"},
-            {SeedButton::L, "L", "L (L=A)"},
-        },
-        LockMode::LOCK_WHILE_RUNNING,
-        SeedButton::A
-    )
-    , EXTRA_BUTTON(
-        "<b>Extra Button:</b><br>"
-        "Additional button presses that affect the seed.",
-        {
-            {BlackoutButton::None, "None", "None"},
-            {BlackoutButton::L, "L", "Blackout L"},
-            {BlackoutButton::R, "R", "Blackout R"},
-        },
-        LockMode::LOCK_WHILE_RUNNING,
-        BlackoutButton::None
-    )
-    , SEED_DELAY(
-        "<b>Seed Delay Time (ms):</b><br>"
-        "The delay between starting the game and advancing past the title screen. Set this to match your target seed.<br>"
-        "<i>If using Ten Lines for seed info, select <b>Nintendo Switch 1</b> as your console even if using a Switch 2.</i><br>"
-        "<b>Warning: values close to 30500ms can sometimes cause problems, and you may need to manually increase your initial seed calibration or pick a new target.</b>",
-        LockMode::LOCK_WHILE_RUNNING,
-        31338, 30400 // default, min
-    )
     , ADVANCES(
         "<b>Advances:</b><br>The total number of RNG advances for your target.",
         LockMode::LOCK_WHILE_RUNNING,
@@ -185,6 +158,12 @@ WildRng::WildRng()
         "<i>Warning: can result in larger misses.</i>",
         LockMode::LOCK_WHILE_RUNNING,
         false // default
+    )
+    , SEED_RADIUS(
+        "<b>Nearby Seed Radius:</b><br>"
+        "The number of nearby seeds on each side of the target to search when identifying which seed was hit.",
+        LockMode::LOCK_WHILE_RUNNING,
+        5, 1 // default, min
     )
     , MAX_RESETS(
         "<b>Max Resets:</b>",
@@ -237,18 +216,16 @@ WildRng::WildRng()
     PA_ADD_OPTION(m_game_info);
     PA_ADD_OPTION(GAME_VERSION);
     PA_ADD_OPTION(LANGUAGE);
+    PA_ADD_OPTION(SOUND);
     PA_ADD_OPTION(m_target_settings);
     PA_ADD_OPTION(ENCOUNTER_TYPE);
     PA_ADD_OPTION(GAME_LOCATION);
     PA_ADD_OPTION(RNG_METHOD);
     PA_ADD_OPTION(SEED);
-    PA_ADD_OPTION(SEED_LIST);
-    PA_ADD_OPTION(SEED_BUTTON);
-    PA_ADD_OPTION(EXTRA_BUTTON);
-    PA_ADD_OPTION(SEED_DELAY);
     PA_ADD_OPTION(ADVANCES);
     PA_ADD_OPTION(m_program_settings);
     PA_ADD_OPTION(USE_TEACHY_TV);
+    PA_ADD_OPTION(SEED_RADIUS);
     PA_ADD_OPTION(MAX_RESETS);
     PA_ADD_OPTION(MAX_BALL_THROWS);
     PA_ADD_OPTION(MAX_RARE_CANDIES);
@@ -315,12 +292,18 @@ void WildRng::program(SingleSwitchProgramEnvironment& env, ProControllerContext&
     // prepare timings
 
     const uint16_t TARGET_SEED = parse_seed(env.console, SEED);
-    const std::vector<uint16_t> SEED_VALUES = parse_seed_list(env.console, SEED_LIST);
-    const int16_t SEED_POSITION = seed_position_in_list(TARGET_SEED, SEED_VALUES);
-
-    if (SEED_POSITION == -1){
-        throw UserSetupError(env.console, "The target Seed is missing from the list of nearby seeds.");
+    SeedsDatabase seeds_db(seeds_json_path(GAME_VERSION == GameVersion::firered, LANGUAGE));
+    const SeedMatch seed_match = seeds_db.find_seed(TARGET_SEED, SOUND, SEED_RADIUS);
+    if (!seed_match.found){
+        throw UserSetupError(env.console, "The target Seed was not found in the seed database for this game version, language, and sound setting.");
     }
+    const std::vector<uint16_t> SEED_VALUES = seed_match.seed_values;
+    const int16_t SEED_POSITION = seed_match.seed_position;
+    const uint64_t SEED_DELAY = seed_match.seed_delay;
+    const SeedButton SEED_BUTTON = seed_match.seed_button;
+    const BlackoutButton EXTRA_BUTTON = seed_match.extra_button;
+    env.log("Seed delay: " + std::to_string(SEED_DELAY) + "ms, button mode: " + seed_match.button_mode
+        + ", column: " + seed_match.column_name);
 
     PokemonFRLG_RngTarget TARGET = PokemonFRLG_RngTarget::sweetscent;
 

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_WildRng.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_WildRng.h
@@ -22,6 +22,7 @@
 #include "PokemonFRLG_BlindNavigation.h"
 #include "PokemonFRLG_RngCalibration.h"
 #include "PokemonFRLG_RngDisplays.h"
+#include "PokemonFRLG_SeedsDatabase.h"
 
 namespace PokemonAutomation{
 namespace NintendoSwitch{
@@ -67,21 +68,19 @@ private:
     SectionDividerOption m_game_info;
     EnumDropdownOption<GameVersion> GAME_VERSION;
     OCR::LanguageOCROption LANGUAGE;
+    EnumDropdownOption<SoundSetting> SOUND;
 
     SectionDividerOption m_target_settings;
     EnumDropdownOption<EncounterType> ENCOUNTER_TYPE;
     StringSelectDatabase LOCATIONS_DATABASE;
     StringSelectOption GAME_LOCATION;
     EnumDropdownOption<AdvRngMethod> RNG_METHOD;
-    StringOption SEED; 
-    TextEditOption SEED_LIST;
-    EnumDropdownOption<SeedButton> SEED_BUTTON;
-    EnumDropdownOption<BlackoutButton> EXTRA_BUTTON;
-    SimpleIntegerOption<uint64_t> SEED_DELAY;
+    StringOption SEED;
     SimpleIntegerOption<uint64_t>ADVANCES;
 
     SectionDividerOption m_program_settings;
     BooleanCheckBoxOption USE_TEACHY_TV;
+    SimpleIntegerOption<uint16_t> SEED_RADIUS;
     SimpleIntegerOption<uint64_t> MAX_RESETS;
     SimpleIntegerOption<uint64_t> MAX_RARE_CANDIES;
     SimpleIntegerOption<uint64_t> MAX_BALL_THROWS;

--- a/SerialPrograms/cmake/SourceFiles.cmake
+++ b/SerialPrograms/cmake/SourceFiles.cmake
@@ -1590,6 +1590,8 @@ file(GLOB LIBRARY_SOURCES
     Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_LocationsDatabase.h
     Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_EncountersDatabase.cpp
     Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_EncountersDatabase.h
+    Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_SeedsDatabase.cpp
+    Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_SeedsDatabase.h
     Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_SidHelper.cpp
     Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_SidHelper.h
     Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngHelper.cpp


### PR DESCRIPTION
Depends on https://github.com/PokemonAutomation/Packages/pull/78

This eliminates some UI fields (seed delay & nearby seeds) that were sources of common user errors by making use of seed lists.