### PR TITLE
Collapse duplicate file hashing function.

### DIFF
--- a/Common/Cpp/Filesystem/Filesystem.cpp
+++ b/Common/Cpp/Filesystem/Filesystem.cpp
@@ -42,6 +42,9 @@ bool create_directories(const Path& path){
     return std::filesystem::create_directories(path.stdpath());
 }
 
+bool remove(const Path& path){
+    return std::filesystem::remove(path);
+}
 std::uintmax_t remove_all(const Path& path){
     return std::filesystem::remove_all(path.stdpath());
 }

--- a/Common/Cpp/Filesystem/Filesystem.h
+++ b/Common/Cpp/Filesystem/Filesystem.h
@@ -40,6 +40,7 @@ bool create_directories(const Path& path);
 
 //  Delete the contents of the path (if it is a directory) and the contents of all its subdirectories, recursively.
 //  Then delete the file/directory of path itself. Symlinks are not followed (symlink is removed, not its target).
+bool remove(const Path& path);
 std::uintmax_t remove_all(const Path& path);
 
 //  Copy a file.

--- a/SerialPrograms/Source/CommonFramework/ResourceDownload/DownloadThread.cpp
+++ b/SerialPrograms/Source/CommonFramework/ResourceDownload/DownloadThread.cpp
@@ -23,9 +23,6 @@ using std::endl;
 
 namespace PokemonAutomation{
 
-namespace fs = std::filesystem;
-
-
 
 
 DownloadThread::~DownloadThread(){
@@ -104,7 +101,7 @@ void DownloadThread::run_download(DownloadedResourceMetadata resource_metadata){
     try{
 
         // delete directory and the old resource
-        fs::remove_all(Filesystem::Path(resource_directory));
+        Filesystem::remove_all(resource_directory);
 
         // download
         std::string zip_path = resource_directory + "/temp.zip";
@@ -122,7 +119,7 @@ void DownloadThread::run_download(DownloadedResourceMetadata resource_metadata){
         // hash
         std::string hash = 
             hash_file(
-                *this,
+                this,
                 zip_path,
                 [this](uint64_t bytes_done, uint64_t total_bytes){
                     m_hooks.report_hash_progress(bytes_done, total_bytes);
@@ -149,23 +146,23 @@ void DownloadThread::run_download(DownloadedResourceMetadata resource_metadata){
         );
 
         // delete old zip file
-        fs::remove(Filesystem::Path(zip_path));
+        Filesystem::remove(zip_path);
 
         throw_if_cancelled();
 
     }catch(OperationCancelledException&){
         // delete directory and the resource
-        fs::remove_all(Filesystem::Path(resource_directory));
+        Filesystem::remove_all(resource_directory);
 
         throw;
     }catch(OperationFailedException&){
         // delete directory and the resource
-        fs::remove_all(Filesystem::Path(resource_directory));
+        Filesystem::remove_all(resource_directory);
 
         throw;
     }catch(...){
         // delete directory and the resource
-        fs::remove_all(Filesystem::Path(resource_directory));
+        Filesystem::remove_all(resource_directory);
 
         throw;
     }

--- a/SerialPrograms/Source/CommonFramework/Tools/FileHash.cpp
+++ b/SerialPrograms/Source/CommonFramework/Tools/FileHash.cpp
@@ -19,7 +19,7 @@ namespace PokemonAutomation{
 
 
 std::string hash_file(
-    CancellableScope& scope,
+    CancellableScope* scope,
     const std::string& file_path,
     std::function<void(uint64_t bytes_done, uint64_t total_bytes)> hash_progress
 ){
@@ -34,7 +34,9 @@ std::string hash_file(
 
     QByteArray buffer(1024 * 1024, 0); // Pre-allocate 1MB once
     while (!file.atEnd()){
-        scope.throw_if_cancelled();
+        if (scope != nullptr){
+            scope->throw_if_cancelled();
+        }
         
         qint64 num_bytes_in_chunk = file.read(buffer.data(), buffer.size());
         if (num_bytes_in_chunk == -1){
@@ -44,7 +46,9 @@ std::string hash_file(
         hash.addData(QByteArrayView(buffer.data(), num_bytes_in_chunk));
         total_bytes_read += num_bytes_in_chunk;
 
-        hash_progress(total_bytes_read, file_size);
+        if (hash_progress != nullptr){
+            hash_progress(total_bytes_read, file_size);
+        }
     }
 
     return hash.result().toHex().toStdString(); 

--- a/SerialPrograms/Source/CommonFramework/Tools/FileHash.h
+++ b/SerialPrograms/Source/CommonFramework/Tools/FileHash.h
@@ -17,10 +17,13 @@ namespace PokemonAutomation{
 
 // uses SHA 256
 std::string hash_file(
-    CancellableScope& scope,
+    CancellableScope* scope,
     const std::string& file_path,
-    std::function<void(uint64_t bytes_done, uint64_t total_bytes)> hash_progress
+    std::function<void(uint64_t bytes_done, uint64_t total_bytes)> hash_progress = nullptr
 );
+inline std::string hash_file(const std::string& file_path){
+    return hash_file(nullptr, file_path, nullptr);
+}
 
 
 }

--- a/SerialPrograms/Source/ML/Models/ML_ONNXRuntimeHelpers.cpp
+++ b/SerialPrograms/Source/ML/Models/ML_ONNXRuntimeHelpers.cpp
@@ -5,11 +5,6 @@
  *  Helper functions to work with ONNX Runtime library
  */
 
-#include <QString>
-#include <QFile>
-#include <QCryptographicHash>
-#include <QByteArray>
-
 #include <iostream>
 #include <string>
 #include <fstream>
@@ -19,6 +14,7 @@
 #include "Common/Cpp/Exceptions.h"
 #include "Common/Cpp/Filesystem/Filesystem.h"
 #include "CommonFramework/Logging/Logger.h"
+#include "CommonFramework/Tools/FileHash.h"
 #include "ML_OrtEnv.h"
 #include "ML_ONNXRuntimeHelpers.h"
 
@@ -26,20 +22,6 @@ namespace PokemonAutomation{
 namespace ML{
 
 
-// Computes the cryptographic hash of a file.
-std::string create_file_hash(const std::string& filepath){
-    QFile file(QString::fromStdString(filepath));
-    if (!file.open(QIODevice::ReadOnly)){
-        return "";
-    }
-
-    QCryptographicHash hash(QCryptographicHash::Sha256);
-    if (hash.addData(&file)){
-        return hash.result().toHex(0).toStdString();
-    }else{
-        return "";
-    }
-}
 
 
 Ort::SessionOptions create_session_options(const std::string& model_cache_path, bool use_gpu){
@@ -143,7 +125,7 @@ Ort::SessionOptions create_session_options(const std::string& model_cache_path, 
 // model_path: the model path to load the ML model. This is needed to ensure we delete the old model cache
 //   when a new model
 std::pair<bool, std::string> clean_up_old_model_cache(const std::string& model_cache_path, const std::string& model_path){
-    std::string file_hash = create_file_hash(model_path);
+    std::string file_hash = hash_file(model_path);
     if (file_hash.size() == 0){
         // the model file cannot be loaded
         return {true, ""};

--- a/SerialPrograms/Source/ML/Models/ML_ONNXRuntimeHelpers.h
+++ b/SerialPrograms/Source/ML/Models/ML_ONNXRuntimeHelpers.h
@@ -16,6 +16,7 @@
 namespace PokemonAutomation{
 namespace ML{
 
+
 // Create an ONNX SessionOptions
 // If on macOS, will use CoreML as the backend.
 // If on Windows, will try CUDA first (NVIDIA GPUs), then DirectML (all GPU vendors).


### PR DESCRIPTION
Cleanup steps preparing for the big `Ort::Env` refactor.

Next up is to remove the Qt from FileHash.h/cpp.