### PR TITLE
toggle the build for the command line exe

### DIFF
--- a/SerialPrograms/CMakeLists.txt
+++ b/SerialPrograms/CMakeLists.txt
@@ -821,5 +821,11 @@ if (QT_MAJOR GREATER_EQUAL 6)
     qt_finalize_target(SerialPrograms)
 endif()
 
-# Add command-line executable (GUI-free) from subdirectory
-include(Source/CommandLine/CommandLineExecutable.cmake)
+
+# Define a toggle option (ON by default)
+option(COMMAND_LINE_EXE "Build the optional executable" ON)
+
+if(COMMAND_LINE_EXE)
+    # Add command-line executable (GUI-free) from subdirectory
+    include(Source/CommandLine/CommandLineExecutable.cmake)
+endif()


### PR DESCRIPTION
To save ~10% on compile times.
It will still compile the command line exe by default. But you can toggle it off if you wish.
Within Qt Creator: Projects -> Build Settings -> Under CMake, look for COMMAND_LINE_EXE in the table. Set it to OFF.