### PR TITLE
FRLG Togepi RNG fix

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_BlindNavigation.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_BlindNavigation.cpp
@@ -202,6 +202,17 @@ void collect_togepi_egg_after_delay(ProControllerContext& context, const uint64_
     context.wait_for_all_requests();    
 }
 
+void collect_preapproved_togepi_egg_after_delay(ProControllerContext& context, const uint64_t& ingame_delay){
+    // wait with the start menu open to avoid overworld stuff causing extra advances
+    pbf_press_button(context, BUTTON_PLUS, 200ms, 300ms);
+    pbf_wait(context, std::chrono::milliseconds(ingame_delay - 5200)); // 4000ms + 500ms + 500ms + 200ms
+    pbf_press_button(context, BUTTON_B, 200ms, 300ms);
+    // accept egg
+    pbf_press_button(context, BUTTON_A, 200ms, 2800ms);
+    // exit dialogue
+    pbf_mash_button(context, BUTTON_B, 2500ms);
+}
+
 void trigger_held_daycare_egg_after_delay(ProControllerContext& context, const uint64_t& ingame_delay){
     // No dialogue to advance through -- just wait
     pbf_wait(context, std::chrono::milliseconds(ingame_delay - 4000));
@@ -522,11 +533,20 @@ void check_timings(
             );
         }
         return;
+    case PokemonFRLG_RngTarget::togepifast:
+        if (timings.ingame_delay < 5500){
+            OperationFailedException::fire(
+                ErrorReport::NO_ERROR_REPORT,
+                "Togepi (pre-approved): the in-game delay cannot be less than 5500ms (500 advances). Check your in-game advances and calibration or pick a new target.",
+                console
+            );
+        }
+        return;
     case PokemonFRLG_RngTarget::eggheld:
         if (timings.ingame_delay < 4000) {
             OperationFailedException::fire(
                 ErrorReport::NO_ERROR_REPORT,
-                "Togepi: the in-game delay cannot be less than 4000ms (350 advances). Check your in-game advances and calibration or pick a new target.",
+                "Held Frame: the in-game delay cannot be less than 4000ms (350 advances). Check your in-game advances and calibration or pick a new target.",
                 console
             );
         }
@@ -535,7 +555,7 @@ void check_timings(
         if (timings.ingame_delay < 12000) {
             OperationFailedException::fire(
                 ErrorReport::NO_ERROR_REPORT,
-                "Togepi: the in-game delay cannot be less than 12000ms (1440 advances). Check your in-game advances and calibration or pick a new target.",
+                "Pickup Frame: the in-game delay cannot be less than 12000ms (1440 advances). Check your in-game advances and calibration or pick a new target.",
                 console
             );
         }
@@ -759,6 +779,9 @@ void perform_blind_sequence(
         return;
     case PokemonFRLG_RngTarget::togepi:
         collect_togepi_egg_after_delay(context, timings.ingame_delay);
+        return;
+    case PokemonFRLG_RngTarget::togepifast:
+        collect_preapproved_togepi_egg_after_delay(context, timings.ingame_delay);
         return;
     case PokemonFRLG_RngTarget::eggheld:
         trigger_held_daycare_egg_after_delay(context, timings.ingame_delay);

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_BlindNavigation.h
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_BlindNavigation.h
@@ -39,6 +39,7 @@ namespace PokemonFRLG{
         gamecornerpinsir,
         gamecornerporygon,
         togepi,
+        togepifast,
         eggheld,
         eggpickup,
         electrode,

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_GiftRng.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_GiftRng.cpp
@@ -121,6 +121,7 @@ GiftRng::GiftRng()
             {PokemonFRLG_RngTarget::gamecornerpinsir, "gamecornerpinsir", "Game Corner Pinsir"},
             {PokemonFRLG_RngTarget::gamecornerporygon, "gamecornerporygon", "Game Corner Porygon"},
             {PokemonFRLG_RngTarget::togepi, "togepi", "Togepi"},
+            {PokemonFRLG_RngTarget::togepifast, "togepifast", "Togepi (pre-approved)"}
         },
         LockMode::LOCK_WHILE_RUNNING,
         PokemonFRLG_RngTarget::magikarp
@@ -313,6 +314,7 @@ void GiftRng::program(SingleSwitchProgramEnvironment& env, ProControllerContext&
         GENDER_THRESHOLD = -1;
         break;
     case PokemonFRLG_RngTarget::togepi:
+    case PokemonFRLG_RngTarget::togepifast:
         BASE_STATS = { 35, 20, 65, 40, 65, 20 };
         GENDER_THRESHOLD = 30;
         LEVEL = 5;

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngHelper.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngHelper.cpp
@@ -87,6 +87,7 @@ RngHelper::RngHelper()
             {PokemonFRLG_RngTarget::gamecornerpinsir, "gamecornerpinsir", "Game Corner Pinsir"},
             {PokemonFRLG_RngTarget::gamecornerporygon, "gamecornerporygon", "Game Corner Porygon"},
             {PokemonFRLG_RngTarget::togepi, "togepi", "Togepi"},
+            {PokemonFRLG_RngTarget::togepifast, "togepifast", "Togepi (pre-approved)"},
             {PokemonFRLG_RngTarget::eggheld, "eggheld", "Daycare Egg Held Frame"},
             {PokemonFRLG_RngTarget::eggpickup, "eggpickup", "Daycare Egg Pickup"},
             {PokemonFRLG_RngTarget::staticencounter, "staticencounter", "Static Overworld Encounters"},

--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngNavigation.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngNavigation.cpp
@@ -657,6 +657,7 @@ bool check_for_shiny(
     case PokemonFRLG_RngTarget::starters:
         return shiny_check_summary(console, context, -2, StartMenuContext::NO_DEX);
     case PokemonFRLG_RngTarget::togepi:
+    case PokemonFRLG_RngTarget::togepifast:
         hatch_togepi_egg(console, context);
     case PokemonFRLG_RngTarget::magikarp:
     case PokemonFRLG_RngTarget::hitmonlee:


### PR DESCRIPTION
Adds an option for Togepi RNG in case you've already shown the old man a max friendship Pokemon, but your party was full.

Reported by thewhitewolfking and clap