### PR TITLE
FRLG Roamer: fix leave_pokecenter never actually exiting

### DIFF
--- a/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngNavigation.cpp
+++ b/SerialPrograms/Source/PokemonFRLG/Programs/RngManipulation/PokemonFRLG_RngNavigation.cpp
@@ -345,8 +345,42 @@ void hatch_daycare_egg(ConsoleHandle& console, ProControllerContext& context){
 
 
 void travel_from_celio_to_kanto(ConsoleHandle& console, ProControllerContext& context){
-    // assumes the player is standing on Celio's left (west) side
-    pbf_move_left_joystick(context, {-1, 0}, 1280ms, 300ms);
+    // assumes the player is standing on Celio's left (west) side.
+    //
+    // Confirmed by testing: the character never even turns left -- it goes
+    // straight into the "walk down" phase of leave_pokecenter(). Blind waiting
+    // (tried up to 30s) does not fix it, but blindly mashing A does have an
+    // effect (it re-opens Celio's dialogue), proving the game is responsive
+    // and a leftover dialogue box is the blocker, not an unresponsive game.
+    // So: check via screenshot whether a dialogue box is actually on screen,
+    // and only press A once if so, re-checking after each single press.
+    // Never press A when no dialogue is detected, to avoid re-triggering a
+    // fresh conversation with Celio.
+    {
+        WhiteDialogDetector dialog_detector(COLOR_RED);
+        bool cleared = false;
+        for (int attempts = 0; attempts < 10; attempts++){
+            context.wait_for_all_requests();
+            VideoSnapshot screen = console.video().snapshot();
+            if (!dialog_detector.detect(screen)){
+                cleared = true;
+                break;
+            }
+            pbf_press_button(context, BUTTON_A, 200ms, 800ms);
+        }
+        if (!cleared){
+            console.log("travel_from_celio_to_kanto(): Dialogue box did not clear after 10 checks. Continuing anyway.", COLOR_RED);
+        }
+        context.wait_for_all_requests();
+    }
+    // 5 discrete steps left (matches manual testing), instead of one continuous
+    // hold, so a single dropped input doesn't eat the whole movement.
+    // 400ms/step measured as ~9 tiles for 5 iterations; scaled down to land on
+    // ~5 tiles for 5 iterations (400 * 5/9 ~= 220ms).
+    for (int i = 0; i < 5; i++){
+        pbf_move_left_joystick(context, {-1, 0}, 220ms, 200ms);
+    }
+    context.wait_for_all_requests();
     leave_pokecenter(console, context);
     // walk down to the One Island sign
     WhiteDialogWatcher dialog_detected(COLOR_RED);


### PR DESCRIPTION
travel_from_celio_to_kanto() does a single 1280ms hold left before calling leave_pokecenter(), assuming you can already move right after activate_roamer()'s dialogue ends. Turns out that's not reliable -- in testing (with Spanish game text) the character never even tries to turn left, it just falls straight into leave_pokecenter()'s blind walk-down and misses the door every time, eventually throwing the exit exception.

Turns out there's a leftover dialogue box still open after activate_roamer() finishes that eats the movement input. Waiting longer before moving doesn't help (tried up to 30s) since waiting alone doesn't close a dialogue box, but mashing A does close it -- which also confirms the game isn't actually frozen, just still showing text. Problem is mashing blind risks re-opening a new conversation with Celio if you overshoot.

So now it checks a screenshot for a dialogue box before moving, and only presses A once if it's actually there, re-checking in between presses. Also switched the left move to 5 separate steps instead of one long hold, since the continuous hold kept getting eaten somewhere.

None of this touches anything before the PID gets fixed in activate_roamer(), so it shouldn't affect the RNG result -- tested it and it's still landing on the right targets.

Heads up on the 220ms/step value for the movement: that number was reverse-calibrated from a single test session on my own hardware/capture setup (measured 400ms/step as ~9 tiles for 5 steps, scaled down to land on ~5). It's possible the dialogue fix alone was the actual bug and the original 1280ms hold would've been fine once unblocked -- discrete taps and a continuous hold don't necessarily cover distance at the same rate per ms, so this timing may need retuning on other hardware. Flagging this in case it needs adjustment rather than presenting it as a settled number.

Tested and working on FRLG (Spanish).