### PR TITLE
add intermediate dev mode

### DIFF
--- a/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.cpp
+++ b/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.cpp
@@ -35,9 +35,9 @@
 #include "Controllers/ControllerSettings.h"
 #include "GlobalSettingsPanel.h"
 
-#include <iostream>
-using std::cout;
-using std::endl;
+// #include <iostream>
+// using std::cout;
+// using std::endl;
 
 namespace PokemonAutomation{
 

--- a/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.cpp
+++ b/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.cpp
@@ -197,13 +197,13 @@ GlobalSettings::GlobalSettings()
 //        IS_BETA_VERSION
     )
     , ERROR_REPORTS(CONSTRUCT_TOKEN)
-    , DEVELOPER_MODE_CHECKBOX(
-        "<b>Enable Developer mode:</b><br>Enable features for testing/development."
-        "<br>Restart application to take full effect after changing this.",
-        LockMode::UNLOCK_WHILE_RUNNING,
-        false
-    )
     , DEVELOPER_TOKEN(
+        true,
+        "<b>Developer Token for Regular Dev mode:</b><br>Restart application to take full effect after changing this.",
+        LockMode::LOCK_WHILE_RUNNING,
+        "", ""
+    )
+    , INTERNAL_DEVELOPER_TOKEN(
         true,
         "<b>Developer Token for Internal Dev mode:</b><br>Restart application to take full effect after changing this.",
         LockMode::LOCK_WHILE_RUNNING,
@@ -267,8 +267,8 @@ GlobalSettings::GlobalSettings()
     PA_ADD_OPTION(ERROR_REPORTS);
 #endif
 
-    PA_ADD_OPTION(DEVELOPER_MODE_CHECKBOX);
     PA_ADD_OPTION(DEVELOPER_TOKEN);
+    PA_ADD_OPTION(INTERNAL_DEVELOPER_TOKEN);
 
     USE_GPU_FOR_ML_INFERENCE0.set_visibility(ConfigOptionState::HIDDEN);
     RESOURCE_DOWNLOAD_TABLE.set_visibility(ConfigOptionState::HIDDEN);
@@ -290,7 +290,6 @@ void GlobalSettings::load_json(const JsonValue& json){
     STATIC_GLOBALS.load_json(json);
     BatchOption::load_json(json);
 
-    STATIC_GLOBALS.DEVELOPER_MODE = DEVELOPER_MODE_CHECKBOX.current_value();
     const bool developer_mode = STATIC_GLOBALS.DEVELOPER_MODE;
 
     ConfigOptionState devmode_visibility = developer_mode

--- a/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.cpp
+++ b/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.cpp
@@ -35,9 +35,9 @@
 #include "Controllers/ControllerSettings.h"
 #include "GlobalSettingsPanel.h"
 
-// #include <iostream>
-// using std::cout;
-// using std::endl;
+#include <iostream>
+using std::cout;
+using std::endl;
 
 namespace PokemonAutomation{
 
@@ -197,9 +197,15 @@ GlobalSettings::GlobalSettings()
 //        IS_BETA_VERSION
     )
     , ERROR_REPORTS(CONSTRUCT_TOKEN)
+    , DEVELOPER_MODE_CHECKBOX(
+        "<b>Enable Developer mode:</b><br>Enable features for testing/development."
+        "<br>Restart application to take full effect after changing this.",
+        LockMode::UNLOCK_WHILE_RUNNING,
+        false
+    )
     , DEVELOPER_TOKEN(
         true,
-        "<b>Developer Token:</b><br>Restart application to take full effect after changing this.",
+        "<b>Developer Token for Internal Dev mode:</b><br>Restart application to take full effect after changing this.",
         LockMode::LOCK_WHILE_RUNNING,
         "", ""
     )
@@ -261,6 +267,7 @@ GlobalSettings::GlobalSettings()
     PA_ADD_OPTION(ERROR_REPORTS);
 #endif
 
+    PA_ADD_OPTION(DEVELOPER_MODE_CHECKBOX);
     PA_ADD_OPTION(DEVELOPER_TOKEN);
 
     USE_GPU_FOR_ML_INFERENCE0.set_visibility(ConfigOptionState::HIDDEN);
@@ -281,8 +288,10 @@ void GlobalSettings::load_json(const JsonValue& json){
     }
 
     STATIC_GLOBALS.load_json(json);
-    const bool developer_mode = STATIC_GLOBALS.DEVELOPER_MODE;
     BatchOption::load_json(json);
+
+    STATIC_GLOBALS.DEVELOPER_MODE = DEVELOPER_MODE_CHECKBOX.current_value();
+    const bool developer_mode = STATIC_GLOBALS.DEVELOPER_MODE;
 
     ConfigOptionState devmode_visibility = developer_mode
         ? ConfigOptionState::ENABLED

--- a/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.cpp
+++ b/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.cpp
@@ -290,6 +290,8 @@ void GlobalSettings::load_json(const JsonValue& json){
     STATIC_GLOBALS.load_json(json);
     BatchOption::load_json(json);
 
+    // cout << "DEVELOPER_MODE: " << STATIC_GLOBALS.DEVELOPER_MODE << endl;
+    // cout << "INTERNAL_DEVELOPER_MODE: " << STATIC_GLOBALS.INTERNAL_DEVELOPER_MODE << endl;
     const bool developer_mode = STATIC_GLOBALS.DEVELOPER_MODE;
 
     ConfigOptionState devmode_visibility = developer_mode

--- a/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.cpp
+++ b/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.cpp
@@ -199,13 +199,7 @@ GlobalSettings::GlobalSettings()
     , ERROR_REPORTS(CONSTRUCT_TOKEN)
     , DEVELOPER_TOKEN(
         true,
-        "<b>Developer Token for Regular Dev mode:</b><br>Restart application to take full effect after changing this.",
-        LockMode::LOCK_WHILE_RUNNING,
-        "", ""
-    )
-    , INTERNAL_DEVELOPER_TOKEN(
-        true,
-        "<b>Developer Token for Internal Dev mode:</b><br>Restart application to take full effect after changing this.",
+        "<b>Developer Token:</b><br>Restart application to take full effect after changing this.",
         LockMode::LOCK_WHILE_RUNNING,
         "", ""
     )
@@ -268,7 +262,6 @@ GlobalSettings::GlobalSettings()
 #endif
 
     PA_ADD_OPTION(DEVELOPER_TOKEN);
-    PA_ADD_OPTION(INTERNAL_DEVELOPER_TOKEN);
 
     USE_GPU_FOR_ML_INFERENCE0.set_visibility(ConfigOptionState::HIDDEN);
     RESOURCE_DOWNLOAD_TABLE.set_visibility(ConfigOptionState::HIDDEN);

--- a/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.h
+++ b/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.h
@@ -118,8 +118,8 @@ public:
 
     Pimpl<ErrorReportOption> ERROR_REPORTS;
 
-    BooleanCheckBoxOption DEVELOPER_MODE_CHECKBOX;
     StringOption DEVELOPER_TOKEN;
+    StringOption INTERNAL_DEVELOPER_TOKEN;
 
     // The mode that does not run Qt GUI, but instead runs some tests for
     // debugging, unit testing and developing purposes.

--- a/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.h
+++ b/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.h
@@ -118,6 +118,7 @@ public:
 
     Pimpl<ErrorReportOption> ERROR_REPORTS;
 
+    BooleanCheckBoxOption DEVELOPER_MODE_CHECKBOX;
     StringOption DEVELOPER_TOKEN;
 
     // The mode that does not run Qt GUI, but instead runs some tests for

--- a/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.h
+++ b/SerialPrograms/Source/CommonFramework/GlobalSettingsPanel.h
@@ -119,7 +119,6 @@ public:
     Pimpl<ErrorReportOption> ERROR_REPORTS;
 
     StringOption DEVELOPER_TOKEN;
-    StringOption INTERNAL_DEVELOPER_TOKEN;
 
     // The mode that does not run Qt GUI, but instead runs some tests for
     // debugging, unit testing and developing purposes.

--- a/SerialPrograms/Source/CommonFramework/StaticGlobals.cpp
+++ b/SerialPrograms/Source/CommonFramework/StaticGlobals.cpp
@@ -54,21 +54,7 @@ void StaticGlobals::load_json(const JsonValue& json){
         bool internal_dev = INTERNAL_TOKENS.find(hash.get_hash_hex()) != INTERNAL_TOKENS.end();
         bool regular_dev = TOKENS.find(hash.get_hash_hex()) != TOKENS.end();
         DEVELOPER_MODE = regular_dev || internal_dev;
-    }
-
-    const std::string* internal_dev_token = obj->get_string("INTERNAL_DEVELOPER_TOKEN");
-    if (internal_dev_token){
-        SHA256 hash;
-        hash.push(internal_dev_token->c_str(), internal_dev_token->size());
-        hash.finish();
-        hash.get_hash_hex();
-
-        bool internal_dev = INTERNAL_TOKENS.find(hash.get_hash_hex()) != INTERNAL_TOKENS.end();
-        if (internal_dev){
-            INTERNAL_DEVELOPER_MODE = true;
-            DEVELOPER_MODE = true;
-        }
-            
+        INTERNAL_DEVELOPER_MODE = internal_dev;
     }
 
     const JsonObject* debug_obj = obj->get_object("DEBUG");

--- a/SerialPrograms/Source/CommonFramework/StaticGlobals.cpp
+++ b/SerialPrograms/Source/CommonFramework/StaticGlobals.cpp
@@ -47,7 +47,7 @@ void StaticGlobals::load_json(const JsonValue& json){
         hash.push(dev_token->c_str(), dev_token->size());
         hash.finish();
         hash.get_hash_hex();
-        DEVELOPER_MODE = TOKENS.find(hash.get_hash_hex()) != TOKENS.end();
+        INTERNAL_DEVELOPER_MODE = TOKENS.find(hash.get_hash_hex()) != TOKENS.end();
     }
 
     const JsonObject* debug_obj = obj->get_object("DEBUG");

--- a/SerialPrograms/Source/CommonFramework/StaticGlobals.cpp
+++ b/SerialPrograms/Source/CommonFramework/StaticGlobals.cpp
@@ -28,6 +28,20 @@ const std::set<std::string> TOKENS{
     "9b41db8175b5f248a78e738c7bd63a36e33b57953cb4e80ccdd13c2a7e892eec", //  Dalton's token.
 };
 
+const std::set<std::string> INTERNAL_TOKENS{
+//    "f6538243092d8a3b9959bca988f054e1670f57c7246df2cbba25c4df3fe7a4e7",
+    "2d04af67f6520e3550842d7eeb292868c6d0d4809b607f5a454712023d8815e1",
+    "475d0a0a305a02cbf8b602bd47c3b275dccd5ac19fbe480729804a8e4e360b71",
+    "6643d9fe87b3e54dc75dfac8ac22f0cc8bd17f6a8a786debf5fc4c517ee65469",
+    "8e48e38e49bffc8462ada9d2d9d850d5b3b5c9529d20978c09bc548bc9a614a4",
+    "7694adee4419d62c6a923c4efc9e7b41def7b96bb84ea882701b0bf2e8c13bee",
+    "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", //  jw's token.
+    "e8d168bc482e96553ea9f9ecaea5a817474dbccc2a6a228a6bde67f2b2aa2889", //  James' token.
+    "7555b7c63481cad42306718c67e7f9def5bfd1da8f6cd299ccd3d7dc95f307ae", //  Kuro's token.
+    "3d475b46d121fc24559d100de2426feaa53cd6578aac2817c4857a610ccde2dd", //  kichi's token.
+    "9b41db8175b5f248a78e738c7bd63a36e33b57953cb4e80ccdd13c2a7e892eec", //  Dalton's token.
+};
+
 
 
 
@@ -47,7 +61,22 @@ void StaticGlobals::load_json(const JsonValue& json){
         hash.push(dev_token->c_str(), dev_token->size());
         hash.finish();
         hash.get_hash_hex();
-        INTERNAL_DEVELOPER_MODE = TOKENS.find(hash.get_hash_hex()) != TOKENS.end();
+        DEVELOPER_MODE = TOKENS.find(hash.get_hash_hex()) != TOKENS.end();
+    }
+
+    const std::string* internal_dev_token = obj->get_string("INTERNAL_DEVELOPER_TOKEN");
+    if (internal_dev_token){
+        SHA256 hash;
+        hash.push(internal_dev_token->c_str(), internal_dev_token->size());
+        hash.finish();
+        hash.get_hash_hex();
+
+        bool internal_dev = INTERNAL_TOKENS.find(hash.get_hash_hex()) != INTERNAL_TOKENS.end();
+        if (internal_dev){
+            INTERNAL_DEVELOPER_MODE = true;
+            DEVELOPER_MODE = true;
+        }
+            
     }
 
     const JsonObject* debug_obj = obj->get_object("DEBUG");

--- a/SerialPrograms/Source/CommonFramework/StaticGlobals.cpp
+++ b/SerialPrograms/Source/CommonFramework/StaticGlobals.cpp
@@ -21,22 +21,11 @@ const std::set<std::string> TOKENS{
     "6643d9fe87b3e54dc75dfac8ac22f0cc8bd17f6a8a786debf5fc4c517ee65469",
     "8e48e38e49bffc8462ada9d2d9d850d5b3b5c9529d20978c09bc548bc9a614a4",
     "7694adee4419d62c6a923c4efc9e7b41def7b96bb84ea882701b0bf2e8c13bee",
-    "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", //  jw's token.
     "e8d168bc482e96553ea9f9ecaea5a817474dbccc2a6a228a6bde67f2b2aa2889", //  James' token.
-    "7555b7c63481cad42306718c67e7f9def5bfd1da8f6cd299ccd3d7dc95f307ae", //  Kuro's token.
-    "3d475b46d121fc24559d100de2426feaa53cd6578aac2817c4857a610ccde2dd", //  kichi's token.
-    "9b41db8175b5f248a78e738c7bd63a36e33b57953cb4e80ccdd13c2a7e892eec", //  Dalton's token.
 };
 
 const std::set<std::string> INTERNAL_TOKENS{
-//    "f6538243092d8a3b9959bca988f054e1670f57c7246df2cbba25c4df3fe7a4e7",
-    "2d04af67f6520e3550842d7eeb292868c6d0d4809b607f5a454712023d8815e1",
-    "475d0a0a305a02cbf8b602bd47c3b275dccd5ac19fbe480729804a8e4e360b71",
-    "6643d9fe87b3e54dc75dfac8ac22f0cc8bd17f6a8a786debf5fc4c517ee65469",
-    "8e48e38e49bffc8462ada9d2d9d850d5b3b5c9529d20978c09bc548bc9a614a4",
-    "7694adee4419d62c6a923c4efc9e7b41def7b96bb84ea882701b0bf2e8c13bee",
     "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", //  jw's token.
-    "e8d168bc482e96553ea9f9ecaea5a817474dbccc2a6a228a6bde67f2b2aa2889", //  James' token.
     "7555b7c63481cad42306718c67e7f9def5bfd1da8f6cd299ccd3d7dc95f307ae", //  Kuro's token.
     "3d475b46d121fc24559d100de2426feaa53cd6578aac2817c4857a610ccde2dd", //  kichi's token.
     "9b41db8175b5f248a78e738c7bd63a36e33b57953cb4e80ccdd13c2a7e892eec", //  Dalton's token.
@@ -61,7 +50,10 @@ void StaticGlobals::load_json(const JsonValue& json){
         hash.push(dev_token->c_str(), dev_token->size());
         hash.finish();
         hash.get_hash_hex();
-        DEVELOPER_MODE = TOKENS.find(hash.get_hash_hex()) != TOKENS.end();
+
+        bool internal_dev = INTERNAL_TOKENS.find(hash.get_hash_hex()) != INTERNAL_TOKENS.end();
+        bool regular_dev = TOKENS.find(hash.get_hash_hex()) != TOKENS.end();
+        DEVELOPER_MODE = regular_dev || internal_dev;
     }
 
     const std::string* internal_dev_token = obj->get_string("INTERNAL_DEVELOPER_TOKEN");

--- a/SerialPrograms/Source/CommonFramework/StaticGlobals.h
+++ b/SerialPrograms/Source/CommonFramework/StaticGlobals.h
@@ -27,6 +27,7 @@ public:
 public:
     bool NAUGHTY_MODE = false;
     bool DEVELOPER_MODE = false;
+    bool INTERNAL_DEVELOPER_MODE = false;
 
 
     // Debug color stats like those in:

--- a/SerialPrograms/Source/NintendoSwitch/NintendoSwitch_Panels.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/NintendoSwitch_Panels.cpp
@@ -88,7 +88,9 @@ std::vector<PanelEntry> PanelListFactory::make_panels() const{
         ret.emplace_back(make_single_switch_program<TestDudunsparceFormDetector_Descriptor, TestDudunsparceFormDetector>());
         ret.emplace_back(make_computer_program<ComputerPrograms::UnitTestRunner_Descriptor, ComputerPrograms::UnitTestRunner>());
 #ifdef PA_OFFICIAL
-        add_panels(ret);
+        if (STATIC_GLOBALS.INTERNAL_DEVELOPER_MODE){
+            add_panels(ret);
+        }
 #endif
     }
 

--- a/SerialPrograms/Source/PokemonSV/PokemonSV_Panels.cpp
+++ b/SerialPrograms/Source/PokemonSV/PokemonSV_Panels.cpp
@@ -171,7 +171,7 @@ std::vector<PanelEntry> PanelListFactory::make_panels() const{
     }
 
 #ifdef PA_OFFICIAL
-    if (STATIC_GLOBALS.DEVELOPER_MODE){
+    if (STATIC_GLOBALS.INTERNAL_DEVELOPER_MODE){
         ret.emplace_back("---- Research ----");
         add_panels(ret);
     }


### PR DESCRIPTION
I believe I moved all the internal stuff under INTERNAL_DEVELOPER_MODE. But please double check.
Also, I'm not sure if we want other stuff hidden under internal dev mode, such as RSE, ML stuff (although these are already available in the public repo).