### PR TITLE
Multi-Controller Support

### DIFF
--- a/Common/Cpp/Containers/FixedLimitVector.h
+++ b/Common/Cpp/Containers/FixedLimitVector.h
@@ -109,6 +109,10 @@ FixedLimitVector<Object>::FixedLimitVector()
     , m_capacity(0)
 {}
 
+template <typename Object>
+void FixedLimitVector<Object>::pop_back(){
+    m_data[--m_size].~Object();
+}
 
 
 

--- a/Common/Cpp/Containers/FixedLimitVector.h
+++ b/Common/Cpp/Containers/FixedLimitVector.h
@@ -19,6 +19,7 @@
 #define PokemonAutomation_FixedLimitVector_H
 
 #include <stddef.h>
+#include "AlignedMalloc.h"
 
 namespace PokemonAutomation{
 
@@ -71,6 +72,14 @@ private:
 
 
 //  Implementations
+
+template <typename Object>
+FixedLimitVector<Object>::~FixedLimitVector(){
+    while (m_size > 0){
+        pop_back();
+    }
+    aligned_free(m_data);
+}
 
 template <typename Object>
 FixedLimitVector<Object>::FixedLimitVector(FixedLimitVector&& x) noexcept

--- a/Common/Cpp/Containers/FixedLimitVector.h
+++ b/Common/Cpp/Containers/FixedLimitVector.h
@@ -27,10 +27,10 @@ template <typename Object>
 class FixedLimitVector{
 public:
     ~FixedLimitVector();
-    FixedLimitVector(const FixedLimitVector&) = delete;
-    void operator=(const FixedLimitVector&) = delete;
-    FixedLimitVector(FixedLimitVector&& x);
-    void operator=(FixedLimitVector&& x);
+    FixedLimitVector(const FixedLimitVector& x);
+    void operator=(const FixedLimitVector& x);
+    FixedLimitVector(FixedLimitVector&& x) noexcept;
+    void operator=(FixedLimitVector&& x) noexcept;
 
 public:
     FixedLimitVector();
@@ -73,7 +73,7 @@ private:
 //  Implementations
 
 template <typename Object>
-FixedLimitVector<Object>::FixedLimitVector(FixedLimitVector&& x)
+FixedLimitVector<Object>::FixedLimitVector(FixedLimitVector&& x) noexcept
     : m_data(x.m_data)
     , m_size(x.m_size)
     , m_capacity(x.m_capacity)
@@ -83,7 +83,7 @@ FixedLimitVector<Object>::FixedLimitVector(FixedLimitVector&& x)
     x.m_capacity = 0;
 }
 template <typename Object>
-void FixedLimitVector<Object>::operator=(FixedLimitVector&& x){
+void FixedLimitVector<Object>::operator=(FixedLimitVector&& x) noexcept{
     reset();
     m_data = x.m_data;
     m_size = x.m_size;

--- a/Common/Cpp/Containers/FixedLimitVector.tpp
+++ b/Common/Cpp/Containers/FixedLimitVector.tpp
@@ -18,16 +18,6 @@ namespace PokemonAutomation{
 //  Rule of 5
 
 template <typename Object>
-FixedLimitVector<Object>::~FixedLimitVector(){
-    while (m_size > 0){
-        pop_back();
-    }
-    aligned_free(m_data);
-}
-
-
-
-template <typename Object>
 FixedLimitVector<Object>::FixedLimitVector(const FixedLimitVector& x)
     : FixedLimitVector(x.capacity())
 {

--- a/Common/Cpp/Containers/FixedLimitVector.tpp
+++ b/Common/Cpp/Containers/FixedLimitVector.tpp
@@ -87,10 +87,6 @@ bool FixedLimitVector<Object>::emplace_back(Args&&... args){
         return false;
     }
 }
-template <typename Object>
-void FixedLimitVector<Object>::pop_back(){
-    m_data[--m_size].~Object();
-}
 
 
 

--- a/Common/Cpp/Containers/FixedLimitVector.tpp
+++ b/Common/Cpp/Containers/FixedLimitVector.tpp
@@ -27,6 +27,25 @@ FixedLimitVector<Object>::~FixedLimitVector(){
 
 
 
+template <typename Object>
+FixedLimitVector<Object>::FixedLimitVector(const FixedLimitVector& x)
+    : FixedLimitVector(x.capacity())
+{
+    for (const Object& obj : x){
+        emplace_back(obj);
+    }
+}
+template <typename Object>
+void FixedLimitVector<Object>::operator=(const FixedLimitVector& x){
+    if (this == &x){
+        return;
+    }
+    FixedLimitVector tmp(x);
+    operator=(std::move(tmp));
+}
+
+
+
 //  Constructors
 
 template <typename Object>

--- a/Common/Cpp/LifetimeSanitizer.cpp
+++ b/Common/Cpp/LifetimeSanitizer.cpp
@@ -39,6 +39,7 @@ struct LifetimeSanitizerFields{
 //            "MultiSwitchProgramWidget2",
 //            "VideoSource",
 //            "AsyncTask",
+//            "ControllerOption",
         })
     {}
 };

--- a/Common/Cpp/Logging/TaggedLogger.cpp
+++ b/Common/Cpp/Logging/TaggedLogger.cpp
@@ -12,14 +12,22 @@ namespace PokemonAutomation{
 
 TaggedLogger::TaggedLogger(Logger& logger, std::string tag)
     : m_logger(logger)
-    , m_tag(std::move(tag))
-{}
+{
+    m_tags.emplace_back(std::move(tag));
+}
+TaggedLogger::TaggedLogger(TaggedLogger& logger, std::string tag)
+    : m_logger(logger.base_logger())
+    , m_tags(logger.m_tags)
+{
+    m_tags.emplace_back(std::move(tag));
+}
 
 void TaggedLogger::log(const std::string& msg, Color color){
-    std::string str =
-        current_time_to_str() +
-        " - [" + m_tag + "]: " +
-        msg;
+    std::string str = current_time_to_str() + " - ";
+    for (const std::string& tag : m_tags){
+        str += "[" + tag + "]";
+    }
+    str += ": " + msg;
     m_logger.log(std::move(str), color);
 }
 

--- a/Common/Cpp/Logging/TaggedLogger.h
+++ b/Common/Cpp/Logging/TaggedLogger.h
@@ -10,6 +10,7 @@
 #define PokemonAutomation_Logging_TaggedLogger_H
 
 #include <string>
+#include <vector>
 #include "AbstractLogger.h"
 
 namespace PokemonAutomation{
@@ -25,19 +26,22 @@ namespace PokemonAutomation{
 //   // Output: "2024-01-15 10:30:45.123 - [Network]: Connection established"
 class TaggedLogger : public Logger{
 public:
-    // Construct a TaggedLogger that wraps the given base logger.
-    // All log messages will be prefixed with a timestamp and the given tag.
+    //  Construct a TaggedLogger that wraps the given base logger.
+    //  All log messages will be prefixed with a timestamp and the given tag.
     TaggedLogger(Logger& logger, std::string tag);
 
-    // Get the underlying base logger.
+    //  Constructs a TaggedLogger from an existing one by appending another tag.
+    TaggedLogger(TaggedLogger& logger, std::string tag);
+
+    //  Get the underlying base logger.
     Logger& base_logger(){ return m_logger; }
 
-    // Logger interface: prepends timestamp and tag, then forwards to base logger.
+    //  Logger interface: prepends timestamp and tag, then forwards to base logger.
     virtual void log(const std::string& msg, Color color = Color()) override;
 
 private:
     Logger& m_logger;
-    std::string m_tag;
+    std::vector<std::string> m_tags;
 };
 
 

--- a/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioInfo.cpp
+++ b/SerialPrograms/Source/CommonFramework/AudioPipeline/AudioInfo.cpp
@@ -317,7 +317,6 @@ struct AudioDeviceInfo::Data{
 #elif QT_VERSION_MAJOR == 6
     QAudioDevice info;
 #endif
-
 };
 std::vector<AudioDeviceInfo> AudioDeviceInfo::all_input_devices(){
     //  The device list that Qt provides above will include duplicates on Windows

--- a/SerialPrograms/Source/ConsoleInfra/ConsoleSystemOption.cpp
+++ b/SerialPrograms/Source/ConsoleInfra/ConsoleSystemOption.cpp
@@ -4,9 +4,12 @@
  *
  */
 
+#include "Common/Cpp/Exceptions.h"
 #include "Common/Cpp/Json/JsonValue.h"
 #include "Common/Cpp/Json/JsonArray.h"
 #include "Common/Cpp/Json/JsonObject.h"
+#include "Common/Cpp/Containers/FixedLimitVector.tpp"
+#include "Controllers/NullController.h"
 #include "ConsoleInfra/ConsoleSystemOption.h"
 
 namespace PokemonAutomation{
@@ -27,7 +30,16 @@ ConsoleSystemOption::ConsoleSystemOption(
 )
     : m_allow_commands_while_running(allow_commands_while_running)
     , m_controllers(num_controllers)
-{}
+{
+    if (num_controllers == 0){
+        throw InternalProgramError(nullptr, PA_CURRENT_FUNCTION, "num_controllers cannot be 0.");
+    }
+    bool enable_input = true;
+    for (size_t c = 0; c < num_controllers; c++){
+        m_controllers.emplace_back(enable_input);
+        enable_input = false;
+    }
+}
 ConsoleSystemOption::ConsoleSystemOption(
     size_t num_controllers,
     bool allow_commands_while_running,
@@ -35,7 +47,7 @@ ConsoleSystemOption::ConsoleSystemOption(
 )
     : ConsoleSystemOption(num_controllers, allow_commands_while_running)
 {
-    load_json(json);
+    ConsoleSystemOption::load_json(json);
 }
 void ConsoleSystemOption::load_json(const JsonValue& json){
     const JsonObject* obj = json.to_object();
@@ -57,21 +69,19 @@ void ConsoleSystemOption::load_json(const JsonValue& json){
     }
     value = obj->get_value(JSON_CONTROLLER);
     if (value){
-        std::vector<ControllerOption> controllers;
-        controllers.emplace_back().load_json(*value);
-        m_controllers = std::move(controllers);
+        m_controllers[0].load_json(*value);
     }
-    value = obj->get_value(JSON_CONTROLLERS);
-    if (value){
-        std::vector<ControllerOption> controllers;
-        if (value->is_array()){
-            for (const JsonValue& item : *value->to_array()){
-                controllers.emplace_back().load_json(item);
-            }
-        }else{
-            controllers.emplace_back().load_json(*value);
+    const JsonArray* array = obj->get_array(JSON_CONTROLLERS);
+    if (array){
+        size_t c = 0;
+        size_t stop = std::min(m_controllers.size(), array->size());
+        for (; c < stop; c++){
+            m_controllers[c].load_json((*array)[c]);
         }
-        m_controllers = std::move(controllers);
+        stop = m_controllers.size();
+        for (; c < stop; c++){
+            m_controllers[c].set_descriptor(std::make_shared<NullControllerDescriptor>());
+        }
     }
 }
 JsonValue ConsoleSystemOption::to_json() const{

--- a/SerialPrograms/Source/ConsoleInfra/ConsoleSystemOption.h
+++ b/SerialPrograms/Source/ConsoleInfra/ConsoleSystemOption.h
@@ -10,7 +10,7 @@
 #ifndef PokemonAutomation_ConsoleInfra_ConsoleSystemOption_H
 #define PokemonAutomation_ConsoleInfra_ConsoleSystemOption_H
 
-#include <vector>
+#include "Common/Cpp/Containers/FixedLimitVector.h"
 #include "CommonFramework/AudioPipeline/AudioOption.h"
 #include "CommonFramework/VideoPipeline/VideoSourceDescriptor.h"
 #include "CommonFramework/VideoPipeline/VideoOverlayOption.h"
@@ -52,7 +52,7 @@ public:
     VideoSourceOption m_video;
     AudioOption m_audio;
     VideoOverlayOption m_overlay;
-    std::vector<ControllerOption> m_controllers;
+    FixedLimitVector<ControllerOption> m_controllers;
 };
 
 

--- a/SerialPrograms/Source/ConsoleInfra/ConsoleSystemSession.cpp
+++ b/SerialPrograms/Source/ConsoleInfra/ConsoleSystemSession.cpp
@@ -47,8 +47,7 @@ ConsoleSystemSession::~ConsoleSystemSession(){
 ConsoleSystemSession::ConsoleSystemSession(
     Logger& logger,
     ConsoleSystemOption& option,
-    size_t console_number,
-    size_t num_controllers
+    size_t console_number
 )
     : m_console_number(console_number)
     , m_logger(logger, "Console " + std::to_string(console_number))
@@ -56,14 +55,13 @@ ConsoleSystemSession::ConsoleSystemSession(
     , m_video(m_logger, option.m_video)
     , m_audio(m_logger, option.m_audio)
     , m_overlay(m_logger, option.m_overlay)
-    , m_controllers(num_controllers)
     , m_history(m_logger)
     , m_memory_usage(new MemoryUtilizationStats())
     , m_cpu_utilization(new CpuUtilizationStat())
     , m_main_thread_utilization(new ThreadUtilizationStat(current_thread_handle(), "Main Qt Thread:"))
 {
     for (ControllerOption& controller : option.m_controllers){
-        m_controllers.emplace_back(m_logger, controller);
+        m_controllers.emplace_back(std::make_unique<ControllerSession>(m_logger, controller));
     }
 
     m_history.start(m_audio.input_format(), m_video.current_source() != nullptr);
@@ -94,10 +92,7 @@ void ConsoleSystemSession::save(ConsoleSystemOption& option) const{
     m_audio.save(option.m_audio);
     m_overlay.save(option.m_overlay);
 
-    option.m_controllers.resize(m_controllers.size());
-    for (size_t c = 0; c < m_controllers.size(); c++){
-        m_controllers[c].save(option.m_controllers[c]);
-    }
+    option.m_controllers = m_option.m_controllers;
 }
 void ConsoleSystemSession::load(const ConsoleSystemOption& option){
     std::lock_guard<Mutex> lg(m_lock);
@@ -106,16 +101,18 @@ void ConsoleSystemSession::load(const ConsoleSystemOption& option){
     m_audio.load(option.m_audio);
     m_overlay.load(option.m_overlay);
 
-    m_option.m_controllers.resize(option.m_controllers.size());
     size_t c = 0;
-    for (; c < option.m_controllers.size(); c++){
-        if (c >= m_controllers.size()){
-            return;
-        }
-        m_controllers[c].load(option.m_controllers[c]);
+
+    size_t stop = std::min(m_option.m_controllers.size(), option.m_controllers.size());
+    for (; c < stop; c++){
+        m_option.m_controllers[c] = option.m_controllers[c];
+        m_controllers[c]->load(option.m_controllers[c]);
     }
-    for (; c < m_controllers.size(); c++){
-        m_controllers[c].set_device(std::make_shared<NullControllerDescriptor>());
+
+    stop = m_option.m_controllers.size();
+    for (; c < stop; c++){
+        m_option.m_controllers[c].set_descriptor(std::make_shared<NullControllerDescriptor>());
+        m_controllers[c]->set_device(m_option.m_controllers[c].descriptor());
     }
 }
 
@@ -124,8 +121,8 @@ void ConsoleSystemSession::lock_controllers(std::string reason){
     {
         std::lock_guard<Mutex> lg(m_lock);
         m_lock_controllers_reason = std::move(reason);
-        for (ControllerSession& controller : m_controllers){
-            controller.set_options_locked(true);
+        for (std::unique_ptr<ControllerSession>& controller : m_controllers){
+            controller->set_options_locked(true);
         }
     }
     m_listeners.run_method(&Listener::on_lock_controllers);
@@ -135,8 +132,8 @@ void ConsoleSystemSession::unlock_controllers(){
         std::lock_guard<Mutex> lg(m_lock);
         m_lock_controllers_reason.clear();
         global_input_clear_state();
-        for (ControllerSession& controller : m_controllers){
-            controller.set_options_locked(false);
+        for (std::unique_ptr<ControllerSession>& controller : m_controllers){
+            controller->set_options_locked(false);
         }
     }
     m_listeners.run_method(&Listener::on_unlock_controllers);
@@ -170,8 +167,8 @@ void ConsoleSystemSession::on_focus_out(){
     global_input_clear_state();
     global_input_remove_listener(*this);
 
-    for (ControllerSession& controller : m_controllers){
-        std::string error = controller.try_run<AbstractController>([](AbstractController& controller){
+    for (std::unique_ptr<ControllerSession>& controller : m_controllers){
+        std::string error = controller->try_run<AbstractController>([](AbstractController& controller){
             controller.cancel_all_commands();
         });
         if (!error.empty()){
@@ -191,8 +188,8 @@ void ConsoleSystemSession::run_controller_input(ControllerInputState& state){
     }
 
 //    cout << "ConsoleSystemSession::run_controller_input()" << endl;
-    for (ControllerSession& controller : m_controllers){
-        std::string error = controller.try_run<AbstractController>([&](AbstractController& controller){
+    for (std::unique_ptr<ControllerSession>& controller : m_controllers){
+        std::string error = controller->try_run<AbstractController>([&](AbstractController& controller){
             controller.run_controller_input(state);
         });
         if (!error.empty()){

--- a/SerialPrograms/Source/ConsoleInfra/ConsoleSystemSession.cpp
+++ b/SerialPrograms/Source/ConsoleInfra/ConsoleSystemSession.cpp
@@ -55,13 +55,18 @@ ConsoleSystemSession::ConsoleSystemSession(
     , m_video(m_logger, option.m_video)
     , m_audio(m_logger, option.m_audio)
     , m_overlay(m_logger, option.m_overlay)
+    , m_controllers(option.m_controllers.size())
     , m_history(m_logger)
     , m_memory_usage(new MemoryUtilizationStats())
     , m_cpu_utilization(new CpuUtilizationStat())
     , m_main_thread_utilization(new ThreadUtilizationStat(current_thread_handle(), "Main Qt Thread:"))
 {
-    for (ControllerOption& controller : option.m_controllers){
-        m_controllers.emplace_back(std::make_unique<ControllerSession>(m_logger, controller));
+    if (option.m_controllers.size() == 1){
+        m_controllers.emplace_back(m_logger, option.m_controllers[0]);
+    }else{
+        for (ControllerOption& controller : option.m_controllers){
+            m_controllers.emplace_back(m_logger, m_controllers.size(), controller);
+        }
     }
 
     m_history.start(m_audio.input_format(), m_video.current_source() != nullptr);
@@ -106,13 +111,13 @@ void ConsoleSystemSession::load(const ConsoleSystemOption& option){
     size_t stop = std::min(m_option.m_controllers.size(), option.m_controllers.size());
     for (; c < stop; c++){
         m_option.m_controllers[c] = option.m_controllers[c];
-        m_controllers[c]->load(option.m_controllers[c]);
+        m_controllers[c].session.load(option.m_controllers[c]);
     }
 
     stop = m_option.m_controllers.size();
     for (; c < stop; c++){
         m_option.m_controllers[c].set_descriptor(std::make_shared<NullControllerDescriptor>());
-        m_controllers[c]->set_device(m_option.m_controllers[c].descriptor());
+        m_controllers[c].session.set_device(m_option.m_controllers[c].descriptor());
     }
 }
 
@@ -121,8 +126,8 @@ void ConsoleSystemSession::lock_controllers(std::string reason){
     {
         std::lock_guard<Mutex> lg(m_lock);
         m_lock_controllers_reason = std::move(reason);
-        for (std::unique_ptr<ControllerSession>& controller : m_controllers){
-            controller->set_options_locked(true);
+        for (ControllerEntry& controller : m_controllers){
+            controller.session.set_options_locked(true);
         }
     }
     m_listeners.run_method(&Listener::on_lock_controllers);
@@ -132,8 +137,8 @@ void ConsoleSystemSession::unlock_controllers(){
         std::lock_guard<Mutex> lg(m_lock);
         m_lock_controllers_reason.clear();
         global_input_clear_state();
-        for (std::unique_ptr<ControllerSession>& controller : m_controllers){
-            controller->set_options_locked(false);
+        for (ControllerEntry& controller : m_controllers){
+            controller.session.set_options_locked(false);
         }
     }
     m_listeners.run_method(&Listener::on_unlock_controllers);
@@ -167,8 +172,8 @@ void ConsoleSystemSession::on_focus_out(){
     global_input_clear_state();
     global_input_remove_listener(*this);
 
-    for (std::unique_ptr<ControllerSession>& controller : m_controllers){
-        std::string error = controller->try_run<AbstractController>([](AbstractController& controller){
+    for (ControllerEntry& controller : m_controllers){
+        std::string error = controller.session.try_run<AbstractController>([](AbstractController& controller){
             controller.cancel_all_commands();
         });
         if (!error.empty()){
@@ -188,8 +193,8 @@ void ConsoleSystemSession::run_controller_input(ControllerInputState& state){
     }
 
 //    cout << "ConsoleSystemSession::run_controller_input()" << endl;
-    for (std::unique_ptr<ControllerSession>& controller : m_controllers){
-        std::string error = controller->try_run<AbstractController>([&](AbstractController& controller){
+    for (ControllerEntry& controller : m_controllers){
+        std::string error = controller.session.try_run<AbstractController>([&](AbstractController& controller){
             controller.run_controller_input(state);
         });
         if (!error.empty()){

--- a/SerialPrograms/Source/ConsoleInfra/ConsoleSystemSession.h
+++ b/SerialPrograms/Source/ConsoleInfra/ConsoleSystemSession.h
@@ -76,7 +76,7 @@ public:
     const StreamHistorySession& stream_history() const{ return m_history; }
 
     size_t controllers() const{ return m_controllers.size(); }
-    ControllerSession& controller(size_t index){ return *m_controllers[index]; }
+    ControllerSession& controller(size_t index){ return m_controllers[index].session; }
 
 
 public:
@@ -107,7 +107,21 @@ private:
     VideoSession m_video;
     AudioSession m_audio;
     VideoOverlaySession m_overlay;
-    std::vector<std::unique_ptr<ControllerSession>> m_controllers;
+
+    struct ControllerEntry{
+        TaggedLogger logger;
+        ControllerSession session;
+
+        ControllerEntry(TaggedLogger& p_logger, ControllerOption& option)
+            : logger(p_logger)
+            , session(logger, option)
+        {}
+        ControllerEntry(TaggedLogger& p_logger, size_t p_controller_index, ControllerOption& option)
+            : logger(p_logger, std::to_string(p_controller_index))
+            , session(logger, option)
+        {}
+    };
+    FixedLimitVector<ControllerEntry> m_controllers;
 
     StreamHistorySession m_history;
 

--- a/SerialPrograms/Source/ConsoleInfra/ConsoleSystemSession.h
+++ b/SerialPrograms/Source/ConsoleInfra/ConsoleSystemSession.h
@@ -21,7 +21,6 @@
 #define PokemonAutomation_ConsoleInfra_ConsoleSystemSession_H
 
 #include "Common/Cpp/Logging/TaggedLogger.h"
-#include "Common/Cpp/Containers/FixedLimitVector.h"
 #include "CommonFramework/AudioPipeline/AudioSession.h"
 #include "CommonFramework/VideoPipeline/VideoSession.h"
 #include "CommonFramework/VideoPipeline/VideoOverlaySession.h"
@@ -61,8 +60,7 @@ public:
     ConsoleSystemSession(
         Logger& logger,
         ConsoleSystemOption& option,
-        size_t console_number,
-        size_t num_controllers
+        size_t console_number
     );
 
 
@@ -78,7 +76,7 @@ public:
     const StreamHistorySession& stream_history() const{ return m_history; }
 
     size_t controllers() const{ return m_controllers.size(); }
-    ControllerSession& controller(size_t index){ return m_controllers[index]; }
+    ControllerSession& controller(size_t index){ return *m_controllers[index]; }
 
 
 public:
@@ -109,7 +107,7 @@ private:
     VideoSession m_video;
     AudioSession m_audio;
     VideoOverlaySession m_overlay;
-    FixedLimitVector<ControllerSession> m_controllers;
+    std::vector<std::unique_ptr<ControllerSession>> m_controllers;
 
     StreamHistorySession m_history;
 

--- a/SerialPrograms/Source/ConsoleInfra/ConsoleSystemWidget.cpp
+++ b/SerialPrograms/Source/ConsoleInfra/ConsoleSystemWidget.cpp
@@ -63,7 +63,7 @@ ConsoleSystemWidget::ConsoleSystemWidget(
     m_group_layout->setContentsMargins(0, 0, 0, 0);
 
     if (session.controllers() == 1){
-        m_group_layout->addWidget(new ControllerSelectorWidget(*this, m_session.controller(0), false));
+        m_group_layout->addWidget(new ControllerSelectorWidget(*this, m_session.controller(0), std::nullopt));
     }
 
     m_video_selector = new VideoSourceSelectorWidget(m_session.logger(), m_session.video());
@@ -74,7 +74,7 @@ ConsoleSystemWidget::ConsoleSystemWidget(
 
     if (session.controllers() != 1){
         for (size_t c = 0; c < m_session.controllers(); c++){
-            m_group_layout->addWidget(new ControllerSelectorWidget(*this, m_session.controller(c), true));
+            m_group_layout->addWidget(new ControllerSelectorWidget(*this, m_session.controller(c), c));
         }
     }
 }

--- a/SerialPrograms/Source/ConsoleInfra/ConsoleSystemWidget.cpp
+++ b/SerialPrograms/Source/ConsoleInfra/ConsoleSystemWidget.cpp
@@ -1,0 +1,111 @@
+/*  Console System (Qt Widget)
+ *
+ *  From: https://github.com/PokemonAutomation/
+ *
+ */
+
+#include <QKeyEvent>
+#include <QVBoxLayout>
+#include <QGroupBox>
+#include "Controllers/ControllerSelectorWidget.h"
+#include "ConsoleSystemWidget.h"
+
+namespace PokemonAutomation{
+namespace ConsoleInfra{
+
+
+
+ConsoleSystemWidget::~ConsoleSystemWidget(){
+    //  Delete all the UI elements first since they reference the states.
+    delete m_audio_display;
+    delete m_audio_widget;
+    delete m_video_display;
+    delete m_video_selector;
+}
+
+ConsoleSystemWidget::ConsoleSystemWidget(
+    QWidget& parent,
+    ConsoleSystemSession& session
+)
+    : QWidget(&parent)
+    , m_session(session)
+{
+    setFocusPolicy(Qt::StrongFocus);
+
+    QVBoxLayout* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setAlignment(Qt::AlignTop);
+
+    m_group_box = new CollapsibleGroupBox(*this, "Console " + QString::number(m_session.console_number()) + " Settings");
+    layout->addWidget(m_group_box);
+
+    {
+        m_audio_display = new AudioDisplayWidget(*this, m_session.logger(), m_session.audio());
+        layout->addWidget(m_audio_display);
+
+        QVBoxLayout* video_holder = new QVBoxLayout();
+        layout->addLayout(video_holder);
+        video_holder->setContentsMargins(0, 0, 0, 0);
+
+        m_video_display = new VideoDisplayWidget(
+            *this, *video_holder,
+            m_session.console_number(),
+            m_session.video(),
+            m_session.overlay()
+        );
+        video_holder->addWidget(m_video_display);
+    }
+
+    QWidget* widget = new QWidget(m_group_box);
+    m_group_box->set_widget(widget);
+    m_group_layout = new QVBoxLayout(widget);
+    m_group_layout->setAlignment(Qt::AlignTop);
+    m_group_layout->setContentsMargins(0, 0, 0, 0);
+
+    if (session.controllers() == 1){
+        m_group_layout->addWidget(new ControllerSelectorWidget(*this, m_session.controller(0), false));
+    }
+
+    m_video_selector = new VideoSourceSelectorWidget(m_session.logger(), m_session.video());
+    m_group_layout->addWidget(m_video_selector);
+
+    m_audio_widget = new AudioSelectorWidget(*m_group_box->widget(), m_session.audio());
+    m_group_layout->addWidget(m_audio_widget);
+
+    if (session.controllers() != 1){
+        for (size_t c = 0; c < m_session.controllers(); c++){
+            m_group_layout->addWidget(new ControllerSelectorWidget(*this, m_session.controller(c), true));
+        }
+    }
+}
+
+
+void ConsoleSystemWidget::focusInEvent(QFocusEvent* event){
+//    cout << "focusInEvent" << endl;
+    QWidget::focusInEvent(event);
+    m_session.overlay().report_focus_in();
+}
+void ConsoleSystemWidget::focusOutEvent(QFocusEvent* event){
+//    cout << "focusOutEvent" << endl;
+    QWidget::focusOutEvent(event);
+    m_session.overlay().report_focus_out();
+}
+void ConsoleSystemWidget::keyPressEvent(QKeyEvent* event){
+//    cout << "SwitchSystemWidget::keyPressEvent()" << endl;
+    m_session.overlay().report_key_press(event);
+//    QWidget::keyPressEvent(event);
+}
+void ConsoleSystemWidget::keyReleaseEvent(QKeyEvent* event){
+//    cout << "SwitchSystemWidget::keyReleaseEvent()" << endl;
+    m_session.overlay().report_key_release(event);
+//    QWidget::keyReleaseEvent(event);
+}
+
+
+
+
+
+
+
+}
+}

--- a/SerialPrograms/Source/ConsoleInfra/ConsoleSystemWidget.h
+++ b/SerialPrograms/Source/ConsoleInfra/ConsoleSystemWidget.h
@@ -1,0 +1,56 @@
+/*  Console System (Qt Widget)
+ *
+ *  From: https://github.com/PokemonAutomation/
+ *
+ */
+
+#ifndef PokemonAutomation_ConsoleInfra_ConsoleSystemWidget_H
+#define PokemonAutomation_ConsoleInfra_ConsoleSystemWidget_H
+
+#include <QVBoxLayout>
+#include <QWidget>
+#include "Common/Qt/CollapsibleGroupBox.h"
+#include "CommonFramework/AudioPipeline/UI/AudioSelectorWidget.h"
+#include "CommonFramework/AudioPipeline/UI/AudioDisplayWidget.h"
+#include "CommonFramework/VideoPipeline/UI/VideoSourceSelectorWidget.h"
+#include "CommonFramework/VideoPipeline/UI/VideoDisplayWidget.h"
+#include "ConsoleSystemSession.h"
+
+namespace PokemonAutomation{
+namespace ConsoleInfra{
+
+
+class ConsoleSystemWidget : public QWidget{
+public:
+    virtual ~ConsoleSystemWidget();
+    ConsoleSystemWidget(
+        QWidget& parent,
+        ConsoleSystemSession& session
+    );
+
+
+private:
+    virtual void focusInEvent(QFocusEvent* event) override;
+    virtual void focusOutEvent(QFocusEvent* event) override;
+    virtual void keyPressEvent(QKeyEvent* event) override;
+    virtual void keyReleaseEvent(QKeyEvent* event) override;
+
+
+protected:
+    ConsoleSystemSession& m_session;
+
+    CollapsibleGroupBox* m_group_box;
+
+    VideoDisplayWidget* m_video_display;
+    AudioDisplayWidget* m_audio_display;
+
+    QVBoxLayout* m_group_layout;
+    VideoSourceSelectorWidget* m_video_selector;
+    AudioSelectorWidget* m_audio_widget;
+};
+
+
+
+}
+}
+#endif

--- a/SerialPrograms/Source/Controllers/ControllerOption.cpp
+++ b/SerialPrograms/Source/Controllers/ControllerOption.cpp
@@ -41,17 +41,24 @@ void InterfaceType::register_factory(
 
 
 
-ControllerOption::ControllerOption()
-    : m_descriptor(new NullControllerDescriptor())
+ControllerOption::ControllerOption(bool default_enable_mode)
+    : m_default_enable_mode(default_enable_mode)
+    , m_enable_input(default_enable_mode)
+    , m_descriptor(new NullControllerDescriptor())
+    , m_sanitizer("ControllerOption")
 {}
 
 
 void ControllerOption::set_descriptor(std::shared_ptr<ControllerDescriptor> descriptor){
+    m_sanitizer.check_scope();
+
     m_descriptor_cache[descriptor->interface_type] = descriptor;
     m_descriptor = std::move(descriptor);
 }
 
 std::shared_ptr<ControllerDescriptor> ControllerOption::get_descriptor_from_cache(ControllerInterface interface_type) const{
+    m_sanitizer.check_scope();
+
     auto iter = m_descriptor_cache.find(interface_type);
     if (iter == m_descriptor_cache.end()){
         return nullptr;
@@ -62,6 +69,8 @@ std::shared_ptr<ControllerDescriptor> ControllerOption::get_descriptor_from_cach
 
 
 void ControllerOption::load_json(const JsonValue& json){
+    m_sanitizer.check_scope();
+
     std::shared_ptr<ControllerDescriptor> descriptor;
     do{
         if (json.is_null()){
@@ -72,6 +81,9 @@ void ControllerOption::load_json(const JsonValue& json){
         if (obj == nullptr){
             break;
         }
+
+        obj->read_boolean(m_enable_input, "EnableInput");
+
         const std::string* type = obj->get_string("Interface");
         if (type == nullptr){
             break;
@@ -100,10 +112,13 @@ void ControllerOption::load_json(const JsonValue& json){
     m_descriptor = std::move(descriptor);
 }
 JsonValue ControllerOption::to_json() const{
+    m_sanitizer.check_scope();
+
     if (!m_descriptor){
         return JsonValue();
     }
     JsonObject obj;
+    obj["EnableInput"] = m_enable_input;
     obj["Interface"] = CONTROLLER_INTERFACE_STRINGS.get_string(m_descriptor->interface_type);
 
     for (const auto& item : m_descriptor_cache){

--- a/SerialPrograms/Source/Controllers/ControllerOption.h
+++ b/SerialPrograms/Source/Controllers/ControllerOption.h
@@ -19,7 +19,7 @@ namespace PokemonAutomation{
 //
 class ControllerOption{
 public:
-    ControllerOption();
+    ControllerOption(bool default_enable_mode);
 
     std::shared_ptr<ControllerDescriptor> descriptor() const{
         return m_descriptor;
@@ -37,9 +37,15 @@ public:
     JsonValue to_json() const;
 
 
+public:
+    bool m_default_enable_mode;
+    bool m_enable_input = true;
+
 private:
     std::shared_ptr<ControllerDescriptor> m_descriptor;
     std::map<ControllerInterface, std::shared_ptr<ControllerDescriptor>> m_descriptor_cache;
+
+    LifetimeSanitizer m_sanitizer;
 };
 
 

--- a/SerialPrograms/Source/Controllers/ControllerSelectorWidget.cpp
+++ b/SerialPrograms/Source/Controllers/ControllerSelectorWidget.cpp
@@ -6,9 +6,9 @@
 
 #include <QKeyEvent>
 #include <QHBoxLayout>
+#include <QCheckBox>
 #include <QMessageBox>
 #include "Common/Qt/NoWheelComboBox.h"
-#include "CommonFramework/GlobalSettingsPanel.h"
 #include "CommonFramework/Panels/ConsoleSettingsStretch.h"
 #include "Controllers/ControllerTypeStrings.h"
 #include "ControllerSelectorWidget.h"
@@ -31,22 +31,48 @@ namespace PokemonAutomation{
 ControllerSelectorWidget::~ControllerSelectorWidget(){
     m_session.remove_listener(*this);
 }
-ControllerSelectorWidget::ControllerSelectorWidget(QWidget& parent, ControllerSession& session)
+ControllerSelectorWidget::ControllerSelectorWidget(
+    QWidget& parent,
+    ControllerSession& session,
+    bool show_enable_box
+)
     : QWidget(&parent)
     , m_session(session)
 {
-    QHBoxLayout* layout0 = new QHBoxLayout(this);
-    layout0->setContentsMargins(0, 0, 0, 0);
+    QHBoxLayout* layoutL = new QHBoxLayout(this);
+    layoutL->setContentsMargins(0, 0, 0, 0);
 
-    layout0->addWidget(new QLabel("<b>Controller:</b>", this), CONSOLE_SETTINGS_STRETCH_L0_LABEL);
+    if (!show_enable_box){
+        layoutL->addWidget(new QLabel("<b>Controller:</b>", this), CONSOLE_SETTINGS_STRETCH_L0_LABEL);
+    }else{
+        QHBoxLayout* layoutL0 = new QHBoxLayout();
+        layoutL->addLayout(layoutL0, CONSOLE_SETTINGS_STRETCH_L0_LABEL);
+        layoutL0->setContentsMargins(0, 0, 0, 0);
 
-    QHBoxLayout* layout1 = new QHBoxLayout();
-    layout0->addLayout(layout1, CONSOLE_SETTINGS_STRETCH_L0_RIGHT);
-    layout1->setContentsMargins(0, 0, 0, 0);
+        layoutL0->addWidget(new QLabel("<b>Controller:</b>", this));
+
+        QCheckBox* check_box = new QCheckBox(this);
+        layoutL0->addWidget(check_box, 1, Qt::AlignRight);
+        if (session.input_enabled()){
+            check_box->setCheckState(Qt::Checked);
+        }else{
+            check_box->setCheckState(Qt::Unchecked);
+        }
+        connect(
+            check_box, &QCheckBox::checkStateChanged,
+            this, [this, check_box](int){
+                m_session.set_input_enabled(check_box->isChecked());
+            }
+        );
+    }
+
+    QHBoxLayout* layoutR = new QHBoxLayout();
+    layoutL->addLayout(layoutR, CONSOLE_SETTINGS_STRETCH_L0_RIGHT);
+    layoutR->setContentsMargins(0, 0, 0, 0);
 
     m_dropdowns = new QHBoxLayout();
-    layout1->addLayout(m_dropdowns, CONSOLE_SETTINGS_STRETCH_L1_BODY);
-    layout1->addSpacing(5);
+    layoutR->addLayout(m_dropdowns, CONSOLE_SETTINGS_STRETCH_L1_BODY);
+    layoutR->addSpacing(5);
 
     m_interface_dropdown = new NoWheelCompactComboBox(this);
     m_dropdowns->addWidget(m_interface_dropdown);
@@ -83,8 +109,8 @@ ControllerSelectorWidget::ControllerSelectorWidget(QWidget& parent, ControllerSe
     refresh_controllers(session.controller_type(), session.available_controllers());
 
     m_status_text = new QLabel(this);
-    layout1->addWidget(m_status_text, CONSOLE_SETTINGS_STRETCH_L1_RIGHT);
-    layout1->addSpacing(5);
+    layoutR->addWidget(m_status_text, CONSOLE_SETTINGS_STRETCH_L1_RIGHT);
+    layoutR->addSpacing(5);
 
     m_status_text->setText(QString::fromStdString(session.status_text()));
     m_status_text->setTextFormat(Qt::RichText);
@@ -99,7 +125,7 @@ ControllerSelectorWidget::ControllerSelectorWidget(QWidget& parent, ControllerSe
         "If the controller supports pairing, this will unpair it and allow it to pair with a new host."
     );
 #endif
-    layout1->addWidget(m_reset_button, CONSOLE_SETTINGS_STRETCH_L1_BUTTON);
+    layoutR->addWidget(m_reset_button, CONSOLE_SETTINGS_STRETCH_L1_BUTTON);
 
     bool options_locked = session.options_locked();
     if (m_selector){
@@ -292,6 +318,16 @@ void ControllerSelectorWidget::update_buttons(){
 }
 
 
+void ControllerSelectorWidget::focusInEvent(QFocusEvent* event){
+//    cout << "ControllerSelectorWidget::focusInEvent()" << endl;
+    QWidget::focusInEvent(event);
+}
+void ControllerSelectorWidget::focusOutEvent(QFocusEvent* event){
+//    cout << "ControllerSelectorWidget::focusOutEvent()" << endl;
+    m_shift_held = false;
+    update_buttons();
+    QWidget::focusOutEvent(event);
+}
 void ControllerSelectorWidget::keyPressEvent(QKeyEvent* event){
 //    cout << "ControllerSelectorWidget::keyPressEvent()" << endl;
     if (event->key() == Qt::Key_Shift){
@@ -307,16 +343,6 @@ void ControllerSelectorWidget::keyReleaseEvent(QKeyEvent* event){
     }
     update_buttons();
 //    QWidget::keyReleaseEvent(event);
-}
-void ControllerSelectorWidget::focusInEvent(QFocusEvent* event){
-//    cout << "ControllerSelectorWidget::focusInEvent()" << endl;
-    QWidget::focusInEvent(event);
-}
-void ControllerSelectorWidget::focusOutEvent(QFocusEvent* event){
-//    cout << "ControllerSelectorWidget::focusOutEvent()" << endl;
-    m_shift_held = false;
-    update_buttons();
-    QWidget::focusOutEvent(event);
 }
 #endif
 

--- a/SerialPrograms/Source/Controllers/ControllerSelectorWidget.cpp
+++ b/SerialPrograms/Source/Controllers/ControllerSelectorWidget.cpp
@@ -34,7 +34,7 @@ ControllerSelectorWidget::~ControllerSelectorWidget(){
 ControllerSelectorWidget::ControllerSelectorWidget(
     QWidget& parent,
     ControllerSession& session,
-    bool show_enable_box
+    std::optional<size_t> index
 )
     : QWidget(&parent)
     , m_session(session)
@@ -42,14 +42,19 @@ ControllerSelectorWidget::ControllerSelectorWidget(
     QHBoxLayout* layoutL = new QHBoxLayout(this);
     layoutL->setContentsMargins(0, 0, 0, 0);
 
-    if (!show_enable_box){
+    if (!index.has_value()){
         layoutL->addWidget(new QLabel("<b>Controller:</b>", this), CONSOLE_SETTINGS_STRETCH_L0_LABEL);
     }else{
         QHBoxLayout* layoutL0 = new QHBoxLayout();
         layoutL->addLayout(layoutL0, CONSOLE_SETTINGS_STRETCH_L0_LABEL);
         layoutL0->setContentsMargins(0, 0, 0, 0);
 
-        layoutL0->addWidget(new QLabel("<b>Controller:</b>", this));
+        layoutL0->addWidget(
+            new QLabel(
+                QString::fromStdString("<b>Controller " + std::to_string(index.value()) + ":</b>"),
+                this
+            )
+        );
 
         QCheckBox* check_box = new QCheckBox(this);
         layoutL0->addWidget(check_box, 1, Qt::AlignRight);

--- a/SerialPrograms/Source/Controllers/ControllerSelectorWidget.cpp
+++ b/SerialPrograms/Source/Controllers/ControllerSelectorWidget.cpp
@@ -105,7 +105,7 @@ ControllerSelectorWidget::ControllerSelectorWidget(
     m_dropdowns->addSpacing(5);
     m_controllers_dropdown = new NoWheelCompactComboBox(this);
     m_controllers_dropdown->setSizeAdjustPolicy(QComboBox::AdjustToContents);
-    m_dropdowns->addWidget(m_controllers_dropdown);
+    m_dropdowns->addWidget(m_controllers_dropdown, 5);
     refresh_controllers(session.controller_type(), session.available_controllers());
 
     m_status_text = new QLabel(this);
@@ -221,11 +221,12 @@ void ControllerSelectorWidget::update_interface_dropdown(ControllerInterface int
             return;
         }
     }
-    m_session.set_controller(ControllerType::None);
+//    m_session.set_controller(ControllerType::None);
     m_interface_dropdown->setCurrentIndex(-1);
 }
 void ControllerSelectorWidget::refresh_selection(ControllerInterface interface_type){
 //    cout << "refresh_selection(): "<< endl;
+
     update_interface_dropdown(interface_type);
 
     delete m_selector;
@@ -246,8 +247,6 @@ void ControllerSelectorWidget::refresh_selection(ControllerInterface interface_t
 
     default:;
     }
-
-
 }
 
 void ControllerSelectorWidget::refresh_controllers(

--- a/SerialPrograms/Source/Controllers/ControllerSelectorWidget.h
+++ b/SerialPrograms/Source/Controllers/ControllerSelectorWidget.h
@@ -22,7 +22,11 @@ namespace PokemonAutomation{
 class ControllerSelectorWidget : public QWidget, private ControllerSession::Listener{
 public:
     ~ControllerSelectorWidget();
-    ControllerSelectorWidget(QWidget& parent, ControllerSession& session);
+    ControllerSelectorWidget(
+        QWidget& parent,
+        ControllerSession& session,
+        bool show_enable_box
+    );
 
     ControllerSession& session(){
         return m_session;
@@ -51,10 +55,10 @@ private:
     void update_buttons();
 
 #if 0
-    virtual void keyPressEvent(QKeyEvent* event) override;
-    virtual void keyReleaseEvent(QKeyEvent* event) override;
     virtual void focusInEvent(QFocusEvent* event) override;
     virtual void focusOutEvent(QFocusEvent* event) override;
+    virtual void keyPressEvent(QKeyEvent* event) override;
+    virtual void keyReleaseEvent(QKeyEvent* event) override;
 #endif
 
 private:

--- a/SerialPrograms/Source/Controllers/ControllerSelectorWidget.h
+++ b/SerialPrograms/Source/Controllers/ControllerSelectorWidget.h
@@ -25,7 +25,7 @@ public:
     ControllerSelectorWidget(
         QWidget& parent,
         ControllerSession& session,
-        bool show_enable_box
+        std::optional<size_t> index
     );
 
     ControllerSession& session(){

--- a/SerialPrograms/Source/Controllers/ControllerSession.cpp
+++ b/SerialPrograms/Source/Controllers/ControllerSession.cpp
@@ -87,6 +87,15 @@ void ControllerSession::load(const ControllerOption& option){
 }
 
 
+bool ControllerSession::input_enabled() const{
+    ReadSpinLock lg(m_state_lock);
+    return m_option.m_enable_input;
+}
+void ControllerSession::set_input_enabled(bool enabled){
+    WriteSpinLock lg(m_state_lock);
+    m_option.m_enable_input = enabled;
+}
+
 
 bool ControllerSession::ready() const{
     ReadSpinLock lg(m_state_lock);
@@ -102,6 +111,7 @@ ControllerConnection::Status ControllerSession::connection_status() const{
     }
     return m_connection->status();
 }
+
 std::shared_ptr<ControllerDescriptor> ControllerSession::descriptor() const{
     ReadSpinLock lg(m_state_lock);
     return m_descriptor;
@@ -141,7 +151,7 @@ std::string ControllerSession::user_input_blocked() const{
     return m_user_input_disallow_reason;
 }
 void ControllerSession::set_user_input_blocked(std::string disallow_reason){
-    ReadSpinLock lg(m_state_lock);
+    WriteSpinLock lg(m_state_lock);
 //    cout << "set_user_input_blocked() = " << disallow_reason << endl;
     m_user_input_disallow_reason = std::move(disallow_reason);
 }

--- a/SerialPrograms/Source/Controllers/ControllerSession.cpp
+++ b/SerialPrograms/Source/Controllers/ControllerSession.cpp
@@ -4,7 +4,7 @@
  *
  */
 
-#include "Common/Cpp/Exceptions.h"
+//#include "Common/Cpp/Exceptions.h"
 //#include "ControllerTypeStrings.h"
 #include "ControllerSession.h"
 
@@ -257,6 +257,7 @@ bool ControllerSession::set_controller(ControllerType controller_type){
                 return false;
             }
             if (m_connection){
+//                cout << (int)m_connection->current_controller() << endl;
                 if (m_connection->current_controller() == controller_type){
                     return true;
                 }

--- a/SerialPrograms/Source/Controllers/ControllerSession.h
+++ b/SerialPrograms/Source/Controllers/ControllerSession.h
@@ -20,7 +20,6 @@ namespace PokemonAutomation{
 
 
 
-
 class ControllerSession final : private ControllerConnection::StatusListener{
 public:
     struct Listener{
@@ -47,6 +46,8 @@ public:
         ControllerOption& option
     );
 
+
+public:
     Logger& logger(){
         return m_logger;
     }
@@ -55,8 +56,12 @@ public:
     void save(ControllerOption& option) const;
     void load(const ControllerOption& option);
 
+    bool input_enabled() const;
+    void set_input_enabled(bool enabled);
+
     bool ready() const;
     ControllerConnection::Status connection_status() const;
+
     std::shared_ptr<ControllerDescriptor> descriptor() const;
     ControllerType controller_type() const;
     std::string status_text() const;
@@ -93,6 +98,9 @@ public:
         ReadSpinLock lg(m_state_lock);
         if (!m_controller){
             return "Controller is null.";
+        }
+        if (!m_option.m_enable_input){
+            return "";
         }
         try{
             //  This will be a cross-cast in most cases.

--- a/SerialPrograms/Source/NintendoSwitch/Framework/NintendoSwitch_SwitchSystemOption.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/Framework/NintendoSwitch_SwitchSystemOption.cpp
@@ -37,7 +37,7 @@ const std::string SwitchSystemOption::JSON_CONSOLE_TYPE = "ConsoleType";
 SwitchSystemOption::SwitchSystemOption(
     bool allow_commands_while_running
 )
-    : ConsoleSystemOption(1, allow_commands_while_running)  //  REMOVE
+    : ConsoleSystemOption(1, allow_commands_while_running)
 {}
 SwitchSystemOption::SwitchSystemOption(
     bool allow_commands_while_running,

--- a/SerialPrograms/Source/NintendoSwitch/Framework/NintendoSwitch_SwitchSystemOption.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/Framework/NintendoSwitch_SwitchSystemOption.cpp
@@ -37,7 +37,7 @@ const std::string SwitchSystemOption::JSON_CONSOLE_TYPE = "ConsoleType";
 SwitchSystemOption::SwitchSystemOption(
     bool allow_commands_while_running
 )
-    : ConsoleSystemOption(1, allow_commands_while_running)
+    : ConsoleSystemOption(1, allow_commands_while_running)  //  REMOVE
 {}
 SwitchSystemOption::SwitchSystemOption(
     bool allow_commands_while_running,

--- a/SerialPrograms/Source/NintendoSwitch/Framework/NintendoSwitch_SwitchSystemSession.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/Framework/NintendoSwitch_SwitchSystemSession.cpp
@@ -35,7 +35,7 @@ SwitchSystemSession::SwitchSystemSession(
     uint64_t program_id,
     size_t console_number
 )
-    : ConsoleSystemSession(global_logger_raw(), option, console_number, 1)
+    : ConsoleSystemSession(global_logger_raw(), option, console_number)
     , m_option(option)
 {
     m_console_id = ProgramTracker::instance().add_console(program_id, *this);

--- a/SerialPrograms/Source/NintendoSwitch/Framework/UI/NintendoSwitch_SwitchSystemWidget.cpp
+++ b/SerialPrograms/Source/NintendoSwitch/Framework/UI/NintendoSwitch_SwitchSystemWidget.cpp
@@ -4,17 +4,8 @@
  *
  */
 
-#include <QKeyEvent>
-#include <QVBoxLayout>
-#include <QGroupBox>
-#include <QFileDialog>
 #include "Common/Qt/CollapsibleGroupBox.h"
 #include "CommonFramework/Globals.h"
-#include "CommonFramework/AudioPipeline/UI/AudioSelectorWidget.h"
-#include "CommonFramework/AudioPipeline/UI/AudioDisplayWidget.h"
-#include "CommonFramework/VideoPipeline/UI/VideoSourceSelectorWidget.h"
-#include "CommonFramework/VideoPipeline/UI/VideoDisplayWidget.h"
-#include "Controllers/ControllerSelectorWidget.h"
 #include "NintendoSwitch_CommandRow.h"
 #include "NintendoSwitch_SwitchSystemWidget.h"
 
@@ -27,94 +18,24 @@ namespace NintendoSwitch{
 
 
 
-SwitchSystemWidget::~SwitchSystemWidget(){
-    //  Delete all the UI elements first since they reference the states.
-    delete m_audio_display;
-    delete m_audio_widget;
-    delete m_video_display;
-    delete m_video_selector;
-    delete m_controller;
-}
 
 SwitchSystemWidget::SwitchSystemWidget(
     QWidget& parent,
     SwitchSystemSession& session,
     uint64_t program_id
 )
-    : QWidget(&parent)
+    : ConsoleSystemWidget(parent, session)
     , m_session(session)
 {
-    QVBoxLayout* layout = new QVBoxLayout(this);
-    layout->setContentsMargins(0, 0, 0, 0);
-    layout->setAlignment(Qt::AlignTop);
-
-    m_group_box = new CollapsibleGroupBox(*this, "Console " + QString::number(m_session.console_number()) + " Settings");
-    layout->addWidget(m_group_box);
-
-    QWidget* widget = new QWidget(m_group_box);
-    m_group_box->set_widget(widget);
     {
-        m_audio_display = new AudioDisplayWidget(*this, m_session.logger(), m_session.audio());
-        layout->addWidget(m_audio_display);
-
-        QVBoxLayout* video_holder = new QVBoxLayout();
-        layout->addLayout(video_holder);
-        video_holder->setContentsMargins(0, 0, 0, 0);
-
-        m_video_display = new VideoDisplayWidget(
-            *this, *video_holder,
-            m_session.console_number(),
-            m_session.video(),
-            m_session.overlay()
-        );
-        video_holder->addWidget(m_video_display);
-    }
-    {
-        QVBoxLayout* group_layout = new QVBoxLayout(widget);
-        group_layout->setAlignment(Qt::AlignTop);
-        group_layout->setContentsMargins(0, 0, 0, 0);
-
-        m_controller = new ControllerSelectorWidget(*this, m_session.controller());
-        group_layout->addWidget(m_controller);
-
-        m_video_selector = new VideoSourceSelectorWidget(m_session.logger(), m_session.video());
-        group_layout->addWidget(m_video_selector);
-
-        m_audio_widget = new AudioSelectorWidget(*widget, m_session.audio());
-        group_layout->addWidget(m_audio_widget);
-
-#if 0
-        //  Experiment with multiple controller layouts.
-        m_controller = new ControllerSelectorWidget(*this, m_session.controller());
-        group_layout->addWidget(m_controller);
-
-        group_layout->addWidget(new ControllerSelectorWidget(*this, m_session.controller()));
-        group_layout->addWidget(new ControllerSelectorWidget(*this, m_session.controller()));
-        group_layout->addWidget(new ControllerSelectorWidget(*this, m_session.controller()));
-        group_layout->addWidget(new ControllerSelectorWidget(*this, m_session.controller()));
-        group_layout->addWidget(new ControllerSelectorWidget(*this, m_session.controller()));
-        group_layout->addWidget(new ControllerSelectorWidget(*this, m_session.controller()));
-        group_layout->addWidget(new ControllerSelectorWidget(*this, m_session.controller()));
-#endif
-
         m_command = new CommandRow(
-            *widget,
+            *m_group_box->widget(),
             m_session,
             m_session.console_type(),
             m_session.allow_commands_while_running()
         );
-        group_layout->addWidget(m_command);
+        m_group_layout->addWidget(m_command);
     }
-
-    setFocusPolicy(Qt::StrongFocus);
-
-
-//    connect(
-//        m_serial_widget, &SerialPortWidget::signal_on_ready,
-//        m_command, [this](bool ready){
-//            m_command->update_ui();
-//        }
-//    );
 }
 
 
@@ -128,26 +49,6 @@ void SwitchSystemWidget::update_ui(ProgramState state){
 }
 
 
-void SwitchSystemWidget::focusInEvent(QFocusEvent* event){
-//    cout << "focusInEvent" << endl;
-    QWidget::focusInEvent(event);
-    m_session.overlay().report_focus_in();
-}
-void SwitchSystemWidget::focusOutEvent(QFocusEvent* event){
-//    cout << "focusOutEvent" << endl;
-    QWidget::focusOutEvent(event);
-    m_session.overlay().report_focus_out();
-}
-void SwitchSystemWidget::keyPressEvent(QKeyEvent* event){
-//    cout << "SwitchSystemWidget::keyPressEvent()" << endl;
-    m_session.overlay().report_key_press(event);
-//    QWidget::keyPressEvent(event);
-}
-void SwitchSystemWidget::keyReleaseEvent(QKeyEvent* event){
-//    cout << "SwitchSystemWidget::keyReleaseEvent()" << endl;
-    m_session.overlay().report_key_release(event);
-//    QWidget::keyReleaseEvent(event);
-}
 
 
 

--- a/SerialPrograms/Source/NintendoSwitch/Framework/UI/NintendoSwitch_SwitchSystemWidget.h
+++ b/SerialPrograms/Source/NintendoSwitch/Framework/UI/NintendoSwitch_SwitchSystemWidget.h
@@ -21,6 +21,7 @@
 #include <QWidget>
 #include "CommonFramework/VideoPipeline/UI/VideoDisplayWidget.h"
 #include "NintendoSwitch/Framework/NintendoSwitch_SwitchSystemSession.h"
+#include "ConsoleInfra/ConsoleSystemWidget.h"
 
 namespace PokemonAutomation{
     class CollapsibleGroupBox;
@@ -46,9 +47,8 @@ class CommandRow;
 // - Video stream display
 // It also owns a SwitchSystemSession that manages the life time of the controller,
 // audio and video streams that will be exposed to automation programs.
-class SwitchSystemWidget final : public QWidget{
+class SwitchSystemWidget final : public ConsoleInfra::ConsoleSystemWidget{
 public:
-    virtual ~SwitchSystemWidget();
     SwitchSystemWidget(
         QWidget& parent,
         SwitchSystemSession& session,
@@ -59,25 +59,9 @@ public:
     void update_ui(ProgramState state);
 
 private:
-    virtual void focusInEvent(QFocusEvent* event) override;
-    virtual void focusOutEvent(QFocusEvent* event) override;
-    virtual void keyPressEvent(QKeyEvent* event) override;
-    virtual void keyReleaseEvent(QKeyEvent* event) override;
-
-private:
     SwitchSystemSession& m_session;
 
-    CollapsibleGroupBox* m_group_box;
-
-    ControllerSelectorWidget* m_controller;
-
-    VideoDisplayWidget* m_video_display;
-    AudioDisplayWidget* m_audio_display;
-
     CommandRow* m_command;
-
-    VideoSourceSelectorWidget* m_video_selector;
-    AudioSelectorWidget* m_audio_widget;
 };
 
 

--- a/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxDetection.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxDetection.cpp
@@ -22,9 +22,6 @@ using std::cout;
 using std::endl;;
 
 namespace PokemonAutomation{
-
-template class FixedLimitVector<NintendoSwitch::PokemonSV::BoxEmptySlotWatcher>;
-
 namespace NintendoSwitch{
 namespace PokemonSV{
 

--- a/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxDetection.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxDetection.cpp
@@ -358,6 +358,8 @@ bool BoxEmptySlotDetector::detect(const ImageViewRGB32& frame){
 }
 
 
+BoxEmptySlotWatcher::~BoxEmptySlotWatcher() = default;
+
 
 BoxEmptyPartyWatcher::BoxEmptyPartyWatcher(Color color) : VisualInferenceCallback("BoxEmptyPartyWatcher"), m_empty_watchers(5){
     for (uint8_t i = 0; i < 5; i++){

--- a/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxDetection.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxDetection.cpp
@@ -358,8 +358,6 @@ bool BoxEmptySlotDetector::detect(const ImageViewRGB32& frame){
 }
 
 
-BoxEmptySlotWatcher::~BoxEmptySlotWatcher() = default;
-
 
 BoxEmptyPartyWatcher::BoxEmptyPartyWatcher(Color color) : VisualInferenceCallback("BoxEmptyPartyWatcher"), m_empty_watchers(5){
     for (uint8_t i = 0; i < 5; i++){

--- a/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxDetection.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxDetection.h
@@ -135,7 +135,11 @@ public:
 // are fully loaded before calling this detector.
 class BoxEmptySlotDetector : public StaticScreenDetector{
 public:
-    BoxEmptySlotDetector(BoxCursorLocation side, uint8_t row, uint8_t col, Color color = COLOR_RED);
+    BoxEmptySlotDetector(
+        BoxCursorLocation side,
+        uint8_t row, uint8_t col,
+        Color color = COLOR_RED
+    );
 
     virtual void make_overlays(VideoOverlaySet& items) const override;
     virtual bool detect(const ImageViewRGB32& screen) override;
@@ -145,7 +149,12 @@ private:
 };
 class BoxEmptySlotWatcher : public DetectorToFinder<BoxEmptySlotDetector>{
 public:
-    BoxEmptySlotWatcher(BoxCursorLocation side, uint8_t row, uint8_t col, FinderType finder_type = FinderType::PRESENT, Color color = COLOR_RED)
+    BoxEmptySlotWatcher(
+        BoxCursorLocation side,
+        uint8_t row, uint8_t col,
+        FinderType finder_type = FinderType::PRESENT,
+        Color color = COLOR_RED
+    )
          : DetectorToFinder("BoxEmptySlotWatcher", finder_type, std::chrono::milliseconds(100), side, row, col, color)
     {}
 };

--- a/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxDetection.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxDetection.h
@@ -149,6 +149,7 @@ private:
 };
 class BoxEmptySlotWatcher : public DetectorToFinder<BoxEmptySlotDetector>{
 public:
+    ~BoxEmptySlotWatcher();
     BoxEmptySlotWatcher(
         BoxCursorLocation side,
         uint8_t row, uint8_t col,

--- a/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxDetection.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxDetection.h
@@ -149,7 +149,6 @@ private:
 };
 class BoxEmptySlotWatcher : public DetectorToFinder<BoxEmptySlotDetector>{
 public:
-    ~BoxEmptySlotWatcher();
     BoxEmptySlotWatcher(
         BoxCursorLocation side,
         uint8_t row, uint8_t col,

--- a/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxEggDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxEggDetector.cpp
@@ -94,7 +94,6 @@ bool BoxEggDetector::detect(const ImageViewRGB32& frame){
     );
 }
 
-BoxEggWatcher::~BoxEggWatcher() = default;
 
 BoxEggPartyColumnWatcher::BoxEggPartyColumnWatcher(Color color)
     : VisualInferenceCallback("BoxEggPartyColumnWatcher")

--- a/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxEggDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxEggDetector.cpp
@@ -94,6 +94,8 @@ bool BoxEggDetector::detect(const ImageViewRGB32& frame){
     );
 }
 
+BoxEggWatcher::~BoxEggWatcher() = default;
+
 BoxEggPartyColumnWatcher::BoxEggPartyColumnWatcher(Color color)
     : VisualInferenceCallback("BoxEggPartyColumnWatcher")
     , m_egg_watchers(5), m_empty_watchers(5)

--- a/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxEggDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxEggDetector.cpp
@@ -17,9 +17,6 @@
 #include "PokemonSV_BoxEggDetector.h"
 
 namespace PokemonAutomation{
-
-template class FixedLimitVector<NintendoSwitch::PokemonSV::BoxEggWatcher>;
-
 namespace NintendoSwitch{
 namespace PokemonSV{
 
@@ -98,8 +95,8 @@ bool BoxEggDetector::detect(const ImageViewRGB32& frame){
 }
 
 BoxEggPartyColumnWatcher::BoxEggPartyColumnWatcher(Color color)
-    : VisualInferenceCallback("BoxEggPartyColumnWatcher"),
-    m_egg_watchers(5), m_empty_watchers(5)
+    : VisualInferenceCallback("BoxEggPartyColumnWatcher")
+    , m_egg_watchers(5), m_empty_watchers(5)
 {
     for (uint8_t i = 0; i < 5; i++){
         m_egg_watchers.emplace_back(

--- a/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxEggDetector.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxEggDetector.h
@@ -53,7 +53,6 @@ private:
 
 class BoxEggWatcher : public DetectorToFinder<BoxEggDetector>{
 public:
-    ~BoxEggWatcher();
     BoxEggWatcher(
         BoxCursorLocation side,
         uint8_t row, uint8_t col,

--- a/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxEggDetector.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxEggDetector.h
@@ -53,6 +53,7 @@ private:
 
 class BoxEggWatcher : public DetectorToFinder<BoxEggDetector>{
 public:
+    ~BoxEggWatcher();
     BoxEggWatcher(
         BoxCursorLocation side,
         uint8_t row, uint8_t col,

--- a/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxEggDetector.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Boxes/PokemonSV_BoxEggDetector.h
@@ -37,7 +37,11 @@ private:
 // Detect if a slot in the box system is an egg.
 class BoxEggDetector : public StaticScreenDetector{
 public:
-    BoxEggDetector(BoxCursorLocation side, uint8_t row, uint8_t col, Color color = COLOR_YELLOW);
+    BoxEggDetector(
+        BoxCursorLocation side,
+        uint8_t row, uint8_t col,
+        Color color = COLOR_YELLOW
+    );
 
     virtual void make_overlays(VideoOverlaySet& items) const override;
     virtual bool detect(const ImageViewRGB32& screen) override;
@@ -49,7 +53,12 @@ private:
 
 class BoxEggWatcher : public DetectorToFinder<BoxEggDetector>{
 public:
-    BoxEggWatcher(BoxCursorLocation side, uint8_t row, uint8_t col, FinderType finder_type = FinderType::PRESENT, Color color = COLOR_YELLOW)
+    BoxEggWatcher(
+        BoxCursorLocation side,
+        uint8_t row, uint8_t col,
+        FinderType finder_type = FinderType::PRESENT,
+        Color color = COLOR_YELLOW
+    )
          : DetectorToFinder("BoxEggWatcher", finder_type, std::chrono::milliseconds(100), side, row, col, color)
     {}
 };

--- a/SerialPrograms/Source/PokemonSV/Inference/Dialogs/PokemonSV_GradientArrowDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Dialogs/PokemonSV_GradientArrowDetector.cpp
@@ -247,31 +247,7 @@ bool GradientArrowDetector::detect(ImageFloatBox& box, const ImageViewRGB32& scr
 
 
 
-#if 0
 GradientArrowWatcher::~GradientArrowWatcher() = default;
-GradientArrowWatcher::GradientArrowWatcher(
-    Color color,
-    GradientArrowType type,
-    const ImageFloatBox& box
-)
-    : VisualInferenceCallback("GradientArrowWatcher")
-    , m_detector(color, type, box)
-{}
-
-void GradientArrowWatcher::make_overlays(VideoOverlaySet& items) const{
-    m_detector.make_overlays(items);
-}
-bool GradientArrowWatcher::process_frame(const VideoSnapshot& frame){
-    bool detected = m_detector.detect(frame);
-    if (detected){
-//        m_last_detected = frame;
-    }
-    return detected;
-}
-//bool GradientArrowWatcher::process_frame(const ImageViewRGB32& frame, WallClock timestamp){
-//    return m_detector.detect(frame);
-//}
-#endif
 
 
 

--- a/SerialPrograms/Source/PokemonSV/Inference/Dialogs/PokemonSV_GradientArrowDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Dialogs/PokemonSV_GradientArrowDetector.cpp
@@ -247,8 +247,6 @@ bool GradientArrowDetector::detect(ImageFloatBox& box, const ImageViewRGB32& scr
 
 
 
-GradientArrowWatcher::~GradientArrowWatcher() = default;
-
 
 
 

--- a/SerialPrograms/Source/PokemonSV/Inference/Dialogs/PokemonSV_GradientArrowDetector.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Dialogs/PokemonSV_GradientArrowDetector.h
@@ -46,6 +46,7 @@ protected:
 
 class GradientArrowWatcher : public DetectorToFinder<GradientArrowDetector>{
 public:
+    ~GradientArrowWatcher();
     GradientArrowWatcher(
         Color color,
         GradientArrowType type,

--- a/SerialPrograms/Source/PokemonSV/Inference/Dialogs/PokemonSV_GradientArrowDetector.h
+++ b/SerialPrograms/Source/PokemonSV/Inference/Dialogs/PokemonSV_GradientArrowDetector.h
@@ -46,7 +46,6 @@ protected:
 
 class GradientArrowWatcher : public DetectorToFinder<GradientArrowDetector>{
 public:
-    ~GradientArrowWatcher();
     GradientArrowWatcher(
         Color color,
         GradientArrowType type,

--- a/SerialPrograms/Source/PokemonSV/Inference/Picnics/PokemonSV_SandwichRecipeDetector.cpp
+++ b/SerialPrograms/Source/PokemonSV/Inference/Picnics/PokemonSV_SandwichRecipeDetector.cpp
@@ -22,9 +22,6 @@
 //using std::endl;
 
 namespace PokemonAutomation{
-
-template class FixedLimitVector<NintendoSwitch::PokemonSV::GradientArrowWatcher>;
-
 namespace NintendoSwitch{
 namespace PokemonSV{
 
@@ -69,9 +66,21 @@ void SandwichRecipeNumberDetector::detect_recipes(const ImageViewRGB32& screen, 
 
             // filterd_image.save("./tmp_" + std::to_string(i) + ".png");
             
-            cv::Mat filtered_image_mat(static_cast<int>(filterd_image.height()), static_cast<int>(filterd_image.width()), CV_8UC4, (void*)filterd_image.data(), filterd_image.bytes_per_row());
+            cv::Mat filtered_image_mat(
+                static_cast<int>(filterd_image.height()),
+                static_cast<int>(filterd_image.width()),
+                CV_8UC4,
+                (void*)filterd_image.data(),
+                filterd_image.bytes_per_row()
+            );
             
-            cv::Mat dilated_image_mat(static_cast<int>(dilated_image.height()), static_cast<int>(dilated_image.width()), CV_8UC4, (void*)dilated_image.data(), dilated_image.bytes_per_row());
+            cv::Mat dilated_image_mat(
+                static_cast<int>(dilated_image.height()),
+                static_cast<int>(dilated_image.width()),
+                CV_8UC4,
+                (void*)dilated_image.data(),
+                dilated_image.bytes_per_row()
+            );
             cv::dilate(filtered_image_mat, dilated_image_mat, element);
         }else{
             dilated_image = filterd_image.copy();

--- a/SerialPrograms/cmake/SourceFiles.cmake
+++ b/SerialPrograms/cmake/SourceFiles.cmake
@@ -877,6 +877,8 @@ file(GLOB LIBRARY_SOURCES
     Source/ConsoleInfra/ConsoleSystemOption.h
     Source/ConsoleInfra/ConsoleSystemSession.cpp
     Source/ConsoleInfra/ConsoleSystemSession.h
+    Source/ConsoleInfra/ConsoleSystemWidget.cpp
+    Source/ConsoleInfra/ConsoleSystemWidget.h
     Source/ControllerInput/Keyboard/GlobalKeyboardHidTracker.cpp
     Source/ControllerInput/Keyboard/GlobalKeyboardHidTracker.h
     Source/ControllerInput/Keyboard/GlobalQtKeyMap.cpp


### PR DESCRIPTION
1. Refactor out console-independent parts of the infra so not everything is Switch-specific.
2. Add support for multiple controllers on the same console.

For now there is no visible change to the user since the Switch part of the UI passes 1 as the # controllers.