### PR TITLE
upload standalone .exe file for windows builds

### DIFF
--- a/.github/workflows/cpp-ci-serial-programs-base.yml
+++ b/.github/workflows/cpp-ci-serial-programs-base.yml
@@ -57,7 +57,7 @@ jobs:
       with:
         # Delete aqtsource once https://github.com/miurahr/aqtinstall/issues/1007 is fixed and released
         aqtsource: 'git+https://github.com/miurahr/aqtinstall'
-        version: '6.11.1'
+        version: '6.10.2'
         modules: 'qtmultimedia qtserialport'
 
     - name: Install dependencies (Ubuntu)
@@ -106,6 +106,13 @@ jobs:
       with:
         name: Serial Programs (os=${{inputs.os}} - compiler=${{inputs.compiler}})
         path: ${{env.UPLOAD_FOLDER}}
+
+    - name: Upload Executable Only
+      uses: actions/upload-artifact@v7
+      if: inputs.upload-build && startsWith(inputs.os, 'windows')
+      with:
+        name: Standalone Executable (os=${{inputs.os}})
+        path: ${{env.UPLOAD_FOLDER}}/SerialPrograms.exe
 
     - name: Checkout CommandLineTests
       uses: actions/checkout@v7


### PR DESCRIPTION
- downgraded Qt version to match our official releases. So that someone can take the standalone .exe binary and test it themselves
- upload standalone .exe file for windows builds. I'm not sure if dropping in the standalone .exe file also works for Mac/Linux. If it does, then we could consider uploading standalone .exe files for them too.