### PR TITLE
Reduce number of file for clang query from 150 to 100

### DIFF
--- a/.github/workflows/cpp-ci-serial-programs-base.yml
+++ b/.github/workflows/cpp-ci-serial-programs-base.yml
@@ -163,7 +163,7 @@ jobs:
           EOF
 
           files=$(jq -r '.[].file' SerialPrograms/bin/compile_commands.json)
-          echo "$files" | xargs --max-args=150 clang-query -p SerialPrograms/bin/ -f query.txt >> output.txt
+          echo "$files" | xargs --max-args=100 clang-query -p SerialPrograms/bin/ -f query.txt >> output.txt
           cat output.txt
           if grep --silent "Match #" output.txt; then
             echo "::error Forbidden std::filesystem::path construction detected!"


### PR DESCRIPTION
I saw this failed frequently recently. I know I had those issues because of too many files, causing some kind of OOM issues. Reducing the number of files at once will slow down a bit the CI but it shouldn't fail as much