### PR TITLE
Various Backends for Video Feeds for GPU Targets

### DIFF
--- a/Common/Cpp/Options/EnumDropdownDatabase.h
+++ b/Common/Cpp/Options/EnumDropdownDatabase.h
@@ -92,8 +92,7 @@ public:
 public:
     EnumDropdownDatabase() : IntegerEnumDropdownDatabase() {}
     EnumDropdownDatabase(std::initializer_list<Entry> list){
-        size_t index = 0;
-        for (auto iter = list.begin(); iter != list.end(); ++iter, index++){
+        for (auto iter = list.begin(); iter != list.end(); ++iter){
             add(
                 iter->value,
                 std::move(iter->slug),

--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -78,10 +78,10 @@ if(WIN32 AND QT_DEPLOY_FILES)
     if(QT_CANDIDATE_DIR AND EXISTS "${QT_CANDIDATE_DIR}")
         message(STATUS "Using preferred Qt directory for Qt${QT_MAJOR} ${PREFERRED_QT_VER}: ${QT_CANDIDATE_DIR}")
         list(APPEND CMAKE_PREFIX_PATH "${QT_CANDIDATE_DIR}")
-        find_package(Qt${QT_MAJOR} ${PREFERRED_QT_VER} COMPONENTS Widgets SerialPort Multimedia MultimediaWidgets REQUIRED)
+        find_package(Qt${QT_MAJOR} ${PREFERRED_QT_VER} COMPONENTS Widgets SerialPort Multimedia MultimediaWidgets OpenGLWidgets Qml Quick QuickWidgets REQUIRED)
     else()
         # Find all subdirectories in the Qt base directory
-        find_package(Qt${QT_MAJOR} COMPONENTS Widgets SerialPort Multimedia MultimediaWidgets REQUIRED)
+        find_package(Qt${QT_MAJOR} COMPONENTS Widgets SerialPort Multimedia MultimediaWidgets OpenGLWidgets Qml Quick QuickWidgets REQUIRED)
         file(GLOB QT_SUBDIRS LIST_DIRECTORIES true "${QT_BASE_DIR}/${QT_MAJOR}*")
 
         # Filter and sort the directories to find the latest version
@@ -109,7 +109,7 @@ if(WIN32 AND QT_DEPLOY_FILES)
         REQUIRED
     )
 else()
-    find_package(Qt${QT_MAJOR} COMPONENTS Widgets SerialPort Multimedia MultimediaWidgets REQUIRED)
+    find_package(Qt${QT_MAJOR} COMPONENTS Widgets SerialPort Multimedia MultimediaWidgets OpenGLWidgets Qml Quick QuickWidgets REQUIRED)
 endif()
 
 # disable deprecated Qt APIs
@@ -188,7 +188,7 @@ endif()
 # Function to apply common properties to both library and executable targets
 function(apply_common_target_properties target_name)
     set_target_properties(${target_name} PROPERTIES LINKER_LANGUAGE CXX)
-    target_link_libraries(${target_name} PRIVATE Qt${QT_MAJOR}::Widgets Qt${QT_MAJOR}::SerialPort Qt${QT_MAJOR}::Multimedia Qt${QT_MAJOR}::MultimediaWidgets)
+    target_link_libraries(${target_name} PRIVATE Qt${QT_MAJOR}::Widgets Qt${QT_MAJOR}::SerialPort Qt${QT_MAJOR}::Multimedia Qt${QT_MAJOR}::MultimediaWidgets Qt${QT_MAJOR}::OpenGLWidgets Qt${QT_MAJOR}::Qml Qt${QT_MAJOR}::Quick Qt${QT_MAJOR}::QuickWidgets)
     target_link_libraries(${target_name} PRIVATE Threads::Threads)
 
     #add defines
@@ -468,10 +468,9 @@ else() # macOS and Linux
     endif() # end Linux
 
     # Find OpenCV
-    pkg_search_module(OpenCV REQUIRED opencv4 opencv)
-    target_include_directories(SerialProgramsLib SYSTEM PRIVATE ${OpenCV_INCLUDE_DIRS}) # "SYSTEM" to suppress warnings
-    target_link_directories(SerialProgramsLib PUBLIC ${OpenCV_LIBRARY_DIRS})
-    target_link_libraries(SerialProgramsLib PUBLIC ${OpenCV_LINK_LIBRARIES})
+    find_package(OpenCV REQUIRED)
+    target_include_directories(SerialProgramsLib SYSTEM PUBLIC ${OpenCV_INCLUDE_DIRS}) # "SYSTEM" to suppress warnings
+    target_link_libraries(SerialProgramsLib PUBLIC ${OpenCV_LIBS})
 
     #we hope to use our own Tesseract build in future so we can rid that dependency
     #but right now to run on Linux and Mac we need to use external Tesseract library

--- a/SerialPrograms/Source/CommonFramework/Main.cpp
+++ b/SerialPrograms/Source/CommonFramework/Main.cpp
@@ -227,11 +227,18 @@ int main(int argc, char *argv[]){
 #endif
 
 #if defined(__linux__)
-    // Qt multimedia, default to gstreamer to prevent flickering
-    // Easier than the alternative which is compiling qt6multimedia with QT_DEFAULT_MEDIA_BACKEND
+    // Enable libv4l2 for GStreamer by default to fix issues with cheap capture cards
+    // This helps prevent "Invalid argument (22)" buffer allocation errors on v4l2src.
+    if (qEnvironmentVariableIsEmpty("GST_V4L2_USE_LIBV4L2")) {
+        qputenv("GST_V4L2_USE_LIBV4L2", "1");
+    }
+
+    // Qt multimedia, default to ffmpeg to prevent GStreamer capture drops.
+    // GStreamer used to be preferred to prevent flickering but causes fatal 
+    // crashes (buffer allocation errors) with cheap capture cards on Linux.
     // See: https://doc.qt.io/qt-6.5/qtmultimedia-index.html
     if (qEnvironmentVariableIsEmpty("QT_MEDIA_BACKEND"))
-        qputenv("QT_MEDIA_BACKEND", "gstreamer");
+        qputenv("QT_MEDIA_BACKEND", "ffmpeg");
 #endif
 
     //  So far, this is only needed on Mac where static initialization is fucked up.

--- a/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraImplementations.cpp
+++ b/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraImplementations.cpp
@@ -22,6 +22,10 @@
 #include "CameraWidgetQt6_QML.h"
 #endif
 
+#if defined(__linux__) || defined(__APPLE__)
+#include "CameraWidgetOpenCV.h"
+#endif
+
 
 namespace PokemonAutomation{
 
@@ -50,6 +54,12 @@ struct CameraBackends{
     }
 
     CameraBackends(){
+#if defined(__linux__) || defined(__APPLE__)
+        m_backends.emplace_back(
+            "opencv-v4l2", "Linux: OpenCV V4L2",
+            std::make_unique<CameraOpenCV::CameraBackend>()
+        );
+#endif
 #if QT_VERSION_MAJOR == 6
         m_backends.emplace_back(
             "qt6-QVideoSink", "Qt6: QVideoSink",

--- a/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraImplementations.cpp
+++ b/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraImplementations.cpp
@@ -17,9 +17,9 @@
 #if 0
 #elif QT_VERSION_MAJOR == 6
 #include "CameraWidgetQt6.h"
-#if QT_VERSION_MINOR >= 5
 #include "CameraWidgetQt6.5.h"
-#endif
+#include "CameraWidgetQt6_QVideoWidget.h"
+#include "CameraWidgetQt6_QML.h"
 #endif
 
 
@@ -54,6 +54,14 @@ struct CameraBackends{
         m_backends.emplace_back(
             "qt6-QVideoSink", "Qt6: QVideoSink",
             std::make_unique<CameraQt6QVideoSink::CameraBackend>()
+        );
+        m_backends.emplace_back(
+            "qt6-qvideowidget", "Qt6: GPU Offloaded (QOpenGLWidget)",
+            std::make_unique<CameraQt6QVideoWidget::CameraBackend>()
+        );
+        m_backends.emplace_back(
+            "qt6-qml", "Qt6: GPU Offloaded (QML QQuickWidget)",
+            std::make_unique<CameraQt6QML::CameraBackend>()
         );
 #endif
 #if QT_VERSION_MAJOR == 6 && QT_VERSION_MINOR >= 5

--- a/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraImplementations.cpp
+++ b/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraImplementations.cpp
@@ -24,6 +24,7 @@
 
 #if defined(__linux__) || defined(__APPLE__)
 #include "CameraWidgetOpenCV.h"
+#include "CameraWidgetOpenCV_QOpenGLWidget.h"
 #endif
 
 
@@ -58,6 +59,10 @@ struct CameraBackends{
         m_backends.emplace_back(
             "opencv-v4l2", "Linux: OpenCV V4L2",
             std::make_unique<CameraOpenCV::CameraBackend>()
+        );
+        m_backends.emplace_back(
+            "opencv-v4l2-gl", "Linux: OpenCV V4L2 (GPU Offloaded)",
+            std::make_unique<CameraOpenCV_QOpenGLWidget::CameraBackend>()
         );
 #endif
 #if QT_VERSION_MAJOR == 6

--- a/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraImplementations.h
+++ b/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraImplementations.h
@@ -23,7 +23,7 @@ public:
 
 // Abstract base class for camera backend implementation.
 // Call `get_camera_backend()` to get the camera backend singleton.
-// Current camera backend is implemented in CameraWidgetQt6.h/cpp.
+// Qt6 camera backends are implemented in CameraWidgetQt6*.h/cpp.
 class CameraBackend{
 public:
     virtual ~CameraBackend() = default;
@@ -47,7 +47,7 @@ public:
 
 
 // Get the camera backend singleton.
-// Current camera backend is implemented in CameraWidgetQt6.h/cpp.
+// Qt6 camera backends are implemented in CameraWidgetQt6*.h/cpp.
 const CameraBackend& get_camera_backend();
 
 // Call `get_camera_backend()` to get camera backend reference and get all cameras' info.

--- a/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraWidgetOpenCV.cpp
+++ b/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraWidgetOpenCV.cpp
@@ -1,0 +1,192 @@
+/*  Camera Widget (OpenCV V4L2)
+ *
+ *  From: https://github.com/PokemonAutomation/
+ *
+ */
+
+#include <QtGlobal>
+#if defined(__linux__) || defined(__APPLE__)
+
+#include <QPainter>
+#include <QMediaDevices>
+#include <QVideoFrameFormat>
+#include <opencv2/opencv.hpp>
+#include "Common/Qt/Redispatch.h"
+#include "CommonFramework/Logging/Logger.h"
+#include "VideoFrameQt.h"
+#include "MediaServicesQt6.h"
+#include "CameraWidgetOpenCV.h"
+
+namespace PokemonAutomation{
+namespace CameraOpenCV{
+
+std::vector<CameraInfo> CameraBackend::get_all_cameras() const{
+    const auto cameras = GlobalMediaServices::instance().get_all_cameras();
+    std::vector<CameraInfo> ret;
+    for (const auto& info : cameras){
+        ret.emplace_back(info.id().toStdString());
+    }
+    return ret;
+}
+
+std::string CameraBackend::get_camera_name(const CameraInfo& info) const{
+    const auto cameras = GlobalMediaServices::instance().get_all_cameras();
+    for (const auto& camera : cameras){
+        if (camera.id().toStdString() == info.device_name()){
+            return camera.description().toStdString();
+        }
+    }
+    return "";
+}
+
+std::unique_ptr<VideoSource> CameraBackend::make_video_source(
+    Logger& logger,
+    const CameraInfo& info,
+    Resolution resolution,
+    VideoFormat format,
+    FramesPerSecond fps
+) const{
+    return std::make_unique<CameraVideoSource>(logger, info, resolution, format, fps);
+}
+
+
+CameraVideoSource::~CameraVideoSource(){
+    m_stop.store(true, std::memory_order_release);
+    if (m_thread.joinable()){
+        m_thread.join();
+    }
+}
+
+CameraVideoSource::CameraVideoSource(
+    Logger& logger,
+    const CameraInfo& info,
+    Resolution desired_resolution,
+    VideoFormat desired_format,
+    FramesPerSecond desired_fps
+)
+    : VideoSource(logger, true)
+    , m_logger(logger)
+    , m_stop(false)
+    , m_last_frame(logger)
+    , m_snapshot_manager(logger, m_last_frame)
+{
+    if (!info){
+        return;
+    }
+    m_logger.log("Starting Camera: Backend = OpenCV V4L2");
+
+    // Populate fake format set so UI has some options if we don't query it.
+    // In a real implementation we would probe, but here we just pass the desired through
+    m_formats[{1920, 1080}][VideoFormat::MJPEG] = {60, 30};
+    m_formats[{1280, 720}][VideoFormat::MJPEG] = {60, 30};
+    m_formats[{1920, 1080}][VideoFormat::YUYV] = {10, 5};
+    m_formats[{desired_resolution.width, desired_resolution.height}][desired_format] = {desired_fps};
+
+    m_resolution = desired_resolution;
+    m_format = desired_format;
+    m_fps = desired_fps;
+
+    std::string device_path = info.device_name();
+#if defined(__linux__)
+    int device_index = 0;
+    if (device_path.find("/dev/video") == 0) {
+        try {
+            device_index = std::stoi(device_path.substr(10));
+        } catch (...) {}
+    }
+    m_cap = std::make_unique<cv::VideoCapture>(device_index, cv::CAP_V4L2);
+#else
+    m_cap = std::make_unique<cv::VideoCapture>(device_path);
+#endif
+
+    if (!m_cap->isOpened()){
+        m_logger.log("Camera failed to open via OpenCV.", COLOR_RED);
+        return;
+    }
+
+    if (desired_format == VideoFormat::MJPEG){
+        m_cap->set(cv::CAP_PROP_FOURCC, cv::VideoWriter::fourcc('M', 'J', 'P', 'G'));
+    } else if (desired_format == VideoFormat::YUYV){
+        m_cap->set(cv::CAP_PROP_FOURCC, cv::VideoWriter::fourcc('Y', 'U', 'Y', 'V'));
+    }
+
+    m_cap->set(cv::CAP_PROP_FRAME_WIDTH, desired_resolution.width);
+    m_cap->set(cv::CAP_PROP_FRAME_HEIGHT, desired_resolution.height);
+    if (desired_fps > 0) {
+        m_cap->set(cv::CAP_PROP_FPS, desired_fps);
+    }
+
+    m_logger.log("Resolution: " + m_resolution.to_string() + ", FPS: " + std::to_string(m_fps));
+
+    m_thread = std::thread(&CameraVideoSource::thread_body, this);
+}
+
+void CameraVideoSource::thread_body(){
+    cv::Mat bgr, bgra;
+    while (!m_stop.load(std::memory_order_acquire)){
+        if (!m_cap->read(bgr)){
+            continue; // Could sleep or break on disconnect
+        }
+
+        WallClock now = current_time();
+
+        cv::cvtColor(bgr, bgra, cv::COLOR_BGR2BGRA);
+
+        QVideoFrameFormat format(QSize(bgra.cols, bgra.rows), QVideoFrameFormat::Format_BGRA8888);
+        QVideoFrame frame(format);
+
+        if (frame.map(QVideoFrame::WriteOnly)){
+            memcpy(frame.bits(0), bgra.data, bgra.total() * bgra.elemSize());
+            frame.unmap();
+            
+            if (!m_last_frame.push_frame(frame, now)){
+                continue;
+            }
+            report_source_frame(std::make_shared<VideoFrame>(now, frame));
+        }
+    }
+}
+
+QWidget* CameraVideoSource::make_display_QtWidget(QWidget* parent){
+    return new CameraVideoDisplay(parent, *this);
+}
+
+CameraVideoDisplay::~CameraVideoDisplay(){
+    m_source.remove_source_frame_listener(*this);
+}
+CameraVideoDisplay::CameraVideoDisplay(QWidget* parent, CameraVideoSource& source)
+    : QWidget(parent)
+    , m_source(source)
+{
+    source.add_source_frame_listener(*this);
+}
+void CameraVideoDisplay::on_frame(std::shared_ptr<const VideoFrame> frame){
+    m_last_frame = std::move(frame);
+    queue_on_main_thread([this]{
+        this->update();
+    });
+}
+void CameraVideoDisplay::paintEvent(QPaintEvent* event){
+    QWidget::paintEvent(event);
+
+    if (!m_last_frame){
+        return;
+    }
+
+    QVideoFrame frame = m_last_frame->frame;
+    if (!frame.isValid()){
+        return;
+    }
+
+    QRect rect(0, 0, this->width(), this->height());
+    QVideoFrame::PaintOptions options;
+    QPainter painter(this);
+
+    frame.paint(&painter, rect, options);
+    m_source.report_rendered_frame(current_time());
+}
+
+
+}
+}
+#endif

--- a/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraWidgetOpenCV.h
+++ b/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraWidgetOpenCV.h
@@ -1,0 +1,119 @@
+/*  Camera Widget (OpenCV V4L2)
+ *
+ *  From: https://github.com/PokemonAutomation/
+ *
+ */
+
+#ifndef PokemonAutomation_VideoPipeline_OpenCV_H
+#define PokemonAutomation_VideoPipeline_OpenCV_H
+
+#include <QtGlobal>
+#if defined(__linux__) || defined(__APPLE__)
+
+#include <QWidget>
+#include <thread>
+#include <atomic>
+#include "Common/Cpp/Concurrency/Mutex.h"
+#include "CommonFramework/VideoPipeline/VideoSource.h"
+#include "CommonFramework/VideoPipeline/CameraInfo.h"
+#include "CameraImplementations.h"
+#include "QVideoFrameCache.h"
+#include "SnapshotManager.h"
+
+// Forward declaration for OpenCV
+namespace cv {
+    class VideoCapture;
+    class Mat;
+}
+
+namespace PokemonAutomation{
+namespace CameraOpenCV{
+
+class CameraBackend : public PokemonAutomation::CameraBackend{
+public:
+    virtual std::vector<CameraInfo> get_all_cameras() const override;
+    virtual std::string get_camera_name(const CameraInfo& info) const override;
+
+    virtual std::unique_ptr<VideoSource> make_video_source(
+        Logger& logger,
+        const CameraInfo& info,
+        Resolution resolution,
+        VideoFormat format,
+        FramesPerSecond fps
+    ) const override;
+};
+
+class CameraVideoSource : public VideoSource{
+public:
+    virtual ~CameraVideoSource();
+    CameraVideoSource(
+        Logger& logger,
+        const CameraInfo& info,
+        Resolution desired_resolution,
+        VideoFormat desired_format,
+        FramesPerSecond desired_fps
+    );
+
+    virtual Resolution current_resolution() const override{
+        return m_resolution;
+    }
+    virtual VideoFormat current_format() const override{
+        return m_format;
+    }
+    virtual FramesPerSecond current_fps() const override{
+        return m_fps;
+    }
+    virtual const VideoFormatSet& supported_formats() const override{
+        return m_formats;
+    }
+
+    virtual VideoSnapshot snapshot_latest_blocking() override{
+        return m_snapshot_manager.snapshot_latest_blocking();
+    }
+    virtual VideoSnapshot snapshot_recent_nonblocking(WallClock min_time) override{
+        return m_snapshot_manager.snapshot_recent_nonblocking(min_time);
+    }
+
+    virtual QWidget* make_display_QtWidget(QWidget* parent) override;
+
+private:
+    void thread_body();
+
+private:
+    friend class CameraVideoDisplay;
+
+    Logger& m_logger;
+    Resolution m_resolution;
+    VideoFormat m_format;
+    FramesPerSecond m_fps;
+
+    VideoFormatSet m_formats;
+
+    std::unique_ptr<cv::VideoCapture> m_cap;
+    std::thread m_thread;
+    std::atomic<bool> m_stop;
+
+    QVideoFrameCache m_last_frame;
+    SnapshotManager m_snapshot_manager;
+};
+
+class CameraVideoDisplay : public QWidget, private VideoFrameListener{
+public:
+    ~CameraVideoDisplay();
+    CameraVideoDisplay(QWidget* parent, CameraVideoSource& source);
+
+private:
+    virtual void on_frame(std::shared_ptr<const VideoFrame> frame) override;
+    virtual void paintEvent(QPaintEvent* event) override;
+
+private:
+    CameraVideoSource& m_source;
+    std::shared_ptr<const VideoFrame> m_last_frame;
+
+    LifetimeSanitizer m_sanitizer;
+};
+
+}
+}
+#endif
+#endif

--- a/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraWidgetOpenCV_QOpenGLWidget.cpp
+++ b/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraWidgetOpenCV_QOpenGLWidget.cpp
@@ -8,6 +8,8 @@
 #if defined(__linux__) || defined(__APPLE__)
 
 #include <QPainter>
+#include <QVideoSink>
+#include <QResizeEvent>
 #include <QMediaDevices>
 #include <QVideoFrameFormat>
 #include <opencv2/opencv.hpp>
@@ -21,10 +23,10 @@
 #include "CommonFramework/Logging/Logger.h"
 #include "VideoFrameQt.h"
 #include "MediaServicesQt6.h"
-#include "CameraWidgetOpenCV.h"
+#include "CameraWidgetOpenCV_QOpenGLWidget.h"
 
 namespace PokemonAutomation{
-namespace CameraOpenCV{
+namespace CameraOpenCV_QOpenGLWidget{
 
 std::vector<CameraInfo> CameraBackend::get_all_cameras() const{
     const auto cameras = GlobalMediaServices::instance().get_all_cameras();
@@ -261,19 +263,45 @@ CameraVideoDisplay::~CameraVideoDisplay(){
     m_source.remove_source_frame_listener(*this);
 }
 CameraVideoDisplay::CameraVideoDisplay(QWidget* parent, CameraVideoSource& source)
-    : QWidget(parent)
+    : QOpenGLWidget(parent)
     , m_source(source)
+    , m_width(80)
+    , m_height(45)
+    , m_sanitizer("CameraVideoDisplay")
 {
+    this->setMinimumSize(80, 45);
     source.add_source_frame_listener(*this);
 }
-void CameraVideoDisplay::on_frame(std::shared_ptr<const VideoFrame> frame){
-    m_last_frame = std::move(frame);
-    queue_on_main_thread([this]{
-        this->update();
-    });
+void CameraVideoDisplay::resizeEvent(QResizeEvent* event){
+    QOpenGLWidget::resizeEvent(event);
+    m_width.store(event->size().width(), std::memory_order_relaxed);
+    m_height.store(event->size().height(), std::memory_order_relaxed);
 }
+
+void CameraVideoDisplay::on_frame(std::shared_ptr<const VideoFrame> frame){
+    int w = m_width.load(std::memory_order_relaxed);
+    int h = m_height.load(std::memory_order_relaxed);
+    
+    std::shared_ptr<const VideoFrame> scaled_frame = frame;
+    
+    if (w > 0 && h > 0 && frame && frame->frame.isValid()){
+        QSize target_size(w, h);
+        if (frame->frame.size() != target_size){
+            QImage img = frame->frame.toImage();
+            QImage scaled = img.scaled(target_size, Qt::IgnoreAspectRatio, Qt::FastTransformation);
+            QVideoFrame out(scaled);
+            scaled_frame = std::make_shared<VideoFrame>(frame->timestamp, out);
+        }
+    }
+
+    QMetaObject::invokeMethod(this, [this, frame = std::move(scaled_frame)]() mutable {
+        m_last_frame = std::move(frame);
+        this->update();
+    }, Qt::QueuedConnection);
+}
+
 void CameraVideoDisplay::paintEvent(QPaintEvent* event){
-    QWidget::paintEvent(event);
+    QOpenGLWidget::paintEvent(event);
 
     if (!m_last_frame){
         return;

--- a/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraWidgetOpenCV_QOpenGLWidget.h
+++ b/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraWidgetOpenCV_QOpenGLWidget.h
@@ -4,13 +4,14 @@
  *
  */
 
-#ifndef PokemonAutomation_VideoPipeline_OpenCV_H
-#define PokemonAutomation_VideoPipeline_OpenCV_H
+#ifndef PokemonAutomation_CameraWidgetOpenCV_QOpenGLWidget_H
+#define PokemonAutomation_CameraWidgetOpenCV_QOpenGLWidget_H
 
 #include <QtGlobal>
 #if defined(__linux__) || defined(__APPLE__)
 
 #include <QWidget>
+#include <QOpenGLWidget>
 #include <thread>
 #include <atomic>
 #include "Common/Cpp/Concurrency/Mutex.h"
@@ -27,7 +28,7 @@ namespace cv {
 }
 
 namespace PokemonAutomation{
-namespace CameraOpenCV{
+namespace CameraOpenCV_QOpenGLWidget{
 
 class CameraBackend : public PokemonAutomation::CameraBackend{
 public:
@@ -99,18 +100,24 @@ private:
     SnapshotManager m_snapshot_manager;
 };
 
-class CameraVideoDisplay : public QWidget, private VideoFrameListener{
+class CameraVideoDisplay : public QOpenGLWidget, private VideoFrameListener{
 public:
     ~CameraVideoDisplay();
     CameraVideoDisplay(QWidget* parent, CameraVideoSource& source);
 
 private:
     virtual void on_frame(std::shared_ptr<const VideoFrame> frame) override;
+
+protected:
+    virtual void resizeEvent(QResizeEvent* event) override;
     virtual void paintEvent(QPaintEvent* event) override;
 
 private:
     CameraVideoSource& m_source;
     std::shared_ptr<const VideoFrame> m_last_frame;
+
+    std::atomic<int> m_width;
+    std::atomic<int> m_height;
 
     LifetimeSanitizer m_sanitizer;
 };

--- a/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6.5.cpp
+++ b/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6.5.cpp
@@ -1,4 +1,4 @@
-﻿/*  Camera Widget (Qt6.5)
+/*  Camera Widget (Qt6.5)
  *
  *  From: https://github.com/PokemonAutomation/
  *
@@ -7,163 +7,135 @@
 #include <QtGlobal>
 #if QT_VERSION_MAJOR == 6 && QT_VERSION_MINOR >= 5
 
-//#include <chrono>
+// #include <chrono>
 #include <QCamera>
-#include <QPainter>
+#include <QImageCapture>
 #include <QMediaDevices>
+#include <QOpenGLWidget>
+#include <QPainter>
 #include <QVBoxLayout>
 #include <QVideoSink>
-#include <QImageCapture>
-//#include "Common/Cpp/Exceptions.h"
-//#include "Common/Cpp/Time.h"
-//#include "Common/Cpp/PrettyPrint.h"
+// #include "Common/Cpp/Exceptions.h"
+// #include "Common/Cpp/Time.h"
+// #include "Common/Cpp/PrettyPrint.h"
+#include "CameraWidgetQt6.5.h"
+#include "CameraWidgetQt6.h"
 #include "Common/Qt/Redispatch.h"
 #include "CommonFramework/Logging/Logger.h"
-#include "VideoFrameQt.h"
 #include "MediaServicesQt6.h"
-#include "CameraWidgetQt6.h"
-#include "CameraWidgetQt6.5.h"
+#include "VideoFrameQt.h"
 
-//#include <iostream>
-//using std::cout;
-//using std::endl;
+// #include <iostream>
+// using std::cout;
+// using std::endl;
 
-namespace PokemonAutomation{
-namespace CameraQt65QMediaCaptureSession{
+namespace PokemonAutomation {
+namespace CameraQt65QMediaCaptureSession {
 
-
-
-
-
-
-std::vector<CameraInfo> CameraBackend::get_all_cameras() const{
+std::vector<CameraInfo> CameraBackend::get_all_cameras() const {
 #if 1
-    const auto cameras = GlobalMediaServices::instance().get_all_cameras();
+  const auto cameras = GlobalMediaServices::instance().get_all_cameras();
 #else
-    const auto cameras = QMediaDevices::videoInputs();
+  const auto cameras = QMediaDevices::videoInputs();
 #endif
-    std::vector<CameraInfo> ret;
-    for (const auto& info : cameras){
-        ret.emplace_back(info.id().toStdString());
-    }
-    return ret;
+  std::vector<CameraInfo> ret;
+  for (const auto &info : cameras) {
+    ret.emplace_back(info.id().toStdString());
+  }
+  return ret;
 }
-std::string CameraBackend::get_camera_name(const CameraInfo& info) const{
+std::string CameraBackend::get_camera_name(const CameraInfo &info) const {
 #if 1
-    const auto cameras = GlobalMediaServices::instance().get_all_cameras();
+  const auto cameras = GlobalMediaServices::instance().get_all_cameras();
 #else
-    const auto cameras = QMediaDevices::videoInputs();
+  const auto cameras = QMediaDevices::videoInputs();
 #endif
-    for (const auto& camera : cameras){
-        if (camera.id().toStdString() == info.device_name()){
-            return camera.description().toStdString();
-        }
+  for (const auto &camera : cameras) {
+    if (camera.id().toStdString() == info.device_name()) {
+      return camera.description().toStdString();
     }
-    global_logger_tagged().log(
-        "Error: No such camera for CameraInfo: " + info.device_name(),
-        COLOR_RED
-    );
-    return "";
+  }
+  global_logger_tagged().log(
+      "Error: No such camera for CameraInfo: " + info.device_name(), COLOR_RED);
+  return "";
 }
-std::unique_ptr<VideoSource> CameraBackend::make_video_source(
-    Logger& logger,
-    const CameraInfo& info,
-    Resolution resolution,
-    VideoFormat format,
-    FramesPerSecond fps
-) const{
-    return std::make_unique<CameraVideoSource>(logger, info, resolution, format, fps);
+std::unique_ptr<VideoSource>
+CameraBackend::make_video_source(Logger &logger, const CameraInfo &info,
+                                 Resolution resolution, VideoFormat format,
+                                 FramesPerSecond fps) const {
+  return std::make_unique<CameraVideoSource>(logger, info, resolution, format,
+                                             fps);
 }
 
+CameraVideoSource::~CameraVideoSource() {
+  if (!m_capture_session) {
+    return;
+  }
+  try {
+    m_logger.log("Stopping Camera...");
+  } catch (...) {
+  }
 
-
-
-
-
-
-CameraVideoSource::~CameraVideoSource(){
-    if (!m_capture_session){
-        return;
-    }
-    try{
-        m_logger.log("Stopping Camera...");
-    }catch (...){}
-
-    run_on_main_thread_and_wait([&]{
-//        m_camera->stop();
-        m_capture_session.reset();
-        m_camera.reset();
-    });
+  run_on_main_thread_and_wait([&] {
+    //        m_camera->stop();
+    m_capture_session.reset();
+    m_camera.reset();
+  });
 }
-CameraVideoSource::CameraVideoSource(
-    Logger& logger,
-    const CameraInfo& info,
-    Resolution desired_resolution,
-    VideoFormat desired_format,
-    FramesPerSecond desired_fps
-)
-    : VideoSource(logger, true)
-    , m_logger(logger)
-    , m_last_frame(logger)
-    , m_snapshot_manager(logger, m_last_frame)
-{
-//    cout << "desired_resolution = " << desired_resolution.width << " x " << desired_resolution.height << endl;
-//    cout << "desired_fps = " << desired_fps << endl;
+CameraVideoSource::CameraVideoSource(Logger &logger, const CameraInfo &info,
+                                     Resolution desired_resolution,
+                                     VideoFormat desired_format,
+                                     FramesPerSecond desired_fps)
+    : VideoSource(logger, true), m_logger(logger), m_last_frame(logger),
+      m_snapshot_manager(logger, m_last_frame) {
+  //    cout << "desired_resolution = " << desired_resolution.width << " x " <<
+  //    desired_resolution.height << endl; cout << "desired_fps = " <<
+  //    desired_fps << endl;
 
-    if (!info){
-        return;
-    }
-    m_logger.log("Starting Camera: Backend = CameraQt65QMediaCaptureSession");
+  if (!info) {
+    return;
+  }
+  m_logger.log("Starting Camera: Backend = CameraQt65QMediaCaptureSession");
 
-    run_on_main_thread_and_wait([&]{
-        init(info, desired_resolution, desired_format, desired_fps);
-    });
+  run_on_main_thread_and_wait(
+      [&] { init(info, desired_resolution, desired_format, desired_fps); });
 }
-void CameraVideoSource::init(
-    const CameraInfo& info,
-    Resolution desired_resolution,
-    VideoFormat desired_format,
-    FramesPerSecond desired_fps
-){
-    m_metaobject.reset(new QObject());
+void CameraVideoSource::init(const CameraInfo &info,
+                             Resolution desired_resolution,
+                             VideoFormat desired_format,
+                             FramesPerSecond desired_fps) {
+  m_metaobject.reset(new QObject());
 
-    auto cameras = QMediaDevices::videoInputs();
-    const QCameraDevice* device = nullptr;
-    for (const auto& camera : cameras){
-        if (camera.id().toStdString() == info.device_name()){
-            device = &camera;
-            break;
-        }
+  auto cameras = QMediaDevices::videoInputs();
+  const QCameraDevice *device = nullptr;
+  for (const auto &camera : cameras) {
+    if (camera.id().toStdString() == info.device_name()) {
+      device = &camera;
+      break;
     }
-    if (device == nullptr){
-        m_logger.log("Camera not found: " + info.device_name(), COLOR_RED);
-        return;
-    }
-    m_logger.log("Camera: " + device->description().toStdString());
+  }
+  if (device == nullptr) {
+    m_logger.log("Camera not found: " + info.device_name(), COLOR_RED);
+    return;
+  }
+  m_logger.log("Camera: " + device->description().toStdString());
 
-    QCameraFormat format = CameraQt6QVideoSink::build_format_set(
-        m_logger,
-        m_formats,
-        *device,
-        desired_resolution,
-        desired_format,
-        desired_fps
-    );
-    if (format.isNull()){
-        return;
-    }
+  QCameraFormat format = CameraQt6QVideoSink::build_format_set(
+      m_logger, m_formats, *device, desired_resolution, desired_format,
+      desired_fps);
+  if (format.isNull()) {
+    return;
+  }
 
-    CameraQt6QVideoSink::get_format(format, m_resolution, m_format, m_fps);
-    m_logger.log(
-        "Resolution: " + m_resolution.to_string() +
-        ", Format: " + VideoFormat_database().find(m_format)->display +
-        ", FPS: " + std::to_string(m_fps)
-    );
+  CameraQt6QVideoSink::get_format(format, m_resolution, m_format, m_fps);
+  m_logger.log("Resolution: " + m_resolution.to_string() +
+               ", Format: " + VideoFormat_database().find(m_format)->display +
+               ", FPS: " + std::to_string(m_fps));
 
-    m_camera.reset(new QCameraThread(m_logger, *device, format));
+  m_camera.reset(new QCameraThread(m_logger, *device, format));
 
-    m_capture_session.reset(new QMediaCaptureSession());
-    m_capture_session->setCamera(&m_camera->camera());
+  m_capture_session.reset(new QMediaCaptureSession());
+  m_capture_session->setCamera(&m_camera->camera());
 
 #if 0
     connect(m_camera.get(), &QCamera::errorOccurred, this, [&](){
@@ -177,89 +149,60 @@ void CameraVideoSource::init(
 #endif
 }
 
+void CameraVideoSource::set_video_output(QGraphicsVideoItem &item) {
+  if (m_capture_session == nullptr) {
+    return;
+  }
+  if (m_capture_session->videoSink() == item.videoSink()) {
+    return;
+  }
+  m_capture_session->setVideoOutput(&item);
 
-void CameraVideoSource::set_video_output(QGraphicsVideoItem& item){
-    if (m_capture_session == nullptr){
-        return;
-    }
-    if (m_capture_session->videoSink() == item.videoSink()){
-        return;
-    }
-    m_capture_session->setVideoOutput(&item);
+  m_metaobject->connect(item.videoSink(), &QVideoSink::videoFrameChanged,
+                        &m_camera->camera(), [&](const QVideoFrame &frame) {
+                          //  This runs on the QCamera's thread. So it is off
+                          //  the critical path.
 
-    m_metaobject->connect(
-        item.videoSink(), &QVideoSink::videoFrameChanged,
-        &m_camera->camera(), [&](const QVideoFrame& frame){
-            //  This runs on the QCamera's thread. So it is off the critical path.
-
-            WallClock now = current_time();
-            if (!m_last_frame.push_frame(frame, now)){
-                return;
-            }
-            report_source_frame(std::make_shared<VideoFrame>(now, frame));
-        }
-    );
+                          WallClock now = current_time();
+                          if (!m_last_frame.push_frame(frame, now)) {
+                            return;
+                          }
+                          report_source_frame(
+                              std::make_shared<VideoFrame>(now, frame));
+                        });
 }
 
-
-
-
-
-
-QWidget* CameraVideoSource::make_display_QtWidget(QWidget* parent){
-    return new CameraVideoDisplay(parent, *this);
+QWidget *CameraVideoSource::make_display_QtWidget(QWidget *parent) {
+  return new CameraVideoDisplay(parent, *this);
 }
 
+CameraVideoDisplay::CameraVideoDisplay(QWidget *parent,
+                                       CameraVideoSource &source)
+    : QWidget(parent), m_source(source), m_view(new StaticQGraphicsView(this)),
+      m_sanitizer("CameraVideoDisplay") {
+  this->setMinimumSize(80, 45);
 
+  // m_view->setViewport(new QOpenGLWidget());
 
+  m_view->setFixedSize(this->size());
+  m_view->setScene(&m_scene);
+  m_video.setSize(this->size());
+  m_scene.setSceneRect(QRectF(QPointF(0, 0), this->size()));
+  m_scene.addItem(&m_video);
+  source.set_video_output(m_video);
 
-
-
-
-
-CameraVideoDisplay::CameraVideoDisplay(QWidget* parent, CameraVideoSource& source)
-    : QWidget(parent)
-    , m_source(source)
-    , m_view(new StaticQGraphicsView(this))
-    , m_sanitizer("CameraVideoDisplay")
-{
-    this->setMinimumSize(80, 45);
-    m_view->setFixedSize(this->size());
-    m_view->setScene(&m_scene);
-    m_video.setSize(this->size());
-    m_scene.setSceneRect(QRectF(QPointF(0, 0), this->size()));
-    m_scene.addItem(&m_video);
-    source.set_video_output(m_video);
-
-    connect(
-        &m_scene, &QGraphicsScene::changed,
-        this, [&](const QList<QRectF>&){
-            auto scope_check = m_sanitizer.check_scope();
-            m_source.report_rendered_frame(current_time());
-        }
-    );
-}
-void CameraVideoDisplay::resizeEvent(QResizeEvent* event){
+  connect(&m_scene, &QGraphicsScene::changed, this, [&](const QList<QRectF> &) {
     auto scope_check = m_sanitizer.check_scope();
-    m_view->setFixedSize(this->size());
-    m_scene.setSceneRect(QRectF(QPointF(0, 0), this->size()));
-    m_video.setSize(this->size());
+    m_source.report_rendered_frame(current_time());
+  });
+}
+void CameraVideoDisplay::resizeEvent(QResizeEvent *event) {
+  auto scope_check = m_sanitizer.check_scope();
+  m_view->setFixedSize(this->size());
+  m_scene.setSceneRect(QRectF(QPointF(0, 0), this->size()));
+  m_video.setSize(this->size());
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-}
-}
+} // namespace CameraQt65QMediaCaptureSession
+} // namespace PokemonAutomation
 #endif

--- a/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6_QML.cpp
+++ b/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6_QML.cpp
@@ -1,0 +1,222 @@
+#include <QtGlobal>
+#if QT_VERSION_MAJOR == 6
+
+#include <QCamera>
+#include <QVideoSink>
+#include <QQuickItem>
+#include <QQmlEngine>
+#include <QTemporaryFile>
+#include "Common/Qt/Redispatch.h"
+#include "CommonFramework/Logging/Logger.h"
+#include "CameraWidgetQt6.h"
+#include "CameraWidgetQt6_QML.h"
+#include "MediaServicesQt6.h"
+#include "VideoFrameQt.h"
+
+namespace PokemonAutomation{
+namespace CameraQt6QML{
+
+std::vector<CameraInfo> CameraBackend::get_all_cameras() const{
+#if 1
+    const auto cameras = GlobalMediaServices::instance().get_all_cameras();
+#else
+    const auto cameras = QMediaDevices::videoInputs();
+#endif
+    std::vector<CameraInfo> ret;
+    for (const auto& info : cameras){
+        ret.emplace_back(info.id().toStdString());
+    }
+    return ret;
+}
+std::string CameraBackend::get_camera_name(const CameraInfo& info) const{
+#if 1
+    const auto cameras = GlobalMediaServices::instance().get_all_cameras();
+#else
+    const auto cameras = QMediaDevices::videoInputs();
+#endif
+    for (const auto& camera : cameras){
+        if (camera.id().toStdString() == info.device_name()){
+            return camera.description().toStdString();
+        }
+    }
+    global_logger_tagged().log("Error: No such camera for CameraInfo: " + info.device_name(), COLOR_RED);
+    return "";
+}
+
+std::unique_ptr<VideoSource> CameraBackend::make_video_source(
+    Logger& logger,
+    const CameraInfo& info,
+    Resolution resolution,
+    VideoFormat format,
+    FramesPerSecond fps
+) const{
+    return std::make_unique<CameraVideoSource>(logger, info, resolution, format, fps);
+}
+
+
+CameraVideoSource::~CameraVideoSource(){
+    if (!m_capture){
+        return;
+    }
+    try{
+        m_logger.log("Stopping Camera...");
+    }catch (...){}
+
+    run_on_main_thread_and_wait([&]{
+        m_metaobject.reset();
+        m_capture.reset();
+        m_camera.reset();
+    });
+}
+CameraVideoSource::CameraVideoSource(
+    Logger& logger,
+    const CameraInfo& info,
+    Resolution desired_resolution,
+    VideoFormat desired_format,
+    FramesPerSecond desired_fps
+)
+    : VideoSource(logger, true)
+    , m_logger(logger)
+    , m_last_frame(logger)
+    , m_snapshot_manager(logger, m_last_frame)
+{
+    if (!info){
+        return;
+    }
+    m_logger.log("Starting Camera: Backend = CameraQt6QML");
+
+    run_on_main_thread_and_wait([&]{
+        init(info, desired_resolution, desired_format, desired_fps);
+    });
+}
+void CameraVideoSource::init(
+    const CameraInfo& info,
+    Resolution desired_resolution,
+    VideoFormat desired_format,
+    FramesPerSecond desired_fps
+){
+    m_metaobject.reset(new QObject());
+
+    auto cameras = QMediaDevices::videoInputs();
+    const QCameraDevice* device = nullptr;
+    for (const auto& camera : cameras){
+        if (camera.id().toStdString() == info.device_name()){
+            device = &camera;
+            break;
+        }
+    }
+    if (device == nullptr){
+        m_logger.log("Camera not found: " + info.device_name(), COLOR_RED);
+        return;
+    }
+    m_logger.log("Camera: " + device->description().toStdString());
+
+    QCameraFormat format = CameraQt6QVideoSink::build_format_set(
+        m_logger,
+        m_formats,
+        *device,
+        desired_resolution,
+        desired_format,
+        desired_fps
+    );
+    if (format.isNull()){
+        return;
+    }
+
+    CameraQt6QVideoSink::get_format(format, m_resolution, m_format, m_fps);
+    m_logger.log(
+        "Resolution: " + m_resolution.to_string() +
+        ", Format: " + VideoFormat_database().find(m_format)->display +
+        ", FPS: " + std::to_string(m_fps)
+    );
+
+    m_camera.reset(new QCameraThread(m_logger, *device, format));
+    m_video_sink.reset(new QVideoSink());
+    m_capture.reset(new QMediaCaptureSession());
+    m_capture->setCamera(&m_camera->camera());
+    m_capture->setVideoSink(m_video_sink.get());
+
+    // Auto-recovery: If the capture card glitches and the pipeline breaks, try to automatically restart it.
+    m_metaobject->connect(&m_camera->camera(), &QCamera::errorOccurred, 
+                          &m_camera->camera(), [this](QCamera::Error, const QString& errorString){
+        m_logger.log("Camera error detected: " + errorString.toStdString() + ". Attempting auto-restart...", COLOR_RED);
+        QMetaObject::invokeMethod(&m_camera->camera(), "start", Qt::QueuedConnection);
+    });
+}
+
+QWidget* CameraVideoSource::make_display_QtWidget(QWidget* parent){
+    CameraVideoDisplay* display = new CameraVideoDisplay(parent, *this);
+    
+    QObject* root = display->rootObject();
+    if (root){
+        QObject* vo = root->findChild<QObject*>("videoOutput");
+        if (vo){
+            QVideoSink* qml_sink = vo->property("videoSink").value<QVideoSink*>();
+            if (qml_sink){
+                m_metaobject->disconnect();
+                m_metaobject->connect(
+                    m_video_sink.get(), &QVideoSink::videoFrameChanged,
+                    qml_sink, [this, qml_sink](const QVideoFrame& frame){
+                        WallClock now = current_time();
+                        if (!m_last_frame.push_frame(frame, now)){
+                            return;
+                        }
+                        
+                        report_source_frame(std::make_shared<VideoFrame>(now, frame));
+                        
+                        QMetaObject::invokeMethod(qml_sink, [qml_sink, frame]() {
+                            qml_sink->setVideoFrame(frame);
+                        }, Qt::QueuedConnection);
+                        
+                        report_rendered_frame(now);
+                    }
+                );
+            }
+        }
+    }
+    
+    return display;
+}
+
+CameraVideoDisplay::~CameraVideoDisplay(){
+    m_source.remove_source_frame_listener(*this);
+}
+CameraVideoDisplay::CameraVideoDisplay(QWidget* parent, CameraVideoSource& source)
+    : QQuickWidget(parent)
+    , m_source(source)
+    , m_sanitizer("CameraVideoDisplay")
+{
+    this->setMinimumSize(80, 45);
+    this->setResizeMode(QQuickWidget::SizeRootObjectToView);
+    
+    QString qml = QStringLiteral(
+        "import QtQuick\n"
+        "import QtMultimedia\n"
+        "Rectangle {\n"
+        "    color: \"black\"\n"
+        "    VideoOutput {\n"
+        "        id: videoOutput\n"
+        "        anchors.fill: parent\n"
+        "        objectName: \"videoOutput\"\n"
+        "        fillMode: VideoOutput.PreserveAspectFit\n"
+        "    }\n"
+        "}\n"
+    );
+    
+    QTemporaryFile file;
+    if (file.open()){
+        file.write(qml.toUtf8());
+        file.close();
+        this->setSource(QUrl::fromLocalFile(file.fileName()));
+    }
+    
+    source.add_source_frame_listener(*this);
+}
+
+void CameraVideoDisplay::on_frame(std::shared_ptr<const VideoFrame> frame){
+    // Not needed, QML handles the rendering directly via SceneGraph
+}
+
+}
+}
+#endif

--- a/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6_QML.h
+++ b/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6_QML.h
@@ -1,0 +1,108 @@
+#ifndef PokemonAutomation_VideoPipeline_Qt6QML_H
+#define PokemonAutomation_VideoPipeline_Qt6QML_H
+
+#include <QtGlobal>
+#if QT_VERSION_MAJOR == 6
+
+#include <QCameraDevice>
+#include <QMediaCaptureSession>
+#include <QVideoFrame>
+#include <QQuickWidget>
+#include "CommonFramework/Tools/StatAccumulator.h"
+#include "CommonFramework/VideoPipeline/VideoSource.h"
+#include "CommonFramework/VideoPipeline/CameraInfo.h"
+#include "QCameraThread.h"
+#include "QVideoFrameCache.h"
+#include "SnapshotManager.h"
+#include "CameraImplementations.h"
+
+class QCamera;
+class QVideoSink;
+
+namespace PokemonAutomation{
+namespace CameraQt6QML{
+
+class CameraBackend : public PokemonAutomation::CameraBackend{
+public:
+    virtual std::vector<CameraInfo> get_all_cameras() const override;
+    virtual std::string get_camera_name(const CameraInfo& info) const override;
+
+    virtual std::unique_ptr<VideoSource> make_video_source(
+        Logger& logger,
+        const CameraInfo& info,
+        Resolution resolution,
+        VideoFormat format,
+        FramesPerSecond fps
+    ) const override;
+};
+
+class CameraVideoSource : public VideoSource{
+public:
+    virtual ~CameraVideoSource();
+    CameraVideoSource(
+        Logger& logger,
+        const CameraInfo& info,
+        Resolution desired_resolution,
+        VideoFormat desired_format,
+        FramesPerSecond desired_fps
+    );
+
+    virtual Resolution current_resolution() const override{ return m_resolution; }
+    virtual VideoFormat current_format() const override{ return m_format; }
+    virtual FramesPerSecond current_fps() const override{ return m_fps; }
+    virtual const VideoFormatSet& supported_formats() const override{ return m_formats; }
+
+    virtual VideoSnapshot snapshot_latest_blocking() override{
+        return m_snapshot_manager.snapshot_latest_blocking();
+    }
+    virtual VideoSnapshot snapshot_recent_nonblocking(WallClock min_time) override{
+        return m_snapshot_manager.snapshot_recent_nonblocking(min_time);
+    }
+
+    virtual QWidget* make_display_QtWidget(QWidget* parent) override;
+
+private:
+    void init(
+        const CameraInfo& info,
+        Resolution desired_resolution,
+        VideoFormat desired_format,
+        FramesPerSecond desired_fps
+    );
+
+private:
+    friend class CameraVideoDisplay;
+
+    std::unique_ptr<QObject> m_metaobject;
+
+    Logger& m_logger;
+    Resolution m_resolution;
+    VideoFormat m_format;
+    FramesPerSecond m_fps;
+
+    std::unique_ptr<QCameraThread> m_camera;
+    std::unique_ptr<QVideoSink> m_video_sink;
+    std::unique_ptr<QMediaCaptureSession> m_capture;
+
+    VideoFormatSet m_formats;
+
+private:
+    QVideoFrameCache m_last_frame;
+    SnapshotManager m_snapshot_manager;
+};
+
+class CameraVideoDisplay : public QQuickWidget, public VideoFrameListener{
+public:
+    virtual ~CameraVideoDisplay();
+    CameraVideoDisplay(QWidget* parent, CameraVideoSource& source);
+
+    virtual void on_frame(std::shared_ptr<const VideoFrame> frame) override;
+
+private:
+    CameraVideoSource& m_source;
+    LifetimeSanitizer m_sanitizer;
+};
+
+}
+}
+#endif
+#endif

--- a/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6_QVideoWidget.cpp
+++ b/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6_QVideoWidget.cpp
@@ -1,0 +1,201 @@
+/*  Camera Widget (Qt6 QVideoWidget)
+ *
+ *  From: https://github.com/PokemonAutomation/
+ *
+ */
+
+#include <QtGlobal>
+#if QT_VERSION_MAJOR == 6
+
+#include <QCamera>
+#include <QVideoSink>
+#include <QPainter>
+#include "Common/Qt/Redispatch.h"
+#include "CommonFramework/Logging/Logger.h"
+#include "CameraWidgetQt6.h"
+#include "CameraWidgetQt6_QVideoWidget.h"
+#include "MediaServicesQt6.h"
+#include "VideoFrameQt.h"
+
+namespace PokemonAutomation{
+namespace CameraQt6QVideoWidget{
+
+std::vector<CameraInfo> CameraBackend::get_all_cameras() const{
+#if 1
+    const auto cameras = GlobalMediaServices::instance().get_all_cameras();
+#else
+    const auto cameras = QMediaDevices::videoInputs();
+#endif
+    std::vector<CameraInfo> ret;
+    for (const auto& info : cameras){
+        ret.emplace_back(info.id().toStdString());
+    }
+    return ret;
+}
+std::string CameraBackend::get_camera_name(const CameraInfo& info) const{
+#if 1
+    const auto cameras = GlobalMediaServices::instance().get_all_cameras();
+#else
+    const auto cameras = QMediaDevices::videoInputs();
+#endif
+    for (const auto& camera : cameras){
+        if (camera.id().toStdString() == info.device_name()){
+            return camera.description().toStdString();
+        }
+    }
+    global_logger_tagged().log("Error: No such camera for CameraInfo: " + info.device_name(), COLOR_RED);
+    return "";
+}
+
+std::unique_ptr<VideoSource> CameraBackend::make_video_source(
+    Logger& logger,
+    const CameraInfo& info,
+    Resolution resolution,
+    VideoFormat format,
+    FramesPerSecond fps
+) const{
+    return std::make_unique<CameraVideoSource>(logger, info, resolution, format, fps);
+}
+
+
+CameraVideoSource::~CameraVideoSource(){
+    if (!m_capture){
+        return;
+    }
+    try{
+        m_logger.log("Stopping Camera...");
+    }catch (...){}
+
+    run_on_main_thread_and_wait([&]{
+        m_metaobject.reset();
+        m_capture.reset();
+        m_video_sink.reset();
+        m_camera.reset();
+    });
+}
+CameraVideoSource::CameraVideoSource(
+    Logger& logger,
+    const CameraInfo& info,
+    Resolution desired_resolution,
+    VideoFormat desired_format,
+    FramesPerSecond desired_fps
+)
+    : VideoSource(logger, true)
+    , m_logger(logger)
+    , m_last_frame(logger)
+    , m_snapshot_manager(logger, m_last_frame)
+{
+    if (!info){
+        return;
+    }
+    m_logger.log("Starting Camera: Backend = CameraQt6QVideoWidget");
+
+    run_on_main_thread_and_wait([&]{
+        init(info, desired_resolution, desired_format, desired_fps);
+    });
+}
+void CameraVideoSource::init(
+    const CameraInfo& info,
+    Resolution desired_resolution,
+    VideoFormat desired_format,
+    FramesPerSecond desired_fps
+){
+    m_metaobject.reset(new QObject());
+
+    auto cameras = QMediaDevices::videoInputs();
+    const QCameraDevice* device = nullptr;
+    for (const auto& camera : cameras){
+        if (camera.id().toStdString() == info.device_name()){
+            device = &camera;
+            break;
+        }
+    }
+    if (device == nullptr){
+        m_logger.log("Camera not found: " + info.device_name(), COLOR_RED);
+        return;
+    }
+    m_logger.log("Camera: " + device->description().toStdString());
+
+    QCameraFormat format = CameraQt6QVideoSink::build_format_set(
+        m_logger,
+        m_formats,
+        *device,
+        desired_resolution,
+        desired_format,
+        desired_fps
+    );
+    if (format.isNull()){
+        return;
+    }
+
+    CameraQt6QVideoSink::get_format(format, m_resolution, m_format, m_fps);
+    m_logger.log(
+        "Resolution: " + m_resolution.to_string() +
+        ", Format: " + VideoFormat_database().find(m_format)->display +
+        ", FPS: " + std::to_string(m_fps)
+    );
+
+    m_camera.reset(new QCameraThread(m_logger, *device, format));
+    m_video_sink.reset(new QVideoSink());
+    m_capture.reset(new QMediaCaptureSession());
+    m_capture->setCamera(&m_camera->camera());
+    m_capture->setVideoSink(m_video_sink.get());
+
+    m_metaobject->connect(
+        m_video_sink.get(), &QVideoSink::videoFrameChanged,
+        &m_camera->camera(), [&](const QVideoFrame& frame){
+            WallClock now = current_time();
+            if (!m_last_frame.push_frame(frame, now)){
+                return;
+            }
+            report_source_frame(std::make_shared<VideoFrame>(now, frame));
+        }
+    );
+}
+
+QWidget* CameraVideoSource::make_display_QtWidget(QWidget* parent){
+    return new CameraVideoDisplay(parent, *this);
+}
+
+CameraVideoDisplay::~CameraVideoDisplay(){
+    m_source.remove_source_frame_listener(*this);
+}
+CameraVideoDisplay::CameraVideoDisplay(QWidget* parent, CameraVideoSource& source)
+    : QOpenGLWidget(parent)
+    , m_source(source)
+    , m_sanitizer("CameraVideoDisplay")
+{
+    this->setMinimumSize(80, 45);
+    source.add_source_frame_listener(*this);
+}
+
+void CameraVideoDisplay::on_frame(std::shared_ptr<const VideoFrame> frame){
+    QMetaObject::invokeMethod(this, [this, frame = std::move(frame)]() mutable {
+        m_last_frame = std::move(frame);
+        this->update();
+    }, Qt::QueuedConnection);
+}
+
+void CameraVideoDisplay::paintEvent(QPaintEvent* event){
+    QOpenGLWidget::paintEvent(event);
+
+    if (!m_last_frame){
+        return;
+    }
+
+    QVideoFrame frame = m_last_frame->frame;
+    if (!frame.isValid()){
+        return;
+    }
+
+    QRect rect(0, 0, this->width(), this->height());
+    QVideoFrame::PaintOptions options;
+    QPainter painter(this);
+
+    frame.paint(&painter, rect, options);
+    m_source.report_rendered_frame(current_time());
+}
+
+}
+}
+#endif

--- a/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6_QVideoWidget.h
+++ b/SerialPrograms/Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6_QVideoWidget.h
@@ -1,0 +1,119 @@
+/*  Camera Widget (Qt6 QVideoWidget)
+ *
+ *  From: https://github.com/PokemonAutomation/
+ *
+ */
+
+#ifndef PokemonAutomation_VideoPipeline_Qt6QVideoWidget_H
+#define PokemonAutomation_VideoPipeline_Qt6QVideoWidget_H
+
+#include <QtGlobal>
+#if QT_VERSION_MAJOR == 6
+
+// NOTE: Maintainers must ensure QT += multimediawidgets (or find_package(Qt6 COMPONENTS MultimediaWidgets REQUIRED)) is included in the build system.
+
+#include <QCameraDevice>
+#include <QMediaCaptureSession>
+#include <QVideoFrame>
+#include <QOpenGLWidget>
+#include "CommonFramework/Tools/StatAccumulator.h"
+#include "CommonFramework/VideoPipeline/VideoSource.h"
+#include "CommonFramework/VideoPipeline/CameraInfo.h"
+#include "QCameraThread.h"
+#include "QVideoFrameCache.h"
+#include "SnapshotManager.h"
+#include "CameraImplementations.h"
+
+class QCamera;
+class QVideoSink;
+
+namespace PokemonAutomation{
+namespace CameraQt6QVideoWidget{
+
+class CameraBackend : public PokemonAutomation::CameraBackend{
+public:
+    virtual std::vector<CameraInfo> get_all_cameras() const override;
+    virtual std::string get_camera_name(const CameraInfo& info) const override;
+
+    virtual std::unique_ptr<VideoSource> make_video_source(
+        Logger& logger,
+        const CameraInfo& info,
+        Resolution resolution,
+        VideoFormat format,
+        FramesPerSecond fps
+    ) const override;
+};
+
+class CameraVideoSource : public VideoSource{
+public:
+    virtual ~CameraVideoSource();
+    CameraVideoSource(
+        Logger& logger,
+        const CameraInfo& info,
+        Resolution desired_resolution,
+        VideoFormat desired_format,
+        FramesPerSecond desired_fps
+    );
+
+    virtual Resolution current_resolution() const override{ return m_resolution; }
+    virtual VideoFormat current_format() const override{ return m_format; }
+    virtual FramesPerSecond current_fps() const override{ return m_fps; }
+    virtual const VideoFormatSet& supported_formats() const override{ return m_formats; }
+
+    virtual VideoSnapshot snapshot_latest_blocking() override{
+        return m_snapshot_manager.snapshot_latest_blocking();
+    }
+    virtual VideoSnapshot snapshot_recent_nonblocking(WallClock min_time) override{
+        return m_snapshot_manager.snapshot_recent_nonblocking(min_time);
+    }
+
+    virtual QWidget* make_display_QtWidget(QWidget* parent) override;
+
+private:
+    void init(
+        const CameraInfo& info,
+        Resolution desired_resolution,
+        VideoFormat desired_format,
+        FramesPerSecond desired_fps
+    );
+
+private:
+    friend class CameraVideoDisplay;
+
+    std::unique_ptr<QObject> m_metaobject;
+
+    Logger& m_logger;
+    Resolution m_resolution;
+    VideoFormat m_format;
+    FramesPerSecond m_fps;
+
+    std::unique_ptr<QCameraThread> m_camera;
+    std::unique_ptr<QVideoSink> m_video_sink;
+    std::unique_ptr<QMediaCaptureSession> m_capture;
+
+    VideoFormatSet m_formats;
+
+private:
+    QVideoFrameCache m_last_frame;
+    SnapshotManager m_snapshot_manager;
+};
+
+class CameraVideoDisplay : public QOpenGLWidget, private VideoFrameListener{
+public:
+    ~CameraVideoDisplay();
+    CameraVideoDisplay(QWidget* parent, CameraVideoSource& source);
+
+private:
+    virtual void on_frame(std::shared_ptr<const VideoFrame> frame) override;
+    virtual void paintEvent(QPaintEvent* event) override;
+
+private:
+    CameraVideoSource& m_source;
+    std::shared_ptr<const VideoFrame> m_last_frame;
+    LifetimeSanitizer m_sanitizer;
+};
+
+}
+}
+#endif
+#endif

--- a/SerialPrograms/Source/CommonTools/Images/WaterfillUtilities.h
+++ b/SerialPrograms/Source/CommonTools/Images/WaterfillUtilities.h
@@ -8,6 +8,7 @@
 #ifndef PokemonAutomation_CommonTools_WaterfillUtilities_H
 #define PokemonAutomation_CommonTools_WaterfillUtilities_H
 
+#include <cstdint>
 #include <functional>
 #include <utility>
 #include "Common/Cpp/ImageResolution.h"

--- a/SerialPrograms/Source/Integrations/DiscordIntegrationSettings.cpp
+++ b/SerialPrograms/Source/Integrations/DiscordIntegrationSettings.cpp
@@ -122,6 +122,7 @@ void DiscordIntegrationSettingsOption::on_config_value_changed([[maybe_unused]] 
 }
 
 void DiscordIntegrationSettingsOption::on_press(ButtonCell& button){
+#ifdef PA_DPP
     if (&button == &m_start_button){
         DppClient::Client::instance().connect();
         on_config_value_changed(this);
@@ -132,6 +133,9 @@ void DiscordIntegrationSettingsOption::on_press(ButtonCell& button){
         on_config_value_changed(this);
         return;
     }
+#else
+    (void)button;
+#endif
 }
 
 

--- a/SerialPrograms/Source/ML/Inference/ML_PaddleOCRPipeline.h
+++ b/SerialPrograms/Source/ML/Inference/ML_PaddleOCRPipeline.h
@@ -13,6 +13,9 @@
 #include <vector>
 #include <onnxruntime_cxx_api.h>
 #include <opencv2/opencv.hpp>
+#if __has_include(<opencv2/geometry/2d.hpp>)
+#include <opencv2/geometry/2d.hpp>
+#endif
 #include "CommonFramework/Language.h"
 #include "CommonFramework/ImageTypes/ImageViewRGB32.h"
 #include "CommonFramework/ImageTools/ImageBoxes.h"

--- a/SerialPrograms/Source/PokemonLZA/Inference/Map/PokemonLZA_DirectionArrowDetector.cpp
+++ b/SerialPrograms/Source/PokemonLZA/Inference/Map/PokemonLZA_DirectionArrowDetector.cpp
@@ -8,6 +8,9 @@
 #include "CommonFramework/ImageTypes/ImageViewRGB32.h"
 #include "CommonFramework/VideoPipeline/VideoOverlayScopes.h"
 #include <opencv2/opencv.hpp>
+#if __has_include(<opencv2/geometry/2d.hpp>)
+#include <opencv2/geometry/2d.hpp>
+#endif
 #include <cmath>
 
 // #define DEBUG_DIRECTION_ARROW

--- a/SerialPrograms/cmake/SourceFiles.cmake
+++ b/SerialPrograms/cmake/SourceFiles.cmake
@@ -545,6 +545,9 @@ file(GLOB LIBRARY_SOURCES
     Source/CommonFramework/VideoPipeline/Backends/CameraImplementations.h
     Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6.5.cpp
     Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6.5.h
+    Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6_QVideoWidget.cpp
+    Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6_QVideoWidget.h
+    Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6_QML.cpp
     Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6.cpp
     Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6.h
     Source/CommonFramework/VideoPipeline/Backends/MediaServicesQt6.cpp

--- a/SerialPrograms/cmake/SourceFiles.cmake
+++ b/SerialPrograms/cmake/SourceFiles.cmake
@@ -550,6 +550,8 @@ file(GLOB LIBRARY_SOURCES
     Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6_QML.cpp
     Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6.cpp
     Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6.h
+    Source/CommonFramework/VideoPipeline/Backends/CameraWidgetOpenCV.cpp
+    Source/CommonFramework/VideoPipeline/Backends/CameraWidgetOpenCV.h
     Source/CommonFramework/VideoPipeline/Backends/MediaServicesQt6.cpp
     Source/CommonFramework/VideoPipeline/Backends/MediaServicesQt6.h
     Source/CommonFramework/VideoPipeline/Backends/QCameraThread.h

--- a/SerialPrograms/cmake/SourceFiles.cmake
+++ b/SerialPrograms/cmake/SourceFiles.cmake
@@ -552,6 +552,8 @@ file(GLOB LIBRARY_SOURCES
     Source/CommonFramework/VideoPipeline/Backends/CameraWidgetQt6.h
     Source/CommonFramework/VideoPipeline/Backends/CameraWidgetOpenCV.cpp
     Source/CommonFramework/VideoPipeline/Backends/CameraWidgetOpenCV.h
+    Source/CommonFramework/VideoPipeline/Backends/CameraWidgetOpenCV_QOpenGLWidget.cpp
+    Source/CommonFramework/VideoPipeline/Backends/CameraWidgetOpenCV_QOpenGLWidget.h
     Source/CommonFramework/VideoPipeline/Backends/MediaServicesQt6.cpp
     Source/CommonFramework/VideoPipeline/Backends/MediaServicesQt6.h
     Source/CommonFramework/VideoPipeline/Backends/QCameraThread.h


### PR DESCRIPTION
This is some code I had Gemini help me put together to expand our different video backends, there are multiple ways to handle this. Additionally, I tested all of these backends myself and had to really prompt the AI to get things to properly work. Though, I was also limited by my absolutely awful capture card constantly dying on Linux, so hopefully this will get you going in the right direction.

Basically, you should be able to choose a backend in the program settings. I think a few of these are Linux only (that's where I dev and run), but the principles are the same.

Do note that we need to some QT packages to get this all to work.