### PR TITLE
FRLG grass_spin fix

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/PokemonFRLG_Navigation.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/PokemonFRLG_Navigation.cpp
@@ -1195,7 +1195,7 @@ void heal_at_pokecenter(ConsoleHandle& console, ProControllerContext& context){
 
 int grass_spin(ConsoleHandle& console, ProControllerContext& context, bool leftright, Seconds timeout){
     BlackScreenWatcher battle_triggered(COLOR_RED);
-    BattleDialogWatcher battle_entered(COLOR_RED);
+    AdvanceBattleDialogWatcher battle_entered(COLOR_RED);
 
     context.wait_for_all_requests();
     console.log("Starting grass spin.");


### PR DESCRIPTION
The stand-in-place way to trigger grass encounters used to use the `BattleDialogDetector` as a backup check for entering a battle in case the black screen was missed for some reason, but due to its high tolerance and relatively few color checks it tends to trigger in other situations (white dialogues from repel ending, overworld areas with somewhat solid-color parts of the ground, fog in Pokemon Tower (?)).

This switches it to the `AdvanceBattleDialogDetector`, which will have fewer false positives.