### PR TITLE
Fix FRLG OCR error caused by small images

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/Inference/PokemonFRLG_DigitReader.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Inference/PokemonFRLG_DigitReader.cpp
@@ -63,9 +63,18 @@ ImageRGB32 preprocess_for_ocr(
 
     // Step 0: Rescale the image to match the expected height at 1080p
     // so that the Gaussian blur size works across resolutions
-    double scale_factor = image.height() / 69; 
-    int new_w = static_cast<int>((image.width()) * scale_factor);
-    int new_h = static_cast<int>((image.height()) * scale_factor);
+    constexpr int expected_height = 69;
+
+    double scale_factor = static_cast<double>(expected_height) / static_cast<double>(image.height());
+
+    int new_w = std::max(
+        1, cvRound(static_cast<int>(image.width() * scale_factor))
+    );
+
+    int new_h = std::max(
+        1, cvRound(static_cast<int>(image.height() * scale_factor))
+    );
+
     cv::Mat rescaled;
     cv::resize(
         src, rescaled, cv::Size(new_w, new_h), 0, 0,


### PR DESCRIPTION
If the image height is less than the expected height (69) the integer division returns zeros. Passing these zeros into cv::resize results in the following error:

`OpenCV(4.12.0)  C:\GHA-OCV-6\_work\ci-gha-workflow\opencv\modules\imgproc\src\resize.cpp4211: error: (-215:Assertion failed) inv_scale_x > 0 in function 'cv::resize'`

<img width="1213" height="516" alt="Screenshot 2026-08-20 094713" src="https://github.com/user-attachments/assets/2a29b183-534a-4ca2-908b-6a79c8e1fd6a" />


I believe the initial scale division needs flipped to `expected height / image height`

I also added some rounding and defaults to prevent passing zeros into the resize method. 
I tested this on switch 1 and switch 2 with both 1080p and 4k